### PR TITLE
feat: Handle reserved names/meta-fields properly

### DIFF
--- a/src/link/federation_spec_definition.rs
+++ b/src/link/federation_spec_definition.rs
@@ -65,11 +65,11 @@ impl FederationSpecDefinition {
             name: name_in_schema,
             arguments: vec![
                 Node::new(Argument {
-                    name: FEDERATION_FIELDS_ARGUMENT_NAME.clone(),
+                    name: FEDERATION_FIELDS_ARGUMENT_NAME,
                     value: Node::new(Value::String(fields)),
                 }),
                 Node::new(Argument {
-                    name: FEDERATION_RESOLVABLE_ARGUMENT_NAME.clone(),
+                    name: FEDERATION_RESOLVABLE_ARGUMENT_NAME,
                     value: Node::new(Value::Boolean(resolvable)),
                 }),
             ],
@@ -110,7 +110,7 @@ impl FederationSpecDefinition {
         let mut arguments = Vec::new();
         if let Some(reason) = reason {
             arguments.push(Node::new(Argument {
-                name: FEDERATION_REASON_ARGUMENT_NAME.clone(),
+                name: FEDERATION_REASON_ARGUMENT_NAME,
                 value: Node::new(Value::String(reason)),
             }));
         }
@@ -133,7 +133,7 @@ impl FederationSpecDefinition {
         Ok(Directive {
             name: name_in_schema,
             arguments: vec![Node::new(Argument {
-                name: FEDERATION_FIELDS_ARGUMENT_NAME.clone(),
+                name: FEDERATION_FIELDS_ARGUMENT_NAME,
                 value: Node::new(Value::String(fields)),
             })],
         })
@@ -152,7 +152,7 @@ impl FederationSpecDefinition {
         Ok(Directive {
             name: name_in_schema,
             arguments: vec![Node::new(Argument {
-                name: FEDERATION_FIELDS_ARGUMENT_NAME.clone(),
+                name: FEDERATION_FIELDS_ARGUMENT_NAME,
                 value: Node::new(Value::String(fields)),
             })],
         })
@@ -186,7 +186,7 @@ impl FederationSpecDefinition {
         Ok(Directive {
             name: name_in_schema,
             arguments: vec![Node::new(Argument {
-                name: FEDERATION_FROM_ARGUMENT_NAME.clone(),
+                name: FEDERATION_FROM_ARGUMENT_NAME,
                 value: Node::new(Value::String(from)),
             })],
         })

--- a/src/query_graph/extract_subgraphs_from_supergraph.rs
+++ b/src/query_graph/extract_subgraphs_from_supergraph.rs
@@ -1688,7 +1688,7 @@ fn add_federation_operations(
 ) -> Result<(), FederationError> {
     // TODO: Use the JS/programmatic approach of checkOrAdd() instead of hard-coding the adds.
     let any_type_pos = ScalarTypeDefinitionPosition {
-        type_name: FEDERATION_ANY_TYPE_NAME.clone(),
+        type_name: FEDERATION_ANY_TYPE_NAME,
     };
     any_type_pos.pre_insert(&mut subgraph.schema)?;
     any_type_pos.insert(
@@ -1701,17 +1701,17 @@ fn add_federation_operations(
     )?;
     let mut service_fields = IndexMap::new();
     service_fields.insert(
-        FEDERATION_SDL_FIELD_NAME.clone(),
+        FEDERATION_SDL_FIELD_NAME,
         Component::new(FieldDefinition {
             description: None,
-            name: FEDERATION_SDL_FIELD_NAME.clone(),
+            name: FEDERATION_SDL_FIELD_NAME,
             arguments: Vec::new(),
             ty: Type::Named(name!("String")),
             directives: Default::default(),
         }),
     );
     let service_type_pos = ObjectTypeDefinitionPosition {
-        type_name: FEDERATION_SERVICE_TYPE_NAME.clone(),
+        type_name: FEDERATION_SERVICE_TYPE_NAME,
     };
     service_type_pos.pre_insert(&mut subgraph.schema)?;
     service_type_pos.insert(
@@ -1747,7 +1747,7 @@ fn add_federation_operations(
     let is_entity_type = !entity_members.is_empty();
     if is_entity_type {
         let entity_type_pos = UnionTypeDefinitionPosition {
-            type_name: FEDERATION_ENTITY_TYPE_NAME.clone(),
+            type_name: FEDERATION_ENTITY_TYPE_NAME,
         };
         entity_type_pos.pre_insert(&mut subgraph.schema)?;
         entity_type_pos.insert(
@@ -1788,24 +1788,24 @@ fn add_federation_operations(
     let query_root_type_name = query_root_pos.get(subgraph.schema.schema())?.name.clone();
     let entity_field_pos = ObjectFieldDefinitionPosition {
         type_name: query_root_type_name.clone(),
-        field_name: FEDERATION_ENTITIES_FIELD_NAME.clone(),
+        field_name: FEDERATION_ENTITIES_FIELD_NAME,
     };
     if is_entity_type {
         entity_field_pos.insert(
             &mut subgraph.schema,
             Component::new(FieldDefinition {
                 description: None,
-                name: FEDERATION_ENTITIES_FIELD_NAME.clone(),
+                name: FEDERATION_ENTITIES_FIELD_NAME,
                 arguments: vec![Node::new(InputValueDefinition {
                     description: None,
-                    name: FEDERATION_REPRESENTATIONS_ARGUMENTS_NAME.clone(),
+                    name: FEDERATION_REPRESENTATIONS_ARGUMENTS_NAME,
                     ty: Node::new(Type::NonNullList(Box::new(Type::NonNullNamed(
-                        FEDERATION_ANY_TYPE_NAME.clone(),
+                        FEDERATION_ANY_TYPE_NAME,
                     )))),
                     default_value: None,
                     directives: Default::default(),
                 })],
-                ty: Type::NonNullList(Box::new(Type::Named(FEDERATION_ENTITY_TYPE_NAME.clone()))),
+                ty: Type::NonNullList(Box::new(Type::Named(FEDERATION_ENTITY_TYPE_NAME))),
                 directives: Default::default(),
             }),
         )?;
@@ -1815,15 +1815,15 @@ fn add_federation_operations(
 
     ObjectFieldDefinitionPosition {
         type_name: query_root_type_name.clone(),
-        field_name: FEDERATION_SERVICE_FIELD_NAME.clone(),
+        field_name: FEDERATION_SERVICE_FIELD_NAME,
     }
     .insert(
         &mut subgraph.schema,
         Component::new(FieldDefinition {
             description: None,
-            name: FEDERATION_SERVICE_FIELD_NAME.clone(),
+            name: FEDERATION_SERVICE_FIELD_NAME,
             arguments: Vec::new(),
-            ty: Type::NonNullNamed(FEDERATION_SERVICE_TYPE_NAME.clone()),
+            ty: Type::NonNullNamed(FEDERATION_SERVICE_TYPE_NAME),
             directives: Default::default(),
         }),
     )?;

--- a/src/query_graph/extract_subgraphs_from_supergraph.rs
+++ b/src/query_graph/extract_subgraphs_from_supergraph.rs
@@ -7,12 +7,11 @@ use crate::link::link_spec_definition::LinkSpecDefinition;
 use crate::link::spec::{Identity, Version};
 use crate::link::spec_definition::{spec_definitions, SpecDefinition};
 use crate::schema::position::{
-    DirectiveDefinitionPosition, EnumTypeDefinitionPosition, EnumValueDefinitionPosition,
-    InputObjectFieldDefinitionPosition, InputObjectTypeDefinitionPosition,
-    InterfaceFieldDefinitionPosition, InterfaceTypeDefinitionPosition,
-    ObjectFieldDefinitionPosition, ObjectTypeDefinitionPosition, ScalarTypeDefinitionPosition,
-    SchemaRootDefinitionKind, SchemaRootDefinitionPosition, TypeDefinitionPosition,
-    UnionTypeDefinitionPosition,
+    DirectiveDefinitionPosition, EnumTypeDefinitionPosition, InputObjectFieldDefinitionPosition,
+    InputObjectTypeDefinitionPosition, InterfaceFieldDefinitionPosition,
+    InterfaceTypeDefinitionPosition, ObjectFieldDefinitionPosition, ObjectTypeDefinitionPosition,
+    ScalarTypeDefinitionPosition, SchemaRootDefinitionKind, SchemaRootDefinitionPosition,
+    TypeDefinitionPosition, UnionTypeDefinitionPosition,
 };
 use crate::schema::FederationSchema;
 use apollo_compiler::ast::FieldDefinition;
@@ -1192,6 +1191,7 @@ fn extract_enum_type_content<'schema>(
         let type_ = pos.get(supergraph_schema.schema())?;
 
         for (value_name, value) in type_.values.iter() {
+            let value_pos = pos.value(value_name.clone());
             let mut enum_value_directive_applications = Vec::new();
             if let Some(enum_value_directive_definition) = enum_value_directive_definition {
                 for directive in value.directives.iter() {
@@ -1209,11 +1209,7 @@ fn extract_enum_type_content<'schema>(
                         graph_enum_value_name_to_subgraph_name,
                         graph_enum_value,
                     )?;
-                    EnumValueDefinitionPosition {
-                        type_name: (*type_name).clone(),
-                        value_name: value_name.clone(),
-                    }
-                    .insert(
+                    value_pos.insert(
                         &mut subgraph.schema,
                         Component::new(EnumValueDefinition {
                             description: None,
@@ -1241,11 +1237,7 @@ fn extract_enum_type_content<'schema>(
                             }.into()
                         );
                     }
-                    EnumValueDefinitionPosition {
-                        type_name: (*type_name).clone(),
-                        value_name: value_name.clone(),
-                    }
-                    .insert(
+                    value_pos.insert(
                         &mut subgraph.schema,
                         Component::new(EnumValueDefinition {
                             description: None,

--- a/src/schema/referencer.rs
+++ b/src/schema/referencer.rs
@@ -1,3 +1,4 @@
+use crate::error::{FederationError, SingleFederationError};
 use crate::schema::position::{
     DirectiveArgumentDefinitionPosition, EnumTypeDefinitionPosition, EnumValueDefinitionPosition,
     InputObjectFieldDefinitionPosition, InputObjectTypeDefinitionPosition,
@@ -5,6 +6,7 @@ use crate::schema::position::{
     InterfaceTypeDefinitionPosition, ObjectFieldArgumentDefinitionPosition,
     ObjectFieldDefinitionPosition, ObjectTypeDefinitionPosition, ScalarTypeDefinitionPosition,
     SchemaDefinitionPosition, SchemaRootDefinitionPosition, UnionTypeDefinitionPosition,
+    UnionTypenameFieldDefinitionPosition,
 };
 use apollo_compiler::schema::Name;
 use indexmap::{Equivalent, IndexMap, IndexSet};
@@ -30,6 +32,90 @@ impl Referencers {
             || self.enum_types.contains_key(name)
             || self.input_object_types.contains_key(name)
     }
+
+    pub(crate) fn get_scalar_type<Q: Hash + Equivalent<Name>>(
+        &self,
+        name: &Q,
+    ) -> Result<&ScalarTypeReferencers, FederationError> {
+        self.scalar_types.get(name).ok_or_else(|| {
+            SingleFederationError::Internal {
+                message: "Scalar type referencers unexpectedly missing type".to_owned(),
+            }
+            .into()
+        })
+    }
+
+    pub(crate) fn get_object_type<Q: Hash + Equivalent<Name>>(
+        &self,
+        name: &Q,
+    ) -> Result<&ObjectTypeReferencers, FederationError> {
+        self.object_types.get(name).ok_or_else(|| {
+            SingleFederationError::Internal {
+                message: "Object type referencers unexpectedly missing type".to_owned(),
+            }
+            .into()
+        })
+    }
+
+    pub(crate) fn get_interface_type<Q: Hash + Equivalent<Name>>(
+        &self,
+        name: &Q,
+    ) -> Result<&InterfaceTypeReferencers, FederationError> {
+        self.interface_types.get(name).ok_or_else(|| {
+            SingleFederationError::Internal {
+                message: "Interface type referencers unexpectedly missing type".to_owned(),
+            }
+            .into()
+        })
+    }
+
+    pub(crate) fn get_union_type<Q: Hash + Equivalent<Name>>(
+        &self,
+        name: &Q,
+    ) -> Result<&UnionTypeReferencers, FederationError> {
+        self.union_types.get(name).ok_or_else(|| {
+            SingleFederationError::Internal {
+                message: "Union type referencers unexpectedly missing type".to_owned(),
+            }
+            .into()
+        })
+    }
+
+    pub(crate) fn get_enum_type<Q: Hash + Equivalent<Name>>(
+        &self,
+        name: &Q,
+    ) -> Result<&EnumTypeReferencers, FederationError> {
+        self.enum_types.get(name).ok_or_else(|| {
+            SingleFederationError::Internal {
+                message: "Enum type referencers unexpectedly missing type".to_owned(),
+            }
+            .into()
+        })
+    }
+
+    pub(crate) fn get_input_object_type<Q: Hash + Equivalent<Name>>(
+        &self,
+        name: &Q,
+    ) -> Result<&InputObjectTypeReferencers, FederationError> {
+        self.input_object_types.get(name).ok_or_else(|| {
+            SingleFederationError::Internal {
+                message: "Input object type referencers unexpectedly missing type".to_owned(),
+            }
+            .into()
+        })
+    }
+
+    pub(crate) fn get_directive<Q: Hash + Equivalent<Name>>(
+        &self,
+        name: &Q,
+    ) -> Result<&DirectiveReferencers, FederationError> {
+        self.directives.get(name).ok_or_else(|| {
+            SingleFederationError::Internal {
+                message: "Directive referencers unexpectedly missing directive".to_owned(),
+            }
+            .into()
+        })
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -38,6 +124,7 @@ pub(crate) struct ScalarTypeReferencers {
     pub(crate) object_field_arguments: IndexSet<ObjectFieldArgumentDefinitionPosition>,
     pub(crate) interface_fields: IndexSet<InterfaceFieldDefinitionPosition>,
     pub(crate) interface_field_arguments: IndexSet<InterfaceFieldArgumentDefinitionPosition>,
+    pub(crate) union_fields: IndexSet<UnionTypenameFieldDefinitionPosition>,
     pub(crate) input_object_fields: IndexSet<InputObjectFieldDefinitionPosition>,
     pub(crate) directive_arguments: IndexSet<DirectiveArgumentDefinitionPosition>,
 }


### PR DESCRIPTION
This PR:
- Updates the `federation-next` schema wrapper to handle reserved names better. Specifically, we now:
  - Error if we try to insert/remove elements containing fields/arguments/input fields/enum values that start with `__`.
    - Note that built-in shadowing is still TODO/isn't implemented here, so accordingly we still ignore built-in types/directives as before.
  - Allow fetching meta-fields for objects/interfaces/unions, via `apollo-rs`'s `Schema.type_field()` method.
    - We track their GraphQL references appropriately, similar to the JS code.
    - We also add some convenience functions to get child positions from parent positions, and update code to call them.
  - Rearrange GraphQL reference insertion to occur after `Schema` element insertion instead of before, as we need the type to already be in the schema to call `type_field()` during GraphQL reference insertion. This means doing map lookups post-element-insertion to get a Rust reference to the inserted element, though arguably inserting GraphQL references afterwards is saner behavior as we don't have to worry about the element not existing yet during GraphQL reference insertion.
- Unrelated to the above, we also add some convenience structs/methods used by query graph creation here, namely:
  - `CompositeTypeDefinitionPosition`, `AbstractTypeDefinitionPosition`, and `FieldDefinitionPosition` (mainly just Rust enum analogues to the corresponding TS union types).
  - Some convenience methods for `Referencers` to handle map lookup errors.