### PR TITLE
Second half of updating `federation-next` to use `apollo-compiler@1.0.0-beta.6`

### DIFF
--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -352,6 +352,8 @@ impl SingleFederationError {
     }
 }
 
+// TODO: Once InvalidNameError includes the invalid name in the error, we can replace this with an
+// implementation for From<InvalidNameError>.
 pub(crate) fn graphql_name(name: &str) -> Result<Name, FederationError> {
     Name::new(name).map_err(|_| {
         SingleFederationError::InvalidGraphQL {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)] // TODO: This is fine while we're iterating, but should be removed later.
-use apollo_compiler::ast::Directives;
+use apollo_compiler::ast::DirectiveList;
 use apollo_compiler::schema::ExtendedType;
 use apollo_compiler::Schema;
 
@@ -60,7 +60,7 @@ impl Supergraph {
                 && !graphql_type
                     .directives()
                     .iter()
-                    .any(|d| d.name.eq("inaccessible"))
+                    .any(|d| d.name == "inaccessible")
         });
         // remove directive applications
         for (_, graphql_type) in api_schema.types.iter_mut() {
@@ -146,8 +146,8 @@ fn is_join_type(type_name: &str) -> bool {
     JOIN_TYPES.contains(&type_name)
 }
 
-fn is_inaccessible_applied(directives: &Directives) -> bool {
-    directives.iter().any(|d| d.name.eq("inaccessible"))
+fn is_inaccessible_applied(directives: &DirectiveList) -> bool {
+    directives.iter().any(|d| d.name == "inaccessible")
 }
 
 #[cfg(test)]

--- a/src/link/database.rs
+++ b/src/link/database.rs
@@ -134,10 +134,11 @@ fn parse_link_if_bootstrap_directive(schema: &Schema, directive: &Directive) -> 
             .and_then(|value| value.as_str())
         {
             let url = url.parse::<Url>();
+            let default_link_name = DEFAULT_LINK_NAME;
             let expected_name = directive
                 .argument_by_name("as")
                 .and_then(|value| value.as_str())
-                .unwrap_or(DEFAULT_LINK_NAME);
+                .unwrap_or(default_link_name.as_str());
             return url.map_or(false, |url| {
                 url.identity == Identity::link_identity() && directive.name == expected_name
             });

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -4,6 +4,8 @@ use crate::link::spec::Identity;
 use crate::link::spec::Url;
 use crate::link::spec_definition::spec_definitions;
 use apollo_compiler::ast::{Directive, Value};
+use apollo_compiler::name;
+use apollo_compiler::schema::Name;
 use std::fmt;
 use std::ops::Deref;
 use std::str;
@@ -18,9 +20,9 @@ pub(crate) mod link_spec_definition;
 pub mod spec;
 pub(crate) mod spec_definition;
 
-pub const DEFAULT_LINK_NAME: &str = "link";
-pub const DEFAULT_IMPORT_SCALAR_NAME: &str = "Import";
-pub const DEFAULT_PURPOSE_ENUM_NAME: &str = "Purpose";
+pub const DEFAULT_LINK_NAME: Name = name!("link");
+pub const DEFAULT_IMPORT_SCALAR_NAME: Name = name!("Import");
+pub const DEFAULT_PURPOSE_ENUM_NAME: Name = name!("Purpose");
 
 // TODO: we should provide proper "diagnostic" here, linking to ast, accumulating more than one
 // error and whatnot.
@@ -80,6 +82,15 @@ impl fmt::Display for Purpose {
             Purpose::EXECUTION => "EXECUTION",
         };
         write!(f, "{}", str)
+    }
+}
+
+impl From<&Purpose> for Name {
+    fn from(value: &Purpose) -> Self {
+        match value {
+            Purpose::SECURITY => name!("SECURITY"),
+            Purpose::EXECUTION => name!("EXECUTION"),
+        }
     }
 }
 

--- a/src/subgraph/mod.rs
+++ b/src/subgraph/mod.rs
@@ -2,9 +2,9 @@ use std::collections::BTreeMap;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use apollo_compiler::ast::{Name, NamedType};
-use apollo_compiler::schema::{ComponentStr, ExtendedType, ObjectType};
-use apollo_compiler::{Node, Schema};
+use apollo_compiler::ast::Name;
+use apollo_compiler::schema::{ComponentName, ExtendedType, ObjectType};
+use apollo_compiler::{name, Node, Schema};
 use indexmap::map::Entry;
 use indexmap::{IndexMap, IndexSet};
 
@@ -29,8 +29,8 @@ pub struct SubgraphError {
     pub msg: String,
 }
 
-impl From<apollo_compiler::Diagnostics> for SubgraphError {
-    fn from(value: apollo_compiler::Diagnostics) -> Self {
+impl From<apollo_compiler::DiagnosticList> for SubgraphError {
+    fn from(value: apollo_compiler::DiagnosticList) -> Self {
         SubgraphError {
             msg: value.to_string_no_color(),
         }
@@ -51,6 +51,12 @@ impl From<FederationSpecError> for SubgraphError {
             msg: value.to_string(),
         }
     }
+}
+
+pub(crate) fn graphql_name_or_subgraph_error(name: &str) -> Result<Name, SubgraphError> {
+    Name::new(name).map_err(|_| SubgraphError {
+        msg: format!("Invalid GraphQL name \"{}\"", name),
+    })
 }
 
 pub struct Subgraph {
@@ -90,25 +96,22 @@ impl Subgraph {
 
         let mut imported_federation_definitions: Option<FederationSpecDefinitions> = None;
         let mut imported_link_definitions: Option<LinkSpecDefinitions> = None;
+        let default_link_name = DEFAULT_LINK_NAME;
         let link_directives = schema
             .schema_definition
             .directives
-            .get_all(DEFAULT_LINK_NAME);
+            .get_all(&default_link_name);
 
         for directive in link_directives {
             let link_directive = Link::from_directive_application(directive)?;
-            if link_directive
-                .url
-                .identity
-                .eq(&Identity::federation_identity())
-            {
+            if link_directive.url.identity == Identity::federation_identity() {
                 if imported_federation_definitions.is_some() {
                     return Err(SubgraphError { msg: "invalid graphql schema - multiple @link imports for the federation specification are not supported".to_owned() });
                 }
 
                 imported_federation_definitions =
                     Some(FederationSpecDefinitions::from_link(link_directive)?);
-            } else if link_directive.url.identity.eq(&Identity::link_identity()) {
+            } else if link_directive.url.identity == Identity::link_identity() {
                 // user manually imported @link specification
                 if imported_link_definitions.is_some() {
                     return Err(SubgraphError { msg: "invalid graphql schema - multiple @link imports for the link specification are not supported".to_owned() });
@@ -176,18 +179,29 @@ impl Subgraph {
         schema: &mut Schema,
         link_spec_definitions: LinkSpecDefinitions,
     ) -> Result<(), SubgraphError> {
+        let purpose_enum_name =
+            graphql_name_or_subgraph_error(&link_spec_definitions.purpose_enum_name)?;
         schema
             .types
-            .entry(link_spec_definitions.purpose_enum_name.as_str().into())
-            .or_insert_with(|| link_spec_definitions.link_purpose_enum_definition().into());
+            .entry(purpose_enum_name.clone())
+            .or_insert_with(|| {
+                link_spec_definitions
+                    .link_purpose_enum_definition(purpose_enum_name)
+                    .into()
+            });
+        let import_scalar_name =
+            graphql_name_or_subgraph_error(&link_spec_definitions.import_scalar_name)?;
         schema
             .types
-            .entry(link_spec_definitions.import_scalar_name.as_str().into())
-            .or_insert_with(|| link_spec_definitions.import_scalar_definition().into());
-        schema
-            .directive_definitions
-            .entry(DEFAULT_LINK_NAME.into())
-            .or_insert_with(|| link_spec_definitions.link_directive_definition().into());
+            .entry(import_scalar_name.clone())
+            .or_insert_with(|| {
+                link_spec_definitions
+                    .import_scalar_definition(import_scalar_name)
+                    .into()
+            });
+        if let Entry::Vacant(entry) = schema.directive_definitions.entry(DEFAULT_LINK_NAME) {
+            entry.insert(link_spec_definitions.link_directive_definition()?.into());
+        }
         Ok(())
     }
 
@@ -195,17 +209,24 @@ impl Subgraph {
         schema: &mut Schema,
         fed_definitions: &FederationSpecDefinitions,
     ) -> Result<(), SubgraphError> {
+        let fieldset_scalar_name =
+            graphql_name_or_subgraph_error(&fed_definitions.fieldset_scalar_name)?;
         schema
             .types
-            .entry(fed_definitions.fieldset_scalar_name.as_str().into())
-            .or_insert_with(|| fed_definitions.fieldset_scalar_definition().into());
+            .entry(fieldset_scalar_name.clone())
+            .or_insert_with(|| {
+                fed_definitions
+                    .fieldset_scalar_definition(fieldset_scalar_name)
+                    .into()
+            });
 
-        for directive_name in FEDERATION_V2_DIRECTIVE_NAMES {
-            let namespaced_directive_name =
-                fed_definitions.namespaced_type_name(directive_name, true);
+        for directive_name in &FEDERATION_V2_DIRECTIVE_NAMES {
+            let namespaced_directive_name = graphql_name_or_subgraph_error(
+                &fed_definitions.namespaced_type_name(directive_name, true),
+            )?;
             if let Entry::Vacant(entry) = schema
                 .directive_definitions
-                .entry(namespaced_directive_name.as_str().into())
+                .entry(namespaced_directive_name.clone())
             {
                 let directive_definition = fed_definitions.directive_definition(
                     directive_name,
@@ -223,7 +244,7 @@ impl Subgraph {
     ) -> Result<(), SubgraphError> {
         schema
             .types
-            .entry(NamedType::new(SERVICE_TYPE))
+            .entry(SERVICE_TYPE)
             .or_insert_with(|| fed_definitions.service_object_type_definition());
 
         let entities = Self::locate_entities(schema, fed_definitions);
@@ -231,11 +252,11 @@ impl Subgraph {
         if entities_present {
             schema
                 .types
-                .entry(NamedType::new(ENTITY_UNION_NAME))
+                .entry(ENTITY_UNION_NAME)
                 .or_insert_with(|| fed_definitions.entity_union_definition(entities));
             schema
                 .types
-                .entry(NamedType::new(ANY_SCALAR_NAME))
+                .entry(ANY_SCALAR_NAME)
                 .or_insert_with(|| fed_definitions.any_scalar_definition());
         }
 
@@ -243,12 +264,13 @@ impl Subgraph {
             .schema_definition
             .make_mut()
             .query
-            .get_or_insert(ComponentStr::new("Query"));
+            .get_or_insert(ComponentName::from(name!("Query")));
         if let ExtendedType::Object(query_type) = schema
             .types
-            .entry(NamedType::new(query_type_name.as_str()))
+            .entry(query_type_name.name.clone())
             .or_insert(ExtendedType::Object(Node::new(ObjectType {
                 description: None,
+                name: query_type_name.name.clone(),
                 directives: Default::default(),
                 fields: IndexMap::new(),
                 implements_interfaces: IndexSet::new(),
@@ -257,13 +279,13 @@ impl Subgraph {
             let query_type = query_type.make_mut();
             query_type
                 .fields
-                .entry(Name::new(SERVICE_SDL_QUERY))
+                .entry(SERVICE_SDL_QUERY)
                 .or_insert_with(|| fed_definitions.service_sdl_query_field());
             if entities_present {
                 // _entities(representations: [_Any!]!): [_Entity]!
                 query_type
                     .fields
-                    .entry(Name::new(ENTITIES_QUERY))
+                    .entry(ENTITIES_QUERY)
                     .or_insert_with(|| fed_definitions.entities_query_field());
             }
         }
@@ -273,7 +295,7 @@ impl Subgraph {
     fn locate_entities(
         schema: &mut Schema,
         fed_definitions: &FederationSpecDefinitions,
-    ) -> IndexSet<ComponentStr> {
+    ) -> IndexSet<ComponentName> {
         let mut entities = Vec::new();
         let immutable_type_map = schema.types.to_owned();
         for (named_type, extended_type) in immutable_type_map.iter() {
@@ -281,11 +303,10 @@ impl Subgraph {
                 .directives()
                 .iter()
                 .find(|d| {
-                    d.name.eq(&Name::new(
-                        fed_definitions
-                            .namespaced_type_name(KEY_DIRECTIVE_NAME, true)
-                            .as_str(),
-                    ))
+                    d.name
+                        == fed_definitions
+                            .namespaced_type_name(&KEY_DIRECTIVE_NAME, true)
+                            .as_str()
                 })
                 .map(|_| true)
                 .unwrap_or(false);
@@ -293,10 +314,8 @@ impl Subgraph {
                 entities.push(named_type);
             }
         }
-        let entity_set: IndexSet<ComponentStr> = entities
-            .iter()
-            .map(|e| ComponentStr::new(e.as_str()))
-            .collect();
+        let entity_set: IndexSet<ComponentName> =
+            entities.iter().map(|e| ComponentName::from(*e)).collect();
         entity_set
     }
 }

--- a/src/subgraph/mod.rs
+++ b/src/subgraph/mod.rs
@@ -53,6 +53,8 @@ impl From<FederationSpecError> for SubgraphError {
     }
 }
 
+// TODO: Once InvalidNameError includes the invalid name in the error, we can replace this with an
+// implementation for From<InvalidNameError>.
 pub(crate) fn graphql_name_or_subgraph_error(name: &str) -> Result<Name, SubgraphError> {
     Name::new(name).map_err(|_| SubgraphError {
         msg: format!("Invalid GraphQL name \"{}\"", name),

--- a/src/subgraph/spec.rs
+++ b/src/subgraph/spec.rs
@@ -122,6 +122,8 @@ pub enum FederationSpecError {
     InvalidGraphQLName(String),
 }
 
+// TODO: Once InvalidNameError includes the invalid name in the error, we can replace this with an
+// implementation for From<InvalidNameError>.
 pub(crate) fn graphql_name_or_federation_spec_error(
     name: &str,
 ) -> Result<Name, FederationSpecError> {

--- a/src/subgraph/spec.rs
+++ b/src/subgraph/spec.rs
@@ -2,13 +2,14 @@ use std::sync::Arc;
 
 use apollo_compiler::ast::{
     Argument, Directive, DirectiveDefinition, DirectiveLocation, EnumValueDefinition,
-    FieldDefinition, InputValueDefinition, Name, NamedType, Type, Value,
+    FieldDefinition, InputValueDefinition, Name, Type, Value,
 };
 use apollo_compiler::schema::{
-    Component, ComponentStr, EnumType, ExtendedType, ObjectType, ScalarType, UnionType,
+    Component, ComponentName, EnumType, ExtendedType, ObjectType, ScalarType, UnionType,
 };
-use apollo_compiler::Node;
+use apollo_compiler::{name, Node};
 use indexmap::{IndexMap, IndexSet};
+use lazy_static::lazy_static;
 use thiserror::Error;
 
 use crate::link::spec::{Identity, Url, Version};
@@ -19,28 +20,28 @@ use crate::subgraph::spec::FederationSpecError::{
     UnsupportedFederationDirective, UnsupportedVersionError,
 };
 
-pub const COMPOSE_DIRECTIVE_NAME: &str = "composeDirective";
-pub const KEY_DIRECTIVE_NAME: &str = "key";
-pub const EXTENDS_DIRECTIVE_NAME: &str = "extends";
-pub const EXTERNAL_DIRECTIVE_NAME: &str = "external";
-pub const INACCESSIBLE_DIRECTIVE_NAME: &str = "inaccessible";
-pub const INTF_OBJECT_DIRECTIVE_NAME: &str = "interfaceObject";
-pub const OVERRIDE_DIRECTIVE_NAME: &str = "override";
-pub const PROVIDES_DIRECTIVE_NAME: &str = "provides";
-pub const REQUIRES_DIRECTIVE_NAME: &str = "requires";
-pub const SHAREABLE_DIRECTIVE_NAME: &str = "shareable";
-pub const TAG_DIRECTIVE_NAME: &str = "tag";
-pub const FIELDSET_SCALAR_NAME: &str = "FieldSet";
+pub const COMPOSE_DIRECTIVE_NAME: Name = name!("composeDirective");
+pub const KEY_DIRECTIVE_NAME: Name = name!("key");
+pub const EXTENDS_DIRECTIVE_NAME: Name = name!("extends");
+pub const EXTERNAL_DIRECTIVE_NAME: Name = name!("external");
+pub const INACCESSIBLE_DIRECTIVE_NAME: Name = name!("inaccessible");
+pub const INTF_OBJECT_DIRECTIVE_NAME: Name = name!("interfaceObject");
+pub const OVERRIDE_DIRECTIVE_NAME: Name = name!("override");
+pub const PROVIDES_DIRECTIVE_NAME: Name = name!("provides");
+pub const REQUIRES_DIRECTIVE_NAME: Name = name!("requires");
+pub const SHAREABLE_DIRECTIVE_NAME: Name = name!("shareable");
+pub const TAG_DIRECTIVE_NAME: Name = name!("tag");
+pub const FIELDSET_SCALAR_NAME: Name = name!("FieldSet");
 
 // federated types
-pub const ANY_SCALAR_NAME: &str = "_Any";
-pub const ENTITY_UNION_NAME: &str = "_Entity";
-pub const SERVICE_TYPE: &str = "_Service";
+pub const ANY_SCALAR_NAME: Name = name!("_Any");
+pub const ENTITY_UNION_NAME: Name = name!("_Entity");
+pub const SERVICE_TYPE: Name = name!("_Service");
 
-pub const ENTITIES_QUERY: &str = "_entities";
-pub const SERVICE_SDL_QUERY: &str = "_service";
+pub const ENTITIES_QUERY: Name = name!("_entities");
+pub const SERVICE_SDL_QUERY: Name = name!("_service");
 
-pub const FEDERATION_V1_DIRECTIVE_NAMES: [&str; 5] = [
+pub const FEDERATION_V1_DIRECTIVE_NAMES: [Name; 5] = [
     KEY_DIRECTIVE_NAME,
     EXTENDS_DIRECTIVE_NAME,
     EXTERNAL_DIRECTIVE_NAME,
@@ -48,7 +49,7 @@ pub const FEDERATION_V1_DIRECTIVE_NAMES: [&str; 5] = [
     REQUIRES_DIRECTIVE_NAME,
 ];
 
-pub const FEDERATION_V2_DIRECTIVE_NAMES: [&str; 11] = [
+pub const FEDERATION_V2_DIRECTIVE_NAMES: [Name; 11] = [
     COMPOSE_DIRECTIVE_NAME,
     KEY_DIRECTIVE_NAME,
     EXTENDS_DIRECTIVE_NAME,
@@ -61,6 +62,46 @@ pub const FEDERATION_V2_DIRECTIVE_NAMES: [&str; 11] = [
     SHAREABLE_DIRECTIVE_NAME,
     TAG_DIRECTIVE_NAME,
 ];
+
+// This type and the subsequent IndexMap exist purely so we can use match with Names; see comment
+// in FederationSpecDefinitions.directive_definition() for more information.
+enum FederationDirectiveName {
+    Compose,
+    Key,
+    Extends,
+    External,
+    Inaccessible,
+    IntfObject,
+    Override,
+    Provides,
+    Requires,
+    Shareable,
+    Tag,
+}
+
+lazy_static! {
+    static ref FEDERATION_DIRECTIVE_NAMES_TO_ENUM: IndexMap<Name, FederationDirectiveName> = {
+        IndexMap::from([
+            (COMPOSE_DIRECTIVE_NAME, FederationDirectiveName::Compose),
+            (KEY_DIRECTIVE_NAME, FederationDirectiveName::Key),
+            (EXTENDS_DIRECTIVE_NAME, FederationDirectiveName::Extends),
+            (EXTERNAL_DIRECTIVE_NAME, FederationDirectiveName::External),
+            (
+                INACCESSIBLE_DIRECTIVE_NAME,
+                FederationDirectiveName::Inaccessible,
+            ),
+            (
+                INTF_OBJECT_DIRECTIVE_NAME,
+                FederationDirectiveName::IntfObject,
+            ),
+            (OVERRIDE_DIRECTIVE_NAME, FederationDirectiveName::Override),
+            (PROVIDES_DIRECTIVE_NAME, FederationDirectiveName::Provides),
+            (REQUIRES_DIRECTIVE_NAME, FederationDirectiveName::Requires),
+            (SHAREABLE_DIRECTIVE_NAME, FederationDirectiveName::Shareable),
+            (TAG_DIRECTIVE_NAME, FederationDirectiveName::Tag),
+        ])
+    };
+}
 
 const MIN_FEDERATION_VERSION: Version = Version { major: 2, minor: 0 };
 const MAX_FEDERATION_VERSION: Version = Version { major: 2, minor: 5 };
@@ -77,6 +118,16 @@ pub enum FederationSpecError {
     },
     #[error("Unsupported federation directive import {0}")]
     UnsupportedFederationDirective(String),
+    #[error("Invalid GraphQL name {0}")]
+    InvalidGraphQLName(String),
+}
+
+pub(crate) fn graphql_name_or_federation_spec_error(
+    name: &str,
+) -> Result<Name, FederationSpecError> {
+    Name::new(name).map_err(|_| {
+        FederationSpecError::InvalidGraphQLName(format!("Invalid GraphQL name \"{}\"", name))
+    })
 }
 
 #[derive(Debug)]
@@ -108,8 +159,8 @@ macro_rules! applied_specification {
                     .map(|i| {
                         if i.alias.is_some() {
                             Value::Object(vec![
-                                ("name".into(), i.element.as_str().into()),
-                                ("as".into(), i.imported_display_name().into()),
+                                (name!("name"), i.element.as_str().into()),
+                                (name!("as"), i.imported_display_name().into()),
                             ])
                         } else {
                             i.imported_display_name().into()
@@ -117,28 +168,28 @@ macro_rules! applied_specification {
                     })
                     .collect::<Vec<Node<Value>>>();
                 let mut applied_link_directive = Directive {
-                    name: DEFAULT_LINK_NAME.into(),
+                    name: DEFAULT_LINK_NAME,
                     arguments: vec![
                         Argument {
-                            name: "url".into(),
+                            name: name!("url"),
                             value: self.link.url.to_string().into(),
                         }.into(),
                         Argument {
-                            name: "import".into(),
+                            name: name!("import"),
                             value: Value::List(imports).into(),
                         }.into(),
                     ]
                 };
                 if let Some(spec_alias) = &self.link.spec_alias {
                     applied_link_directive.arguments.push(Argument {
-                        name: "as".into(),
+                        name: name!("as"),
                         value: spec_alias.into(),
                     }.into())
                 }
                 if let Some(purpose) = &self.link.purpose {
                     applied_link_directive.arguments.push(Argument {
-                        name: "for".into(),
-                        value: Value::Enum(purpose.to_string().into()).into(),
+                        name: name!("for"),
+                        value: Value::Enum(purpose.into()).into(),
                     }.into())
                 }
                 applied_link_directive
@@ -162,7 +213,7 @@ impl FederationSpecDefinitions {
                 max: MAX_FEDERATION_VERSION.to_string(),
             })
         } else {
-            let fieldset_scalar_name = link.type_name_in_schema(FIELDSET_SCALAR_NAME);
+            let fieldset_scalar_name = link.type_name_in_schema(&FIELDSET_SCALAR_NAME);
             Ok(Self {
                 link,
                 fieldset_scalar_name,
@@ -201,54 +252,65 @@ impl FederationSpecDefinitions {
 
     pub fn directive_definition(
         &self,
-        name: &str,
-        alias: &Option<String>,
+        name: &Name,
+        alias: &Option<Name>,
     ) -> Result<DirectiveDefinition, FederationSpecError> {
-        match name {
-            COMPOSE_DIRECTIVE_NAME => Ok(self.compose_directive_definition(alias)),
-            KEY_DIRECTIVE_NAME => Ok(self.key_directive_definition(alias)),
-            EXTENDS_DIRECTIVE_NAME => Ok(self.extends_directive_definition(alias)),
-            EXTERNAL_DIRECTIVE_NAME => Ok(self.external_directive_definition(alias)),
-            INACCESSIBLE_DIRECTIVE_NAME => Ok(self.inaccessible_directive_definition(alias)),
-            INTF_OBJECT_DIRECTIVE_NAME => Ok(self.interface_object_directive_definition(alias)),
-            OVERRIDE_DIRECTIVE_NAME => Ok(self.override_directive_definition(alias)),
-            PROVIDES_DIRECTIVE_NAME => Ok(self.provides_directive_definition(alias)),
-            REQUIRES_DIRECTIVE_NAME => Ok(self.requires_directive_definition(alias)),
-            SHAREABLE_DIRECTIVE_NAME => Ok(self.shareable_directive_definition(alias)),
-            TAG_DIRECTIVE_NAME => Ok(self.tag_directive_definition(alias)),
-            _ => Err(UnsupportedFederationDirective(name.to_string())),
-        }
+        // TODO: NodeStr is not annotated with #[derive(PartialEq, Eq)], so Clippy warns it should
+        // not be used in pattern matching (as some future Rust version will likely turn this into
+        // a hard error). We resort instead to indexing into a static IndexMap to get an enum, which
+        // can be used in a match.
+        let Some(enum_name) = FEDERATION_DIRECTIVE_NAMES_TO_ENUM.get(name) else {
+            return Err(UnsupportedFederationDirective(name.to_string()));
+        };
+        Ok(match enum_name {
+            FederationDirectiveName::Compose => self.compose_directive_definition(alias),
+            FederationDirectiveName::Key => self.key_directive_definition(alias)?,
+            FederationDirectiveName::Extends => self.extends_directive_definition(alias),
+            FederationDirectiveName::External => self.external_directive_definition(alias),
+            FederationDirectiveName::Inaccessible => self.inaccessible_directive_definition(alias),
+            FederationDirectiveName::IntfObject => {
+                self.interface_object_directive_definition(alias)
+            }
+            FederationDirectiveName::Override => self.override_directive_definition(alias),
+            FederationDirectiveName::Provides => self.provides_directive_definition(alias)?,
+            FederationDirectiveName::Requires => self.requires_directive_definition(alias)?,
+            FederationDirectiveName::Shareable => self.shareable_directive_definition(alias),
+            FederationDirectiveName::Tag => self.tag_directive_definition(alias),
+        })
     }
 
     /// scalar FieldSet
-    pub fn fieldset_scalar_definition(&self) -> ScalarType {
+    pub fn fieldset_scalar_definition(&self, name: Name) -> ScalarType {
         ScalarType {
             description: None,
+            name,
             directives: Default::default(),
         }
     }
 
-    fn fields_argument_definition(&self) -> InputValueDefinition {
-        InputValueDefinition {
+    fn fields_argument_definition(&self) -> Result<InputValueDefinition, FederationSpecError> {
+        Ok(InputValueDefinition {
             description: None,
-            name: "fields".into(),
-            ty: Type::new_named(&self.namespaced_type_name(FIELDSET_SCALAR_NAME, false))
-                .non_null()
-                .into(),
+            name: name!("fields"),
+            ty: Type::Named(graphql_name_or_federation_spec_error(
+                &self.namespaced_type_name(&FIELDSET_SCALAR_NAME, false),
+            )?)
+            .non_null()
+            .into(),
             default_value: None,
             directives: Default::default(),
-        }
+        })
     }
 
     /// directive @composeDirective(name: String!) repeatable on SCHEMA
-    fn compose_directive_definition(&self, alias: &Option<String>) -> DirectiveDefinition {
+    fn compose_directive_definition(&self, alias: &Option<Name>) -> DirectiveDefinition {
         DirectiveDefinition {
             description: None,
-            name: alias.as_deref().unwrap_or(COMPOSE_DIRECTIVE_NAME).into(),
+            name: alias.clone().unwrap_or(COMPOSE_DIRECTIVE_NAME),
             arguments: vec![InputValueDefinition {
                 description: None,
-                name: "name".into(),
-                ty: Type::new_named("String").non_null().into(),
+                name: name!("name"),
+                ty: Type::Named(name!("String")).non_null().into(),
                 default_value: None,
                 directives: Default::default(),
             }
@@ -259,16 +321,19 @@ impl FederationSpecDefinitions {
     }
 
     /// directive @key(fields: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
-    fn key_directive_definition(&self, alias: &Option<String>) -> DirectiveDefinition {
-        DirectiveDefinition {
+    fn key_directive_definition(
+        &self,
+        alias: &Option<Name>,
+    ) -> Result<DirectiveDefinition, FederationSpecError> {
+        Ok(DirectiveDefinition {
             description: None,
-            name: alias.as_deref().unwrap_or(KEY_DIRECTIVE_NAME).into(),
+            name: alias.clone().unwrap_or(KEY_DIRECTIVE_NAME),
             arguments: vec![
-                self.fields_argument_definition().into(),
+                self.fields_argument_definition()?.into(),
                 InputValueDefinition {
                     description: None,
-                    name: "resolvable".into(),
-                    ty: Type::new_named("Boolean").into(),
+                    name: name!("resolvable"),
+                    ty: Type::Named(name!("Boolean")).into(),
                     default_value: Some(true.into()),
                     directives: Default::default(),
                 }
@@ -276,14 +341,14 @@ impl FederationSpecDefinitions {
             ],
             repeatable: true,
             locations: vec![DirectiveLocation::Object, DirectiveLocation::Interface],
-        }
+        })
     }
 
     /// directive @extends on OBJECT | INTERFACE
-    fn extends_directive_definition(&self, alias: &Option<String>) -> DirectiveDefinition {
+    fn extends_directive_definition(&self, alias: &Option<Name>) -> DirectiveDefinition {
         DirectiveDefinition {
             description: None,
-            name: alias.as_deref().unwrap_or(EXTENDS_DIRECTIVE_NAME).into(),
+            name: alias.clone().unwrap_or(EXTENDS_DIRECTIVE_NAME),
             arguments: Vec::new(),
             repeatable: false,
             locations: vec![DirectiveLocation::Object, DirectiveLocation::Interface],
@@ -291,10 +356,10 @@ impl FederationSpecDefinitions {
     }
 
     /// directive @external on OBJECT | FIELD_DEFINITION
-    fn external_directive_definition(&self, alias: &Option<String>) -> DirectiveDefinition {
+    fn external_directive_definition(&self, alias: &Option<Name>) -> DirectiveDefinition {
         DirectiveDefinition {
             description: None,
-            name: alias.as_deref().unwrap_or(EXTERNAL_DIRECTIVE_NAME).into(),
+            name: alias.clone().unwrap_or(EXTERNAL_DIRECTIVE_NAME),
             arguments: Vec::new(),
             repeatable: false,
             locations: vec![
@@ -315,13 +380,10 @@ impl FederationSpecDefinitions {
     ///   | OBJECT
     ///   | SCALAR
     ///   | UNION
-    fn inaccessible_directive_definition(&self, alias: &Option<String>) -> DirectiveDefinition {
+    fn inaccessible_directive_definition(&self, alias: &Option<Name>) -> DirectiveDefinition {
         DirectiveDefinition {
             description: None,
-            name: alias
-                .as_deref()
-                .unwrap_or(INACCESSIBLE_DIRECTIVE_NAME)
-                .into(),
+            name: alias.clone().unwrap_or(INACCESSIBLE_DIRECTIVE_NAME),
             arguments: Vec::new(),
             repeatable: false,
             locations: vec![
@@ -340,13 +402,10 @@ impl FederationSpecDefinitions {
     }
 
     /// directive @interfaceObject on OBJECT
-    fn interface_object_directive_definition(&self, alias: &Option<String>) -> DirectiveDefinition {
+    fn interface_object_directive_definition(&self, alias: &Option<Name>) -> DirectiveDefinition {
         DirectiveDefinition {
             description: None,
-            name: alias
-                .as_deref()
-                .unwrap_or(INTF_OBJECT_DIRECTIVE_NAME)
-                .into(),
+            name: alias.clone().unwrap_or(INTF_OBJECT_DIRECTIVE_NAME),
             arguments: Vec::new(),
             repeatable: false,
             locations: vec![DirectiveLocation::Object],
@@ -354,14 +413,14 @@ impl FederationSpecDefinitions {
     }
 
     /// directive @override(from: String!) on FIELD_DEFINITION
-    fn override_directive_definition(&self, alias: &Option<String>) -> DirectiveDefinition {
+    fn override_directive_definition(&self, alias: &Option<Name>) -> DirectiveDefinition {
         DirectiveDefinition {
             description: None,
-            name: alias.as_deref().unwrap_or(OVERRIDE_DIRECTIVE_NAME).into(),
+            name: alias.clone().unwrap_or(OVERRIDE_DIRECTIVE_NAME),
             arguments: vec![InputValueDefinition {
                 description: None,
-                name: "from".into(),
-                ty: Type::new_named("String").non_null().into(),
+                name: name!("from"),
+                ty: Type::Named(name!("String")).non_null().into(),
                 default_value: None,
                 directives: Default::default(),
             }
@@ -372,32 +431,38 @@ impl FederationSpecDefinitions {
     }
 
     /// directive @provides(fields: FieldSet!) on FIELD_DEFINITION
-    fn provides_directive_definition(&self, alias: &Option<String>) -> DirectiveDefinition {
-        DirectiveDefinition {
+    fn provides_directive_definition(
+        &self,
+        alias: &Option<Name>,
+    ) -> Result<DirectiveDefinition, FederationSpecError> {
+        Ok(DirectiveDefinition {
             description: None,
-            name: alias.as_deref().unwrap_or(PROVIDES_DIRECTIVE_NAME).into(),
-            arguments: vec![self.fields_argument_definition().into()],
+            name: alias.clone().unwrap_or(PROVIDES_DIRECTIVE_NAME),
+            arguments: vec![self.fields_argument_definition()?.into()],
             repeatable: false,
             locations: vec![DirectiveLocation::FieldDefinition],
-        }
+        })
     }
 
     /// directive @requires(fields: FieldSet!) on FIELD_DEFINITION
-    fn requires_directive_definition(&self, alias: &Option<String>) -> DirectiveDefinition {
-        DirectiveDefinition {
+    fn requires_directive_definition(
+        &self,
+        alias: &Option<Name>,
+    ) -> Result<DirectiveDefinition, FederationSpecError> {
+        Ok(DirectiveDefinition {
             description: None,
-            name: alias.as_deref().unwrap_or(REQUIRES_DIRECTIVE_NAME).into(),
-            arguments: vec![self.fields_argument_definition().into()],
+            name: alias.clone().unwrap_or(REQUIRES_DIRECTIVE_NAME),
+            arguments: vec![self.fields_argument_definition()?.into()],
             repeatable: false,
             locations: vec![DirectiveLocation::FieldDefinition],
-        }
+        })
     }
 
     /// directive @shareable repeatable on FIELD_DEFINITION | OBJECT
-    fn shareable_directive_definition(&self, alias: &Option<String>) -> DirectiveDefinition {
+    fn shareable_directive_definition(&self, alias: &Option<Name>) -> DirectiveDefinition {
         DirectiveDefinition {
             description: None,
-            name: alias.as_deref().unwrap_or(SHAREABLE_DIRECTIVE_NAME).into(),
+            name: alias.clone().unwrap_or(SHAREABLE_DIRECTIVE_NAME),
             arguments: Vec::new(),
             repeatable: true,
             locations: vec![
@@ -418,14 +483,14 @@ impl FederationSpecDefinitions {
     ///   | OBJECT
     ///   | SCALAR
     ///   | UNION
-    fn tag_directive_definition(&self, alias: &Option<String>) -> DirectiveDefinition {
+    fn tag_directive_definition(&self, alias: &Option<Name>) -> DirectiveDefinition {
         DirectiveDefinition {
             description: None,
-            name: alias.as_deref().unwrap_or(TAG_DIRECTIVE_NAME).into(),
+            name: alias.clone().unwrap_or(TAG_DIRECTIVE_NAME),
             arguments: vec![InputValueDefinition {
                 description: None,
-                name: "name".into(),
-                ty: Type::new_named("String").non_null().into(),
+                name: name!("name"),
+                ty: Type::Named(name!("String")).non_null().into(),
                 default_value: None,
                 directives: Default::default(),
             }
@@ -449,14 +514,19 @@ impl FederationSpecDefinitions {
     pub(crate) fn any_scalar_definition(&self) -> ExtendedType {
         let any_scalar = ScalarType {
             description: None,
+            name: ANY_SCALAR_NAME,
             directives: Default::default(),
         };
         ExtendedType::Scalar(Node::new(any_scalar))
     }
 
-    pub(crate) fn entity_union_definition(&self, entities: IndexSet<ComponentStr>) -> ExtendedType {
+    pub(crate) fn entity_union_definition(
+        &self,
+        entities: IndexSet<ComponentName>,
+    ) -> ExtendedType {
         let service_type = UnionType {
             description: None,
+            name: ENTITY_UNION_NAME,
             directives: Default::default(),
             members: entities,
         };
@@ -465,18 +535,19 @@ impl FederationSpecDefinitions {
     pub(crate) fn service_object_type_definition(&self) -> ExtendedType {
         let mut service_type = ObjectType {
             description: None,
+            name: SERVICE_TYPE,
             directives: Default::default(),
             fields: IndexMap::new(),
             implements_interfaces: IndexSet::new(),
         };
         service_type.fields.insert(
-            Name::new("_sdl"),
+            name!("_sdl"),
             Component::new(FieldDefinition {
-                name: Name::new("_sdl"),
+                name: name!("_sdl"),
                 description: None,
                 directives: Default::default(),
                 arguments: Vec::new(),
-                ty: Type::Named(NamedType::new("String")),
+                ty: Type::Named(name!("String")),
             }),
         );
         ExtendedType::Object(Node::new(service_type))
@@ -484,37 +555,37 @@ impl FederationSpecDefinitions {
 
     pub(crate) fn entities_query_field(&self) -> Component<FieldDefinition> {
         Component::new(FieldDefinition {
-            name: Name::new(ENTITIES_QUERY),
+            name: ENTITIES_QUERY,
             description: None,
             directives: Default::default(),
             arguments: vec![Node::new(InputValueDefinition {
-                name: Name::new("representations"),
+                name: name!("representations"),
                 description: None,
                 directives: Default::default(),
                 ty: Node::new(Type::NonNullList(Box::new(Type::NonNullNamed(
-                    NamedType::new(ANY_SCALAR_NAME),
+                    ANY_SCALAR_NAME,
                 )))),
                 default_value: None,
             })],
-            ty: Type::NonNullList(Box::new(Type::Named(NamedType::new(ENTITY_UNION_NAME)))),
+            ty: Type::NonNullList(Box::new(Type::Named(ENTITY_UNION_NAME))),
         })
     }
 
     pub(crate) fn service_sdl_query_field(&self) -> Component<FieldDefinition> {
         Component::new(FieldDefinition {
-            name: Name::new(SERVICE_SDL_QUERY),
+            name: SERVICE_SDL_QUERY,
             description: None,
             directives: Default::default(),
             arguments: Vec::new(),
-            ty: Type::NonNullNamed(NamedType::new(SERVICE_TYPE)),
+            ty: Type::NonNullNamed(SERVICE_TYPE),
         })
     }
 }
 
 impl LinkSpecDefinitions {
     pub fn new(link: Link) -> Self {
-        let import_scalar_name = link.type_name_in_schema(DEFAULT_IMPORT_SCALAR_NAME);
-        let purpose_enum_name = link.type_name_in_schema(DEFAULT_PURPOSE_ENUM_NAME);
+        let import_scalar_name = link.type_name_in_schema(&DEFAULT_IMPORT_SCALAR_NAME);
+        let purpose_enum_name = link.type_name_in_schema(&DEFAULT_PURPOSE_ENUM_NAME);
         Self {
             link,
             import_scalar_name,
@@ -540,9 +611,10 @@ impl LinkSpecDefinitions {
     }
 
     ///   scalar Import
-    pub fn import_scalar_definition(&self) -> ScalarType {
+    pub fn import_scalar_definition(&self, name: Name) -> ScalarType {
         ScalarType {
             description: None,
+            name,
             directives: Default::default(),
         }
     }
@@ -551,25 +623,26 @@ impl LinkSpecDefinitions {
     ///     SECURITY
     ///     EXECUTION
     ///   }
-    pub fn link_purpose_enum_definition(&self) -> EnumType {
+    pub fn link_purpose_enum_definition(&self, name: Name) -> EnumType {
         EnumType {
             description: None,
+            name,
             directives: Default::default(),
             values: [
                 (
-                    "SECURITY".into(),
+                    name!("SECURITY"),
                     EnumValueDefinition {
                         description: None,
-                        value: "SECURITY".into(),
+                        value: name!("SECURITY"),
                         directives: Default::default(),
                     }
                     .into(),
                 ),
                 (
-                    "EXECUTION".into(),
+                    name!("EXECUTION"),
                     EnumValueDefinition {
                         description: None,
-                        value: "EXECUTION".into(),
+                        value: name!("EXECUTION"),
                         directives: Default::default(),
                     }
                     .into(),
@@ -580,40 +653,47 @@ impl LinkSpecDefinitions {
     }
 
     ///   directive @link(url: String, as: String, import: [Import], for: link__Purpose) repeatable on SCHEMA
-    pub fn link_directive_definition(&self) -> DirectiveDefinition {
-        DirectiveDefinition {
+    pub fn link_directive_definition(&self) -> Result<DirectiveDefinition, FederationSpecError> {
+        Ok(DirectiveDefinition {
             description: None,
-            name: DEFAULT_LINK_NAME.into(),
+            name: DEFAULT_LINK_NAME,
             arguments: vec![
                 InputValueDefinition {
                     description: None,
-                    name: "url".into(),
+                    name: name!("url"),
                     // TODO: doc-comment disagrees with non-null here
-                    ty: Type::new_named("String").non_null().into(),
+                    ty: Type::Named(name!("String")).non_null().into(),
                     default_value: None,
                     directives: Default::default(),
                 }
                 .into(),
                 InputValueDefinition {
                     description: None,
-                    name: "as".into(),
-                    ty: Type::new_named("String").into(),
+                    name: name!("as"),
+                    ty: Type::Named(name!("String")).into(),
                     default_value: None,
                     directives: Default::default(),
                 }
                 .into(),
                 InputValueDefinition {
                     description: None,
-                    name: "import".into(),
-                    ty: Type::new_named(&self.import_scalar_name).list().into(),
+                    name: name!("import"),
+                    ty: Type::Named(graphql_name_or_federation_spec_error(
+                        &self.import_scalar_name,
+                    )?)
+                    .list()
+                    .into(),
                     default_value: None,
                     directives: Default::default(),
                 }
                 .into(),
                 InputValueDefinition {
                     description: None,
-                    name: "for".into(),
-                    ty: Type::new_named(&self.purpose_enum_name).into(),
+                    name: name!("for"),
+                    ty: Type::Named(graphql_name_or_federation_spec_error(
+                        &self.purpose_enum_name,
+                    )?)
+                    .into(),
                     default_value: None,
                     directives: Default::default(),
                 }
@@ -621,7 +701,7 @@ impl LinkSpecDefinitions {
             ],
             repeatable: true,
             locations: vec![DirectiveLocation::Schema],
-        }
+        })
     }
 }
 


### PR DESCRIPTION
This PR is the second half of #85 , and fully updates `federation-next` to work with `apollo-compiler@1.0.0-beta.6`.

Some notes:
- This is mainly replacing `&str` with `Name`, and converting some functions to use `Result`s.
- The other notable changes are that types (e.g. `ObjectType`) need a `name` field now (making it consistent with the rest of the schema elements in `apollo-rs`), and some minor renames.
- Clippy warns that since `NodeStr` doesn't have `#[derive(PartialEq, Eq)]`, then we can't use `Name` in pattern-matching; I've worked around it with an enum and map for now.
- Consolidated a bit of the logic around converting subgraph names to enum values, with a `TODO` around doing what the JS codebase does.
- Unrelated, but I've been told we had some usages of `.eq()` in the Rust code, so I've converted them to `==`.