### PR TITLE
update secops orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 orbs:
   rust: circleci/rust@1.6.0
   gh: circleci/github-cli@2.2.0
-  secops: apollo/circleci-secops-orb@2.0.0
+  secops: apollo/circleci-secops-orb@2.0.1
 
 # We run jobs on the following platforms: linux, macos and windows.
 # These are their specifications:


### PR DESCRIPTION
## Motivation / Implements
This PR updates the version of the SecOps orb used in this repo. Version 2.0.0 of the orb included an issue on the gitleaks job that prevented the job from running on PRs created from forks. The issue was caused by a default configuration in CircleCI which prevents providing secrets provided through CircleCI contexts to PRs created from forks. This default configuration is probably the correct one, so we needed up update the SecOps orb to properly operate on PRs from forks.