### PR TITLE
specify working directory for publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,7 @@ jobs:
       platform:
         type: executor
     executor: << parameters.platform >>
+    working_directory: $CIRCLE_WORKING_DIRECTORY/apollo-federation
     steps:
       - checkout
       - install_system_deps:


### PR DESCRIPTION
Cargo doesnt support publishing multiple modules so we have to explicitly publish single module at a time.

Updating publish job to `apollo-federation` working directory