### PR TITLE
feat: operation normalization for query planner

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub mod link;
 pub mod merge;
 pub mod query_graph;
+pub mod query_plan;
 pub mod schema;
 pub mod subgraph;
 

--- a/src/query_plan/mod.rs
+++ b/src/query_plan/mod.rs
@@ -1,0 +1,1 @@
+pub mod operation;

--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -50,16 +50,6 @@ impl NormalizedSelectionSet {
     }
 }
 
-// impl From<SelectionSet> for NormalizedSelectionSet {
-//     fn from(value: SelectionSet) -> Self {
-//         let mut normalized = NormalizedSelectionSet {
-//             ty: value.ty.clone(),
-//             selections: IndexMap::new()
-//         };
-//         normalized
-//     }
-// }
-
 impl From<NormalizedSelectionSet> for SelectionSet {
     fn from(val: NormalizedSelectionSet) -> Self {
         SelectionSet {

--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -208,7 +208,7 @@ fn normalize_selections(
                 }
 
                 let mut fragment_key: NormalizedSelectionKey = field.into();
-                // deferred fields should nto be merged
+                // deferred fields should not be merged
                 let is_deferred = is_deferred_selection(&field.directives);
                 if is_deferred {
                     while normalized.contains_key(&fragment_key) {
@@ -389,9 +389,9 @@ fn merge_selections(
                                 // insert new
                                 merged_selections.insert(
                                     fragment_key,
-                                    NormalizedSelection::NormalizedInlineFragment(Node::new(
-                                        fragment_to_merge.deref().clone(),
-                                    )),
+                                    NormalizedSelection::NormalizedInlineFragment(
+                                        fragment_to_merge.clone(),
+                                    ),
                                 );
                             } else {
                                 // can merge

--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -350,7 +350,7 @@ type Foo {
     baz
   }
 }"#;
-            let actual = format!("{}", operation);
+            let actual = operation.to_string();
             assert_eq!(expected, actual);
         }
     }

--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -3,7 +3,9 @@ use apollo_compiler::executable::{
     Field, Fragment, InlineFragment, Operation, Selection, SelectionSet,
 };
 use apollo_compiler::{Node, Schema};
+use indexmap::map::Entry;
 use indexmap::IndexMap;
+use std::ops::Deref;
 
 // copy of apollo compiler types that store selections in a map so we can normalize it efficiently
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -12,26 +14,49 @@ pub struct NormalizedSelectionSet {
     pub selections: NormalizedSelectionMap,
 }
 
+/// Normalized selection map is an optimized representation of a regular SelectionSet which does not
+/// contains any duplicated entries and optimizes fragment usages. By storing selection set as a map,
+/// we can efficiently join multiple selection sets.
 pub type NormalizedSelectionMap = IndexMap<NormalizedSelectionKey, NormalizedSelection>;
 
+/// Unique identifier of a selection that is used to determine whether fields/fragments can be merged.
+///
+/// In order to merge two selections they need to
+/// * reference the same field/inline fragment
+/// * specify the same directives
+/// * directives have to be applied in the same order
+/// * directive arguments order does not matter (they get automatically sorted by their names).
+/// * selection cannot specify @defer directive
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum NormalizedSelectionKey {
     Field {
-        name: Name,
+        // field alias (if specified) or field name in the resulting selection set
+        response_name: Name,
+        // directive applied on the field
         directives: DirectiveList,
+        // unique label/counter used to distinguish fields that cannot be merged
+        label: i32,
     },
     InlineFragment {
+        // optional type condition of a fragment
         type_condition: Option<Name>,
+        // directives applied on a fragment
         directives: DirectiveList,
+        // unique label/counter used to distinguish fragments that cannot be merged
+        label: i32,
     },
 }
 
+// copy of apollo compiler types that store selections in a map so we can normalize it efficiently
+// we no longer have FragmentSpread variant as they get either auto expanded and merged into regular
+// field selection or converted to inline fragments if we cannot merge them
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NormalizedSelection {
     NormalizedField(Node<NormalizedField>),
     NormalizedInlineFragment(Node<NormalizedInlineFragment>),
 }
 
+// copy of apollo compiler types that store selections in a map so we can normalize it efficiently
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NormalizedField {
     pub definition: Node<FieldDefinition>,
@@ -42,6 +67,7 @@ pub struct NormalizedField {
     pub selection_set: NormalizedSelectionSet,
 }
 
+// copy of apollo compiler types that store selections in a map so we can normalize it efficiently
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NormalizedInlineFragment {
     pub type_condition: Option<NamedType>,
@@ -50,13 +76,12 @@ pub struct NormalizedInlineFragment {
 }
 
 impl NormalizedSelectionSet {
-    // cannot use From trait as we need to pass the fragments
-    // otherwise we need two passes - one to change to map and another one to expand fragments
     fn from_selection_set(
         selection_set: &SelectionSet,
         fragments: &IndexMap<Name, Node<Fragment>>,
     ) -> Self {
-        let normalized_selections = normalize_selections(&selection_set.selections, fragments);
+        let normalized_selections =
+            normalize_selections(&selection_set.selections, &selection_set.ty, fragments);
         NormalizedSelectionSet {
             ty: selection_set.ty.clone(),
             selections: normalized_selections,
@@ -73,79 +98,225 @@ impl From<NormalizedSelectionSet> for SelectionSet {
     }
 }
 
-/// Converts vec of Selections to a map of NormalizedSelections
+impl NormalizedSelectionKey {
+    /// Generate new key by incrementing unique label value
+    fn next_key(self) -> Self {
+        match self {
+            Self::Field {
+                response_name,
+                directives,
+                label,
+            } => Self::Field {
+                response_name: response_name.clone(),
+                directives: directives.clone(),
+                label: label + 1,
+            },
+            Self::InlineFragment {
+                type_condition,
+                directives,
+                label,
+            } => Self::InlineFragment {
+                type_condition: type_condition.clone(),
+                directives: directives.clone(),
+                label: label + 1,
+            },
+        }
+    }
+}
+
+impl From<&'_ Node<Field>> for NormalizedSelectionKey {
+    fn from(field: &'_ Node<Field>) -> Self {
+        Self::Field {
+            response_name: field.alias.clone().unwrap_or_else(|| field.name.clone()),
+            directives: directives_with_sorted_arguments(&field.directives),
+            label: 0,
+        }
+    }
+}
+
+impl From<&'_ Node<Fragment>> for NormalizedSelectionKey {
+    fn from(fragment: &'_ Node<Fragment>) -> Self {
+        Self::InlineFragment {
+            type_condition: Some(fragment.type_condition().clone()),
+            directives: directives_with_sorted_arguments(&fragment.directives),
+            label: 0,
+        }
+    }
+}
+
+impl From<&'_ Node<InlineFragment>> for NormalizedSelectionKey {
+    fn from(inline_fragment: &'_ Node<InlineFragment>) -> Self {
+        Self::InlineFragment {
+            type_condition: inline_fragment.type_condition.clone(),
+            directives: directives_with_sorted_arguments(&inline_fragment.directives),
+            label: 0,
+        }
+    }
+}
+
+impl From<&'_ Node<NormalizedField>> for NormalizedSelectionKey {
+    fn from(field: &'_ Node<NormalizedField>) -> Self {
+        Self::Field {
+            response_name: field.alias.clone().unwrap_or_else(|| field.name.clone()),
+            directives: field.directives.clone(),
+            label: 0,
+        }
+    }
+}
+
+impl From<&mut Node<NormalizedInlineFragment>> for NormalizedSelectionKey {
+    fn from(inline_fragment: &mut Node<NormalizedInlineFragment>) -> Self {
+        Self::InlineFragment {
+            type_condition: inline_fragment.type_condition.clone(),
+            directives: inline_fragment.directives.clone(),
+            label: 0,
+        }
+    }
+}
+
+/// Converts vec of Selections to a map of NormalizedSelections.
 ///
-/// Expands all named fragments and merge duplicate selections.
+/// Performs following normalizations
+/// * expands all named fragments
+/// * if possible merge fragments to regular field selections (if not possible to merge named fragment,
+///  it will be converted to inline fragment)
+/// * merge duplicate field selections
+/// * removes all __schema/__type introspection fields selections.
 fn normalize_selections(
     selections: &Vec<Selection>,
+    parent_type: &NamedType,
     fragments: &IndexMap<Name, Node<Fragment>>,
 ) -> NormalizedSelectionMap {
     let mut normalized = NormalizedSelectionMap::new();
     for selection in selections {
         match selection {
             Selection::Field(field) => {
-                let expanded_selection_set =
-                    normalize_selections(&field.selection_set.selections, fragments);
+                // skip __schema/__type introspection fields as they are not used for query planning
+                if field.name == "__schema" || field.name == "__type" {
+                    continue;
+                }
 
-                if let NormalizedSelection::NormalizedField(field_entry) = normalized
-                    .entry(field.into())
-                    .or_insert(NormalizedSelection::NormalizedField(Node::new(
-                        NormalizedField {
-                            definition: field.definition.clone(),
-                            alias: field.alias.clone(),
-                            name: field.name.clone(),
-                            arguments: field.arguments.clone(),
-                            directives: field.directives.clone(),
-                            selection_set: NormalizedSelectionSet {
-                                ty: field.selection_set.ty.clone(),
-                                selections: IndexMap::new(),
-                            },
+                let mut fragment_key: NormalizedSelectionKey = field.into();
+                // deferred fields should nto be merged
+                let is_deferred = field.directives.iter().any(|d| d.name == "defer");
+                if is_deferred {
+                    while normalized.contains_key(&fragment_key) {
+                        fragment_key = fragment_key.next_key();
+                    }
+                }
+
+                let normalized_field = normalized.entry(fragment_key).or_insert_with(|| {
+                    NormalizedSelection::NormalizedField(Node::new(NormalizedField {
+                        definition: field.definition.clone(),
+                        alias: field.alias.clone(),
+                        name: field.name.clone(),
+                        arguments: field.arguments.clone(),
+                        directives: field.directives.clone(),
+                        selection_set: NormalizedSelectionSet {
+                            ty: field.selection_set.ty.clone(),
+                            selections: IndexMap::new(),
                         },
-                    )))
-                {
+                    }))
+                });
+                if let NormalizedSelection::NormalizedField(field_entry) = normalized_field {
+                    let expanded_selection_set = normalize_selections(
+                        &field.selection_set.selections,
+                        field.ty().inner_named_type(),
+                        fragments,
+                    );
                     let merged_selections = merge_selections(
                         &field_entry.selection_set.selections,
                         &expanded_selection_set,
                     );
                     field_entry.make_mut().selection_set.selections = merged_selections;
-                    // field_entry.selection_set.selections = merged_selections;
                 }
             }
             Selection::FragmentSpread(named_fragment) => {
                 if let Some(fragment) = fragments.get(&named_fragment.fragment_name) {
                     let expanded_selection_set = normalize_selections(
                         &fragment.selection_set.selections,
+                        parent_type,
                         fragments,
                     );
-                    normalized = merge_selections(&normalized, &expanded_selection_set);
+
+                    // we can collapse named fragments if condition is on the parent type and we don't have any directives
+                    if parent_type == fragment.type_condition() && fragment.directives.is_empty() {
+                        normalized = merge_selections(&normalized, &expanded_selection_set);
+                    } else {
+                        // otherwise we convert to inline fragment
+                        let mut fragment_key: NormalizedSelectionKey = fragment.into();
+                        // deferred fragments should not be merged
+                        let is_deferred = fragment.directives.iter().any(|d| d.name == "defer");
+                        if is_deferred {
+                            while normalized.contains_key(&fragment_key) {
+                                fragment_key = fragment_key.next_key();
+                            }
+                        }
+                        if let NormalizedSelection::NormalizedInlineFragment(fragment_entry) =
+                            normalized.entry(fragment_key).or_insert_with(|| {
+                                NormalizedSelection::NormalizedInlineFragment(Node::new(
+                                    NormalizedInlineFragment {
+                                        type_condition: Some(fragment.type_condition().clone()),
+                                        directives: fragment.directives.clone(),
+                                        selection_set: NormalizedSelectionSet {
+                                            ty: fragment.selection_set.ty.clone(),
+                                            selections: IndexMap::new(),
+                                        },
+                                    },
+                                ))
+                            })
+                        {
+                            let merged_selections = merge_selections(
+                                &fragment_entry.selection_set.selections,
+                                &expanded_selection_set,
+                            );
+                            fragment_entry.make_mut().selection_set.selections = merged_selections;
+                        }
+                    }
                 } else {
-                    // no fragment found
+                    // no fragment found - should never happen as it would be invalid operation
                 }
             }
             Selection::InlineFragment(inline_fragment) => {
                 let expanded_selection_set = normalize_selections(
                     &inline_fragment.selection_set.selections,
+                    parent_type,
                     fragments,
                 );
-
-                if let NormalizedSelection::NormalizedInlineFragment(fragment_entry) = normalized
-                    .entry(inline_fragment.into())
-                    .or_insert(NormalizedSelection::NormalizedInlineFragment(Node::new(
-                        NormalizedInlineFragment {
-                            type_condition: inline_fragment.type_condition.clone(),
-                            directives: inline_fragment.directives.clone(),
-                            selection_set: NormalizedSelectionSet {
-                                ty: inline_fragment.selection_set.ty.clone(),
-                                selections: IndexMap::new(),
-                            },
-                        },
-                    )))
+                // we can collapse selection set if inline fragment condition is on the parent type and we don't have any directives
+                if Some(parent_type) == inline_fragment.type_condition.as_ref()
+                    && inline_fragment.directives.is_empty()
                 {
-                    let merged_selections = merge_selections(
-                        &fragment_entry.selection_set.selections,
-                        &expanded_selection_set,
-                    );
-                    fragment_entry.make_mut().selection_set.selections = merged_selections;
+                    normalized = merge_selections(&normalized, &expanded_selection_set);
+                } else {
+                    let mut fragment_key: NormalizedSelectionKey = inline_fragment.into();
+                    // deferred fragments should not be merged
+                    let is_deferred = inline_fragment.directives.iter().any(|d| d.name == "defer");
+                    if is_deferred {
+                        while normalized.contains_key(&fragment_key) {
+                            fragment_key = fragment_key.next_key();
+                        }
+                    }
+                    if let NormalizedSelection::NormalizedInlineFragment(fragment_entry) =
+                        normalized.entry(fragment_key).or_insert_with(|| {
+                            NormalizedSelection::NormalizedInlineFragment(Node::new(
+                                NormalizedInlineFragment {
+                                    type_condition: inline_fragment.type_condition.clone(),
+                                    directives: inline_fragment.directives.clone(),
+                                    selection_set: NormalizedSelectionSet {
+                                        ty: inline_fragment.selection_set.ty.clone(),
+                                        selections: IndexMap::new(),
+                                    },
+                                },
+                            ))
+                        })
+                    {
+                        let merged_selections = merge_selections(
+                            &fragment_entry.selection_set.selections,
+                            &expanded_selection_set,
+                        );
+                        fragment_entry.make_mut().selection_set.selections = merged_selections;
+                    }
                 }
             }
         }
@@ -159,70 +330,86 @@ fn merge_selections(
 ) -> NormalizedSelectionMap {
     let mut merged_selections = source.clone();
     for (key, selection) in to_merge {
-        if source.contains_key(key) {
-            match selection {
-                NormalizedSelection::NormalizedField(field_to_merge) => {
-                    if let Some(NormalizedSelection::NormalizedField(source_field)) =
-                        merged_selections.get_mut(key)
-                    {
-                        // todo skip deferred
-                        // check if the same
-                        let merged_field_selections = merge_selections(
-                            &source_field.selection_set.selections,
-                            &field_to_merge.selection_set.selections,
-                        );
-                        let merged_selection_set = NormalizedSelectionSet {
-                            ty: source_field.selection_set.ty.clone(),
-                            selections: merged_field_selections,
-                        };
-                        source_field.make_mut().selection_set = merged_selection_set;
-                    } else {
-                        // should never happen, mismatch on keys
+        match merged_selections.entry(key.clone()) {
+            Entry::Occupied(mut entry) => {
+                match entry.get_mut() {
+                    NormalizedSelection::NormalizedField(ref mut source_field) => {
+                        if let NormalizedSelection::NormalizedField(field_to_merge) = selection {
+                            let mut field_key: NormalizedSelectionKey = field_to_merge.into();
+                            let is_deferred =
+                                field_to_merge.directives.iter().any(|d| d.name == "defer");
+                            if field_to_merge.name != source_field.name
+                                || field_to_merge.definition.ty != source_field.definition.ty
+                            {
+                                panic!("TODO invalid operation");
+                            }
+                            if is_deferred {
+                                while merged_selections.contains_key(&field_key) {
+                                    field_key = field_key.next_key();
+                                }
+                                // insert new
+                                merged_selections.insert(
+                                    field_key,
+                                    NormalizedSelection::NormalizedField(Node::new(
+                                        field_to_merge.deref().clone(),
+                                    )),
+                                );
+                            } else {
+                                let merged_field_selections = merge_selections(
+                                    &source_field.selection_set.selections,
+                                    &field_to_merge.selection_set.selections,
+                                );
+                                let merged_selection_set = NormalizedSelectionSet {
+                                    ty: source_field.selection_set.ty.clone(),
+                                    selections: merged_field_selections,
+                                };
+                                source_field.make_mut().selection_set = merged_selection_set;
+                            }
+                        }
                     }
-                }
-                NormalizedSelection::NormalizedInlineFragment(fragment_to_merge) => {
-                    if let Some(NormalizedSelection::NormalizedInlineFragment(source_fragment)) =
-                        merged_selections.get_mut(key)
-                    {
-                        // todo skip deferred
-                        // check if the same
-                        let merged_fragment_selections = merge_selections(
-                            &source_fragment.selection_set.selections,
-                            &fragment_to_merge.selection_set.selections,
-                        );
-                        let merged_selection_set = NormalizedSelectionSet {
-                            ty: source_fragment.selection_set.ty.clone(),
-                            selections: merged_fragment_selections,
-                        };
-                        source_fragment.make_mut().selection_set = merged_selection_set;
-                    } else {
-                        // should never happen, mismatch on keys
+                    NormalizedSelection::NormalizedInlineFragment(ref mut source_fragment) => {
+                        if let NormalizedSelection::NormalizedInlineFragment(fragment_to_merge) =
+                            selection
+                        {
+                            let mut fragment_key: NormalizedSelectionKey = source_fragment.into();
+                            // deferred fragments should not be merged
+                            let is_deferred = fragment_to_merge
+                                .directives
+                                .iter()
+                                .any(|d| d.name == "defer");
+                            if is_deferred {
+                                while merged_selections.contains_key(&fragment_key) {
+                                    fragment_key = fragment_key.next_key();
+                                }
+                                // insert new
+                                merged_selections.insert(
+                                    fragment_key,
+                                    NormalizedSelection::NormalizedInlineFragment(Node::new(
+                                        fragment_to_merge.deref().clone(),
+                                    )),
+                                );
+                            } else {
+                                // can merge
+                                let merged_fragment_selections = merge_selections(
+                                    &source_fragment.selection_set.selections,
+                                    &fragment_to_merge.selection_set.selections,
+                                );
+                                let merged_selection_set = NormalizedSelectionSet {
+                                    ty: source_fragment.selection_set.ty.clone(),
+                                    selections: merged_fragment_selections,
+                                };
+                                source_fragment.make_mut().selection_set = merged_selection_set;
+                            }
+                        }
                     }
                 }
             }
-        } else {
-            merged_selections.insert(key.to_owned(), selection.clone());
+            Entry::Vacant(entry) => {
+                entry.insert(selection.clone());
+            }
         }
     }
     merged_selections
-}
-
-impl From<&'_ Node<Field>> for NormalizedSelectionKey {
-    fn from(field: &'_ Node<Field>) -> Self {
-        Self::Field {
-            name: field.alias.clone().unwrap_or_else(|| { field.name.clone() }),
-            directives: directives_with_sorted_arguments(&field.directives),
-        }
-    }
-}
-
-impl From<&'_ Node<InlineFragment>> for NormalizedSelectionKey {
-    fn from(inline_fragment: &'_ Node<InlineFragment>) -> Self {
-        Self::InlineFragment {
-            type_condition: inline_fragment.type_condition.clone(),
-            directives: directives_with_sorted_arguments(&inline_fragment.directives),
-        }
-    }
 }
 
 fn directives_with_sorted_arguments(directives: &DirectiveList) -> DirectiveList {
@@ -236,6 +423,7 @@ fn directives_with_sorted_arguments(directives: &DirectiveList) -> DirectiveList
     directives
 }
 
+/// Converts NormalizedSelectionMap back to Vec of Selections.
 fn flatten_selections(selections: &NormalizedSelectionMap) -> Vec<Selection> {
     let mut flattened = vec![];
     for selection in selections.values() {
@@ -284,15 +472,8 @@ pub fn normalize_operation(
     _schema: &Schema,
     fragments: &IndexMap<Name, Node<Fragment>>,
 ) {
-    let mut normalized_selection_set =
+    let normalized_selection_set =
         NormalizedSelectionSet::from_selection_set(&operation.selection_set, fragments);
-    // removes top level introspection
-    normalized_selection_set
-        .selections
-        .retain(|key, _| match key {
-            NormalizedSelectionKey::Field { name, .. } => !name.starts_with("__"),
-            NormalizedSelectionKey::InlineFragment { .. } => true,
-        });
 
     // flatten back to vec
     operation.selection_set = SelectionSet::from(normalized_selection_set);
@@ -301,8 +482,6 @@ pub fn normalize_operation(
 #[cfg(test)]
 mod tests {
     use crate::query_plan::operation::normalize_operation;
-    use apollo_compiler::executable::Name;
-    use apollo_compiler::NodeStr;
 
     #[test]
     fn expands_named_fragments() {

--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -338,7 +338,7 @@ type Foo {
 
         if let Some(operation) = executable_document
             .named_operations
-            .get_mut(&Name::new_unchecked(NodeStr::new("NamedFragmentQuery")))
+            .get_mut("NamedFragmentQuery")
         {
             let operation = operation.make_mut();
             normalize_operation(operation, &schema, &executable_document.fragments);

--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -1,5 +1,7 @@
 use apollo_compiler::ast::{Argument, DirectiveList, FieldDefinition, Name, NamedType};
-use apollo_compiler::executable::{Field, Fragment, InlineFragment, Operation, Selection, SelectionSet};
+use apollo_compiler::executable::{
+    Field, Fragment, InlineFragment, Operation, Selection, SelectionSet,
+};
 use apollo_compiler::{Node, Schema};
 use indexmap::IndexMap;
 
@@ -229,11 +231,17 @@ fn selection_inline_fragment_key(fragment: &InlineFragment) -> String {
 }
 
 fn selection_directive_key(directives: &DirectiveList) -> String {
-    directives.iter().map(|d| {
-        let mut d = d.clone();
-        d.make_mut().arguments.sort_by(|a1, a2| a1.name.cmp(&a2.name));
-        format!("{}", d)
-    }).collect::<Vec<String>>().join(", ")
+    directives
+        .iter()
+        .map(|d| {
+            let mut d = d.clone();
+            d.make_mut()
+                .arguments
+                .sort_by(|a1, a2| a1.name.cmp(&a2.name));
+            format!("{}", d)
+        })
+        .collect::<Vec<String>>()
+        .join(", ")
 }
 
 fn flatten_selections(selections: &IndexMap<String, NormalizedSelection>) -> Vec<Selection> {

--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -1,0 +1,422 @@
+use apollo_compiler::ast::{Argument, DirectiveList, FieldDefinition, Name, NamedType};
+use apollo_compiler::executable::{
+    Field, Fragment, InlineFragment, Operation, Selection, SelectionSet,
+};
+use apollo_compiler::{Node, Schema};
+use indexmap::IndexMap;
+
+// copy of apollo compiler types that store selections in a map so we can normalize it efficiently
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NormalizedSelectionSet {
+    pub ty: NamedType,
+    pub selections: IndexMap<String, NormalizedSelection>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NormalizedSelection {
+    NormalizedField(Node<NormalizedField>),
+    NormalizedInlineFragment(Node<NormalizedInlineFragment>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NormalizedField {
+    pub definition: Node<FieldDefinition>,
+    pub alias: Option<Name>,
+    pub name: Name,
+    pub arguments: Vec<Node<Argument>>,
+    pub directives: DirectiveList,
+    pub selection_set: NormalizedSelectionSet,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NormalizedInlineFragment {
+    pub type_condition: Option<NamedType>,
+    pub directives: DirectiveList,
+    pub selection_set: NormalizedSelectionSet,
+}
+
+impl NormalizedSelectionSet {
+    // cannot use From trait as we need to pass the fragments
+    // otherwise we need two passes - one to change to map and another one to expand fragments
+    fn from_selection_set(
+        selection_set: &SelectionSet,
+        fragments: &IndexMap<Name, Node<Fragment>>,
+    ) -> Self {
+        let normalized_selections = normalize_selections(&selection_set.selections, fragments);
+        NormalizedSelectionSet {
+            ty: selection_set.ty.clone(),
+            selections: normalized_selections,
+        }
+    }
+}
+
+// impl From<SelectionSet> for NormalizedSelectionSet {
+//     fn from(value: SelectionSet) -> Self {
+//         let mut normalized = NormalizedSelectionSet {
+//             ty: value.ty.clone(),
+//             selections: IndexMap::new()
+//         };
+//         normalized
+//     }
+// }
+
+impl From<NormalizedSelectionSet> for SelectionSet {
+    fn from(val: NormalizedSelectionSet) -> Self {
+        SelectionSet {
+            ty: val.ty.clone(),
+            selections: flatten_selections(&val.selections),
+        }
+    }
+}
+
+/// Converts vec of Selections to a map of NormalizedSelections
+///
+/// Expands all named fragments and merge duplicate selections.
+fn normalize_selections(
+    selections: &Vec<Selection>,
+    fragments: &IndexMap<Name, Node<Fragment>>,
+) -> IndexMap<String, NormalizedSelection> {
+    let mut normalized: IndexMap<String, NormalizedSelection> = IndexMap::new();
+    for selection in selections {
+        match selection {
+            Selection::Field(field) => {
+                let expanded_selection_set =
+                    normalize_selections(&field.selection_set.selections.to_owned(), fragments);
+                let key = selection_field_key(field);
+
+                if let NormalizedSelection::NormalizedField(field_entry) =
+                    normalized.entry(key.to_owned()).or_insert(
+                        NormalizedSelection::NormalizedField(Node::new(NormalizedField {
+                            definition: field.definition.clone(),
+                            alias: field.alias.clone(),
+                            name: field.name.clone(),
+                            arguments: field.arguments.clone(),
+                            directives: field.directives.clone(),
+                            selection_set: NormalizedSelectionSet {
+                                ty: field.selection_set.ty.clone(),
+                                selections: IndexMap::new(),
+                            },
+                        })),
+                    )
+                {
+                    let merged_selections = merge_selections(
+                        &field_entry.selection_set.selections,
+                        &expanded_selection_set,
+                    );
+                    let mut selection_set = field_entry.selection_set.clone();
+                    selection_set.selections = merged_selections;
+                    field_entry.make_mut().selection_set = selection_set;
+                    // field_entry.selection_set.selections = merged_selections;
+                }
+            }
+            Selection::FragmentSpread(named_fragment) => {
+                if let Some(fragment) = fragments.get(&named_fragment.fragment_name) {
+                    let expanded_selection_set = normalize_selections(
+                        &fragment.selection_set.selections.to_owned(),
+                        fragments,
+                    );
+                    normalized = merge_selections(&normalized, &expanded_selection_set);
+                } else {
+                    // no fragment found
+                }
+            }
+            Selection::InlineFragment(inline_fragment) => {
+                let expanded_selection_set = normalize_selections(
+                    &inline_fragment.selection_set.selections.to_owned(),
+                    fragments,
+                );
+                let key = selection_inline_fragment_key(inline_fragment);
+
+                if let NormalizedSelection::NormalizedInlineFragment(fragment_entry) = normalized
+                    .entry(key.to_owned())
+                    .or_insert(NormalizedSelection::NormalizedInlineFragment(Node::new(
+                        NormalizedInlineFragment {
+                            type_condition: inline_fragment.type_condition.clone(),
+                            directives: inline_fragment.directives.clone(),
+                            selection_set: NormalizedSelectionSet {
+                                ty: inline_fragment.selection_set.ty.clone(),
+                                selections: IndexMap::new(),
+                            },
+                        },
+                    )))
+                {
+                    let merged_selections = merge_selections(
+                        &fragment_entry.selection_set.selections,
+                        &expanded_selection_set,
+                    );
+                    let mut selection_set = fragment_entry.selection_set.clone();
+                    selection_set.selections = merged_selections;
+                    fragment_entry.make_mut().selection_set = selection_set;
+                }
+            }
+        }
+    }
+    normalized
+}
+
+fn merge_selections(
+    source: &IndexMap<String, NormalizedSelection>,
+    to_merge: &IndexMap<String, NormalizedSelection>,
+) -> IndexMap<String, NormalizedSelection> {
+    let mut merged_selections = source.clone();
+    for (key, selection) in to_merge {
+        if source.contains_key(key) {
+            match selection {
+                NormalizedSelection::NormalizedField(field_to_merge) => {
+                    if let Some(NormalizedSelection::NormalizedField(source_field)) =
+                        merged_selections.get_mut(key)
+                    {
+                        // todo skip deferred
+                        // check if the same
+                        let merged_field_selections = merge_selections(
+                            &source_field.selection_set.selections,
+                            &field_to_merge.selection_set.selections,
+                        );
+                        let merged_selection_set = NormalizedSelectionSet {
+                            ty: source_field.selection_set.ty.clone(),
+                            selections: merged_field_selections,
+                        };
+                        source_field.make_mut().selection_set = merged_selection_set;
+                    } else {
+                        // should never happen, mismatch on keys
+                    }
+                }
+                NormalizedSelection::NormalizedInlineFragment(fragment_to_merge) => {
+                    if let Some(NormalizedSelection::NormalizedInlineFragment(source_fragment)) =
+                        merged_selections.get_mut(key)
+                    {
+                        // todo skip deferred
+                        // check if the same
+                        let merged_fragment_selections = merge_selections(
+                            &source_fragment.selection_set.selections,
+                            &fragment_to_merge.selection_set.selections,
+                        );
+                        let merged_selection_set = NormalizedSelectionSet {
+                            ty: source_fragment.selection_set.ty.clone(),
+                            selections: merged_fragment_selections,
+                        };
+                        source_fragment.make_mut().selection_set = merged_selection_set;
+                    } else {
+                        // should never happen, mismatch on keys
+                    }
+                }
+            }
+        } else {
+            merged_selections.insert(key.to_owned(), selection.clone());
+        }
+    }
+    merged_selections
+}
+fn selection_field_key(field: &Field) -> String {
+    // TODO args
+    let mut result = format!("{}", field.name);
+    if !field.directives.is_empty() {
+        result.push_str(format!(" {}", field.directives).as_str())
+    }
+    result
+}
+
+fn selection_inline_fragment_key(fragment: &InlineFragment) -> String {
+    let mut result = format!(
+        "...{}",
+        fragment
+            .type_condition
+            .clone()
+            .map_or("".to_owned(), |t| format!(" on {}", t))
+    );
+    if !fragment.directives.is_empty() {
+        result.push_str(format!(" {}", fragment.directives).as_str())
+    }
+    result
+}
+
+fn flatten_selections(selections: &IndexMap<String, NormalizedSelection>) -> Vec<Selection> {
+    let mut flattened = vec![];
+    for selection in selections.values() {
+        match selection {
+            NormalizedSelection::NormalizedField(normalized_field) => {
+                let selections = flatten_selections(&normalized_field.selection_set.selections);
+                let field = Field {
+                    definition: normalized_field.definition.to_owned(),
+                    alias: normalized_field.alias.to_owned(),
+                    name: normalized_field.name.to_owned(),
+                    arguments: normalized_field.arguments.to_owned(),
+                    directives: normalized_field.directives.to_owned(),
+                    selection_set: SelectionSet {
+                        ty: normalized_field.selection_set.ty.clone(),
+                        selections,
+                    },
+                };
+                flattened.push(Selection::Field(Node::new(field)));
+            }
+            NormalizedSelection::NormalizedInlineFragment(normalized_fragment) => {
+                let selections = flatten_selections(&normalized_fragment.selection_set.selections);
+                let fragment = InlineFragment {
+                    type_condition: normalized_fragment.type_condition.to_owned(),
+                    directives: normalized_fragment.directives.to_owned(),
+                    selection_set: SelectionSet {
+                        ty: normalized_fragment.selection_set.ty.clone(),
+                        selections,
+                    },
+                };
+                flattened.push(Selection::InlineFragment(Node::new(fragment)));
+            }
+        }
+    }
+    flattened
+}
+
+/// Normalizes selection set within specified operation.
+///
+/// This method applies following normalizations
+/// - expands all fragments within an operation
+/// - merge same selections
+/// - removes all introspection fields from top-level selection
+/// - attempts to remove all unnecessary/redundant inline fragments
+pub fn normalize_operation(
+    operation: &mut Operation,
+    _schema: &Schema,
+    fragments: &IndexMap<Name, Node<Fragment>>,
+) {
+    let mut normalized_selection_set =
+        NormalizedSelectionSet::from_selection_set(&operation.selection_set, fragments);
+    // removes top level introspection
+    normalized_selection_set
+        .selections
+        .retain(|key, _| !key.starts_with("__"));
+
+    // flatten back to vec
+    operation.selection_set = SelectionSet::from(normalized_selection_set);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::query_plan::operation::normalize_operation;
+    use apollo_compiler::executable::Name;
+    use apollo_compiler::NodeStr;
+
+    #[test]
+    fn expands_named_fragments() {
+        let operation_with_named_fragment = r#"
+query NamedFragmentQuery {
+  foo {
+    id
+    ...Bar
+  }
+}
+
+fragment Bar on Foo {
+  bar
+  baz
+}
+
+type Query {
+  foo: Foo
+}
+
+type Foo {
+  id: ID!
+  bar: String!
+  baz: Int
+}
+"#;
+        let (schema, mut executable_document) =
+            apollo_compiler::parse_mixed(operation_with_named_fragment, "document.graphql");
+
+        if let Some(operation) = executable_document
+            .named_operations
+            .get_mut(&Name::new_unchecked(NodeStr::new("NamedFragmentQuery")))
+        {
+            let operation = operation.make_mut();
+            normalize_operation(operation, &schema, &executable_document.fragments);
+
+            let expected = r#"query NamedFragmentQuery {
+  foo {
+    id
+    bar
+    baz
+  }
+}"#;
+            let actual = format!("{}", operation);
+            assert_eq!(expected, actual);
+        }
+    }
+
+    #[test]
+    fn expands_and_deduplicates_fragments() {
+        let operation_with_named_fragment = r#"
+query NestedFragmentQuery {
+  foo {
+    ...FirstFragment
+    ...SecondFragment
+  }
+}
+
+fragment FirstFragment on Foo {
+  id
+  bar
+  baz
+}
+
+fragment SecondFragment on Foo {
+  id
+  bar
+}
+
+type Query {
+  foo: Foo
+}
+
+type Foo {
+  id: ID!
+  bar: String!
+  baz: String
+}
+"#;
+        let (schema, mut executable_document) =
+            apollo_compiler::parse_mixed(operation_with_named_fragment, "document.graphql");
+
+        if let Some((_, operation)) = executable_document.named_operations.first_mut() {
+            let operation = operation.make_mut();
+            normalize_operation(operation, &schema, &executable_document.fragments);
+
+            let expected = r#"query NestedFragmentQuery {
+  foo {
+    id
+    bar
+    baz
+  }
+}"#;
+            let actual = format!("{}", operation);
+            assert_eq!(expected, actual);
+        }
+    }
+
+    #[test]
+    fn can_remove_introspection_selections() {
+        let operation_with_introspection = r#"
+query TestIntrospectionQuery {
+  __schema {
+    types {
+      name
+    }
+  }
+}
+
+type Query {
+  foo: String
+}
+"#;
+        let (schema, mut executable_document) =
+            apollo_compiler::parse_mixed(operation_with_introspection, "document.graphql");
+        if let Some(operation) = executable_document
+            .named_operations
+            .get_mut(&Name::new_unchecked(NodeStr::new("TestIntrospectionQuery")))
+        {
+            let operation = operation.make_mut();
+            normalize_operation(operation, &schema, &executable_document.fragments);
+
+            assert!(operation.selection_set.selections.is_empty());
+        }
+    }
+}

--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -5,7 +5,6 @@ use apollo_compiler::executable::{
 use apollo_compiler::{Node, Schema};
 use indexmap::map::Entry;
 use indexmap::IndexMap;
-use std::ops::Deref;
 
 // copy of apollo compiler types that store selections in a map so we can normalize it efficiently
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -506,9 +505,12 @@ type Foo {
   baz: Int
 }
 "#;
-        let (schema, mut executable_document) =
-            apollo_compiler::parse_mixed(operation_with_named_fragment, "document.graphql");
-
+        let (schema, executable_document) = apollo_compiler::parse_mixed_validate(
+            operation_with_named_fragment,
+            "document.graphql",
+        )
+        .unwrap();
+        let mut executable_document = executable_document.into_inner();
         if let Some(operation) = executable_document
             .named_operations
             .get_mut("NamedFragmentQuery")
@@ -559,9 +561,12 @@ type Foo {
   baz: String
 }
 "#;
-        let (schema, mut executable_document) =
-            apollo_compiler::parse_mixed(operation_with_named_fragment, "document.graphql");
-
+        let (schema, executable_document) = apollo_compiler::parse_mixed_validate(
+            operation_with_named_fragment,
+            "document.graphql",
+        )
+        .unwrap();
+        let mut executable_document = executable_document.into_inner();
         if let Some((_, operation)) = executable_document.named_operations.first_mut() {
             let operation = operation.make_mut();
             normalize_operation(operation, &schema, &executable_document.fragments);
@@ -593,8 +598,10 @@ type Query {
   foo: String
 }
 "#;
-        let (schema, mut executable_document) =
-            apollo_compiler::parse_mixed(operation_with_introspection, "document.graphql");
+        let (schema, executable_document) =
+            apollo_compiler::parse_mixed_validate(operation_with_introspection, "document.graphql")
+                .unwrap();
+        let mut executable_document = executable_document.into_inner();
         if let Some(operation) = executable_document
             .named_operations
             .get_mut("TestIntrospectionQuery")

--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -424,7 +424,7 @@ type Query {
             apollo_compiler::parse_mixed(operation_with_introspection, "document.graphql");
         if let Some(operation) = executable_document
             .named_operations
-            .get_mut(&Name::new_unchecked(NodeStr::new("TestIntrospectionQuery")))
+            .get_mut("TestIntrospectionQuery")
         {
             let operation = operation.make_mut();
             normalize_operation(operation, &schema, &executable_document.fragments);

--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -1,7 +1,5 @@
 use apollo_compiler::ast::{Argument, DirectiveList, FieldDefinition, Name, NamedType};
-use apollo_compiler::executable::{
-    Field, Fragment, InlineFragment, Operation, Selection, SelectionSet,
-};
+use apollo_compiler::executable::{Field, Fragment, InlineFragment, Operation, Selection, SelectionSet};
 use apollo_compiler::{Node, Schema};
 use indexmap::IndexMap;
 
@@ -211,7 +209,7 @@ fn selection_field_key(field: &Field) -> String {
     // TODO args
     let mut result = format!("{}", field.name);
     if !field.directives.is_empty() {
-        result.push_str(format!(" {}", field.directives).as_str())
+        result.push_str(selection_directive_key(&field.directives).as_str());
     }
     result
 }
@@ -225,9 +223,17 @@ fn selection_inline_fragment_key(fragment: &InlineFragment) -> String {
             .map_or("".to_owned(), |t| format!(" on {}", t))
     );
     if !fragment.directives.is_empty() {
-        result.push_str(format!(" {}", fragment.directives).as_str())
+        result.push_str(selection_directive_key(&fragment.directives).as_str());
     }
     result
+}
+
+fn selection_directive_key(directives: &DirectiveList) -> String {
+    directives.iter().map(|d| {
+        let mut d = d.clone();
+        d.make_mut().arguments.sort_by(|a1, a2| a1.name.cmp(&a2.name));
+        format!("{}", d)
+    }).collect::<Vec<String>>().join(", ")
 }
 
 fn flatten_selections(selections: &IndexMap<String, NormalizedSelection>) -> Vec<Selection> {

--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -85,7 +85,7 @@ fn normalize_selections(
         match selection {
             Selection::Field(field) => {
                 let expanded_selection_set =
-                    normalize_selections(&field.selection_set.selections.to_owned(), fragments);
+                    normalize_selections(&field.selection_set.selections, fragments);
 
                 if let NormalizedSelection::NormalizedField(field_entry) = normalized
                     .entry(field.into())
@@ -107,16 +107,14 @@ fn normalize_selections(
                         &field_entry.selection_set.selections,
                         &expanded_selection_set,
                     );
-                    let mut selection_set = field_entry.selection_set.clone();
-                    selection_set.selections = merged_selections;
-                    field_entry.make_mut().selection_set = selection_set;
+                    field_entry.make_mut().selection_set.selections = merged_selections;
                     // field_entry.selection_set.selections = merged_selections;
                 }
             }
             Selection::FragmentSpread(named_fragment) => {
                 if let Some(fragment) = fragments.get(&named_fragment.fragment_name) {
                     let expanded_selection_set = normalize_selections(
-                        &fragment.selection_set.selections.to_owned(),
+                        &fragment.selection_set.selections,
                         fragments,
                     );
                     normalized = merge_selections(&normalized, &expanded_selection_set);
@@ -126,7 +124,7 @@ fn normalize_selections(
             }
             Selection::InlineFragment(inline_fragment) => {
                 let expanded_selection_set = normalize_selections(
-                    &inline_fragment.selection_set.selections.to_owned(),
+                    &inline_fragment.selection_set.selections,
                     fragments,
                 );
 
@@ -147,9 +145,7 @@ fn normalize_selections(
                         &fragment_entry.selection_set.selections,
                         &expanded_selection_set,
                     );
-                    let mut selection_set = fragment_entry.selection_set.clone();
-                    selection_set.selections = merged_selections;
-                    fragment_entry.make_mut().selection_set = selection_set;
+                    fragment_entry.make_mut().selection_set.selections = merged_selections;
                 }
             }
         }
@@ -214,7 +210,7 @@ fn merge_selections(
 impl From<&'_ Node<Field>> for NormalizedSelectionKey {
     fn from(field: &'_ Node<Field>) -> Self {
         Self::Field {
-            name: field.name.clone(),
+            name: field.alias.clone().unwrap_or_else(|| { field.name.clone() }),
             directives: directives_with_sorted_arguments(&field.directives),
         }
     }

--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -360,9 +360,7 @@ fn merge_selections(
                                 // insert new
                                 merged_selections.insert(
                                     field_key,
-                                    NormalizedSelection::NormalizedField(Node::new(
-                                        field_to_merge.deref().clone(),
-                                    )),
+                                    NormalizedSelection::NormalizedField(field_to_merge.clone()),
                                 );
                             } else {
                                 let merged_field_selections = merge_selections(

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,2 +1,3 @@
 mod composition_tests;
+mod query_plan;
 mod subgraph;

--- a/tests/query_plan/mod.rs
+++ b/tests/query_plan/mod.rs
@@ -1,0 +1,3 @@
+mod operation_optimization_tests;
+mod operation_tests;
+mod operation_validations_tests;

--- a/tests/query_plan/operation_optimization_tests.rs
+++ b/tests/query_plan/operation_optimization_tests.rs
@@ -1,0 +1,1561 @@
+#[test]
+fn optimize_fragments_using_other_fragments_when_possible() {
+    // test('optimize fragments using other fragments when possible', () => {
+    //     const schema = parseSchema(`
+    //       type Query {
+    //         t: I
+    //       }
+    //
+    //       interface I {
+    //         b: Int
+    //         u: U
+    //       }
+    //
+    //       type T1 implements I {
+    //         a: Int
+    //         b: Int
+    //         u: U
+    //       }
+    //
+    //       type T2 implements I {
+    //         x: String
+    //         y: String
+    //         b: Int
+    //         u: U
+    //       }
+    //
+    //       union U = T1 | T2
+    //     `);
+    //
+    //     const operation = parseOperation(schema, `
+    //       fragment OnT1 on T1 {
+    //         a
+    //         b
+    //       }
+    //
+    //       fragment OnT2 on T2 {
+    //         x
+    //         y
+    //       }
+    //
+    //       fragment OnI on I {
+    //         b
+    //       }
+    //
+    //       fragment OnU on U {
+    //         ...OnI
+    //         ...OnT1
+    //         ...OnT2
+    //       }
+    //
+    //       query {
+    //         t {
+    //           ...OnT1
+    //           ...OnT2
+    //           ...OnI
+    //           u {
+    //             ...OnU
+    //           }
+    //         }
+    //       }
+    //     `);
+    //
+    //     const withoutFragments = operation.expandAllFragments();
+    //     expect(withoutFragments.toString()).toMatchString(`
+    //       {
+    //         t {
+    //           ... on T1 {
+    //             a
+    //             b
+    //           }
+    //           ... on T2 {
+    //             x
+    //             y
+    //           }
+    //           b
+    //           u {
+    //             ... on I {
+    //               b
+    //             }
+    //             ... on T1 {
+    //               a
+    //               b
+    //             }
+    //             ... on T2 {
+    //               x
+    //               y
+    //             }
+    //           }
+    //         }
+    //       }
+    //     `);
+    //
+    //     const optimized = withoutFragments.optimize(operation.fragments!);
+    //     expect(optimized.toString()).toMatchString(`
+    //       fragment OnU on U {
+    //         ... on I {
+    //           b
+    //         }
+    //         ... on T1 {
+    //           a
+    //           b
+    //         }
+    //         ... on T2 {
+    //           x
+    //           y
+    //         }
+    //       }
+    //
+    //       {
+    //         t {
+    //           ...OnU
+    //           u {
+    //             ...OnU
+    //           }
+    //         }
+    //       }
+    //     `);
+    //   });
+}
+
+#[test]
+fn handles_fragments_using_other_fragments() {
+    //test('handles fragments using other fragments', () => {
+    //     const schema = parseSchema(`
+    //       type Query {
+    //         t: I
+    //       }
+    //
+    //       interface I {
+    //         b: Int
+    //         c: Int
+    //         u1: U
+    //         u2: U
+    //       }
+    //
+    //       type T1 implements I {
+    //         a: Int
+    //         b: Int
+    //         c: Int
+    //         me: T1
+    //         u1: U
+    //         u2: U
+    //       }
+    //
+    //       type T2 implements I {
+    //         x: String
+    //         y: String
+    //         b: Int
+    //         c: Int
+    //         u1: U
+    //         u2: U
+    //       }
+    //
+    //       union U = T1 | T2
+    //     `);
+    //
+    //     const operation = parseOperation(schema, `
+    //       fragment OnT1 on T1 {
+    //         a
+    //         b
+    //       }
+    //
+    //       fragment OnT2 on T2 {
+    //         x
+    //         y
+    //       }
+    //
+    //       fragment OnI on I {
+    //         b
+    //         c
+    //       }
+    //
+    //       fragment OnU on U {
+    //         ...OnI
+    //         ...OnT1
+    //         ...OnT2
+    //       }
+    //
+    //       query {
+    //         t {
+    //           ...OnT1
+    //           ...OnT2
+    //           u1 {
+    //             ...OnU
+    //           }
+    //           u2 {
+    //             ...OnU
+    //           }
+    //           ... on T1 {
+    //             me {
+    //               ...OnI
+    //             }
+    //           }
+    //         }
+    //       }
+    //     `);
+    //
+    //     const withoutFragments = operation.expandAllFragments();
+    //     expect(withoutFragments.toString()).toMatchString(`
+    //       {
+    //         t {
+    //           ... on T1 {
+    //             a
+    //             b
+    //             me {
+    //               b
+    //               c
+    //             }
+    //           }
+    //           ... on T2 {
+    //             x
+    //             y
+    //           }
+    //           u1 {
+    //             ... on I {
+    //               b
+    //               c
+    //             }
+    //             ... on T1 {
+    //               a
+    //               b
+    //             }
+    //             ... on T2 {
+    //               x
+    //               y
+    //             }
+    //           }
+    //           u2 {
+    //             ... on I {
+    //               b
+    //               c
+    //             }
+    //             ... on T1 {
+    //               a
+    //               b
+    //             }
+    //             ... on T2 {
+    //               x
+    //               y
+    //             }
+    //           }
+    //         }
+    //       }
+    //     `);
+    //
+    //     const optimized = withoutFragments.optimize(operation.fragments!);
+    //     // We should reuse and keep all fragments, because 1) onU is used twice and 2)
+    //     // all the other ones are used once in the query, and once in onU definition.
+    //     expect(optimized.toString()).toMatchString(`
+    //       fragment OnT1 on T1 {
+    //         a
+    //         b
+    //       }
+    //
+    //       fragment OnT2 on T2 {
+    //         x
+    //         y
+    //       }
+    //
+    //       fragment OnI on I {
+    //         b
+    //         c
+    //       }
+    //
+    //       fragment OnU on U {
+    //         ...OnI
+    //         ...OnT1
+    //         ...OnT2
+    //       }
+    //
+    //       {
+    //         t {
+    //           ... on T1 {
+    //             ...OnT1
+    //             me {
+    //               ...OnI
+    //             }
+    //           }
+    //           ...OnT2
+    //           u1 {
+    //             ...OnU
+    //           }
+    //           u2 {
+    //             ...OnU
+    //           }
+    //         }
+    //       }
+    //     `);
+    //   });
+}
+
+#[test]
+fn handles_fragments_with_nested_selections() {
+    //test('handles fragments with nested selections', () => {
+    //     const schema = parseSchema(`
+    //       type Query {
+    //         t1a: T1
+    //         t2a: T1
+    //       }
+    //
+    //       type T1 {
+    //         t2: T2
+    //       }
+    //
+    //       type T2 {
+    //         x: String
+    //         y: String
+    //       }
+    //     `);
+    //
+    //     testFragmentsRoundtrip({
+    //       schema,
+    //       query: `
+    //         fragment OnT1 on T1 {
+    //           t2 {
+    //             x
+    //           }
+    //         }
+    //
+    //         query {
+    //           t1a {
+    //             ...OnT1
+    //             t2 {
+    //               y
+    //             }
+    //           }
+    //           t2a {
+    //             ...OnT1
+    //           }
+    //         }
+    //       `,
+    //       expanded: `
+    //         {
+    //           t1a {
+    //             t2 {
+    //               x
+    //               y
+    //             }
+    //           }
+    //           t2a {
+    //             t2 {
+    //               x
+    //             }
+    //           }
+    //         }
+    //       `,
+    //     });
+    //   });
+}
+
+#[test]
+fn handles_nested_fragments_with_field_intersection() {
+    //test('handles nested fragments with field intersection', () => {
+    //     const schema = parseSchema(`
+    //       type Query {
+    //         t: T
+    //       }
+    //
+    //       type T {
+    //         a: A
+    //         b: Int
+    //       }
+    //
+    //       type A {
+    //         x: String
+    //         y: String
+    //         z: String
+    //       }
+    //     `);
+    //
+    //
+    //     // The subtlety here is that `FA` contains `__typename` and so after we're reused it, the
+    //     // selection will look like:
+    //     // {
+    //     //   t {
+    //     //     a {
+    //     //       ...FA
+    //     //     }
+    //     //   }
+    //     // }
+    //     // But to recognize that `FT` can be reused from there, we need to be able to see that
+    //     // the `__typename` that `FT` wants is inside `FA` (and since FA applies on the parent type `A`
+    //     // directly, it is fine to reuse).
+    //     testFragmentsRoundtrip({
+    //       schema,
+    //       query:  `
+    //         fragment FA on A {
+    //           __typename
+    //           x
+    //           y
+    //         }
+    //
+    //         fragment FT on T {
+    //           a {
+    //             __typename
+    //             ...FA
+    //           }
+    //         }
+    //
+    //         query {
+    //           t {
+    //             ...FT
+    //           }
+    //         }
+    //       `,
+    //       expanded: `
+    //         {
+    //           t {
+    //             a {
+    //               __typename
+    //               x
+    //               y
+    //             }
+    //           }
+    //         }
+    //       `,
+    //     });
+    //   });
+}
+
+#[test]
+fn handles_fragment_matching_subset_of_field_selection() {
+    // test('handles fragment matching subset of field selection', () => {
+    //     const schema = parseSchema(`
+    //       type Query {
+    //         t: T
+    //       }
+    //
+    //       type T {
+    //         a: String
+    //         b: B
+    //         c: Int
+    //         d: D
+    //       }
+    //
+    //       type B {
+    //         x: String
+    //         y: String
+    //       }
+    //
+    //       type D {
+    //         m: String
+    //         n: String
+    //       }
+    //     `);
+    //
+    //     testFragmentsRoundtrip({
+    //       schema,
+    //       query: `
+    //         fragment FragT on T {
+    //           b {
+    //             __typename
+    //             x
+    //           }
+    //           c
+    //           d {
+    //             m
+    //           }
+    //         }
+    //
+    //         {
+    //           t {
+    //             ...FragT
+    //             d {
+    //               n
+    //             }
+    //             a
+    //           }
+    //         }
+    //       `,
+    //       expanded: `
+    //         {
+    //           t {
+    //             b {
+    //               __typename
+    //               x
+    //             }
+    //             c
+    //             d {
+    //               m
+    //               n
+    //             }
+    //             a
+    //           }
+    //         }
+    //       `,
+    //     });
+    //   });
+}
+
+#[test]
+fn handles_fragment_matching_subset_of_inline_fragment_selection() {
+    // test('handles fragment matching subset of inline fragment selection', () => {
+    //     // Pretty much the same test than the previous one, but matching inside a fragment selection inside
+    //     // of inside a field selection.
+    //     const schema = parseSchema(`
+    //       type Query {
+    //         i: I
+    //       }
+    //
+    //       interface I {
+    //         a: String
+    //       }
+    //
+    //       type T {
+    //         a: String
+    //         b: B
+    //         c: Int
+    //         d: D
+    //       }
+    //
+    //       type B {
+    //         x: String
+    //         y: String
+    //       }
+    //
+    //       type D {
+    //         m: String
+    //         n: String
+    //       }
+    //     `);
+    //
+    //     testFragmentsRoundtrip({
+    //       schema,
+    //       query: `
+    //         fragment FragT on T {
+    //           b {
+    //             __typename
+    //             x
+    //           }
+    //           c
+    //           d {
+    //             m
+    //           }
+    //         }
+    //
+    //         {
+    //           i {
+    //             ... on T {
+    //               ...FragT
+    //               d {
+    //                 n
+    //               }
+    //               a
+    //             }
+    //           }
+    //         }
+    //       `,
+    //       expanded: `
+    //         {
+    //           i {
+    //             ... on T {
+    //               b {
+    //                 __typename
+    //                 x
+    //               }
+    //               c
+    //               d {
+    //                 m
+    //                 n
+    //               }
+    //               a
+    //             }
+    //           }
+    //         }
+    //       `,
+    //     });
+    //   });
+}
+
+#[test]
+fn intersecting_fragments() {
+    // test('intersecting fragments', () => {
+    //     const schema = parseSchema(`
+    //       type Query {
+    //         t: T
+    //       }
+    //
+    //       type T {
+    //         a: String
+    //         b: B
+    //         c: Int
+    //         d: D
+    //       }
+    //
+    //       type B {
+    //         x: String
+    //         y: String
+    //       }
+    //
+    //       type D {
+    //         m: String
+    //         n: String
+    //       }
+    //     `);
+    //
+    //     testFragmentsRoundtrip({
+    //       schema,
+    //       // Note: the code that reuse fragments iterates on fragments in the order they are defined in the document, but when it reuse
+    //       // a fragment, it puts it at the beginning of the selection (somewhat random, it just feel often easier to read), so the net
+    //       // effect on this example is that `Frag2`, which will be reused after `Frag1` will appear first in the re-optimized selection.
+    //       // So we put it first in the input too so that input and output actually match (the `testFragmentsRoundtrip` compares strings,
+    //       // so it is sensible to ordering; we could theoretically use `Operation.equals` instead of string equality, which wouldn't
+    //       // really on ordering, but `Operation.equals` is not entirely trivial and comparing strings make problem a bit more obvious).
+    //       query: `
+    //         fragment Frag1 on T {
+    //           b {
+    //             x
+    //           }
+    //           c
+    //           d {
+    //             m
+    //           }
+    //         }
+    //
+    //         fragment Frag2 on T {
+    //           a
+    //           b {
+    //             __typename
+    //             x
+    //           }
+    //           d {
+    //             m
+    //             n
+    //           }
+    //         }
+    //
+    //         {
+    //           t {
+    //             ...Frag1
+    //             ...Frag2
+    //           }
+    //         }
+    //       `,
+    //       expanded: `
+    //         {
+    //           t {
+    //             b {
+    //               x
+    //               __typename
+    //             }
+    //             c
+    //             d {
+    //               m
+    //               n
+    //             }
+    //             a
+    //           }
+    //         }
+    //       `,
+    //     });
+    //   });
+}
+
+#[test]
+fn fragments_application_makes_type_condition_trivial() {
+    //  test('fragments whose application makes a type condition trivial', () => {
+    //     const schema = parseSchema(`
+    //       type Query {
+    //         t: T
+    //       }
+    //
+    //       interface I {
+    //         x: String
+    //       }
+    //
+    //       type T implements I {
+    //         x: String
+    //         a: String
+    //       }
+    //     `);
+    //
+    //     testFragmentsRoundtrip({
+    //       schema,
+    //       query: `
+    //         fragment FragI on I {
+    //           x
+    //           ... on T {
+    //             a
+    //           }
+    //         }
+    //
+    //         {
+    //           t {
+    //             ...FragI
+    //           }
+    //         }
+    //       `,
+    //       expanded: `
+    //         {
+    //           t {
+    //             x
+    //             a
+    //           }
+    //         }
+    //       `,
+    //     });
+    //   });
+}
+
+#[test]
+fn handles_fragment_matching_at_the_top_level_of_another_fragment() {
+    //test('handles fragment matching at the top level of another fragment', () => {
+    //     const schema = parseSchema(`
+    //       type Query {
+    //         t: T
+    //       }
+    //
+    //       type T {
+    //         a: String
+    //         u: U
+    //       }
+    //
+    //       type U {
+    //         x: String
+    //         y: String
+    //       }
+    //     `);
+    //
+    //     testFragmentsRoundtrip({
+    //       schema,
+    //       query: `
+    //         fragment Frag1 on T {
+    //           a
+    //         }
+    //
+    //         fragment Frag2 on T {
+    //           u {
+    //             x
+    //             y
+    //           }
+    //           ...Frag1
+    //         }
+    //
+    //         fragment Frag3 on Query {
+    //           t {
+    //             ...Frag2
+    //           }
+    //         }
+    //
+    //         {
+    //           ...Frag3
+    //         }
+    //       `,
+    //       expanded: `
+    //         {
+    //           t {
+    //             u {
+    //               x
+    //               y
+    //             }
+    //             a
+    //           }
+    //         }
+    //       `,
+    //     });
+    //   });
+}
+
+#[test]
+fn handles_fragments_used_in_context_where_they_get_trimmed() {
+    //test('handles fragments used in a context where they get trimmed', () => {
+    //     const schema = parseSchema(`
+    //       type Query {
+    //         t1: T1
+    //       }
+    //
+    //       interface I {
+    //         x: Int
+    //       }
+    //
+    //       type T1 implements I {
+    //         x: Int
+    //         y: Int
+    //       }
+    //
+    //       type T2 implements I {
+    //         x: Int
+    //         z: Int
+    //       }
+    //     `);
+    //
+    //     testFragmentsRoundtrip({
+    //       schema,
+    //       query: `
+    //         fragment FragOnI on I {
+    //           ... on T1 {
+    //             y
+    //           }
+    //           ... on T2 {
+    //             z
+    //           }
+    //         }
+    //
+    //         {
+    //           t1 {
+    //             ...FragOnI
+    //           }
+    //         }
+    //       `,
+    //       expanded: `
+    //         {
+    //           t1 {
+    //             y
+    //           }
+    //         }
+    //       `,
+    //     });
+    //   });
+}
+
+#[test]
+fn handles_fragments_used_in_the_context_of_non_intersecting_abstract_types() {
+    //test('handles fragments used in the context of non-intersecting abstract types', () => {
+    //     const schema = parseSchema(`
+    //       type Query {
+    //         i2: I2
+    //       }
+    //
+    //       interface I1 {
+    //         x: Int
+    //       }
+    //
+    //       interface I2 {
+    //         y: Int
+    //       }
+    //
+    //       interface I3 {
+    //         z: Int
+    //       }
+    //
+    //       type T1 implements I1 & I2 {
+    //         x: Int
+    //         y: Int
+    //       }
+    //
+    //       type T2 implements I1 & I3 {
+    //         x: Int
+    //         z: Int
+    //       }
+    //     `);
+    //
+    //     testFragmentsRoundtrip({
+    //       schema,
+    //       query: `
+    //         fragment FragOnI1 on I1 {
+    //           ... on I2 {
+    //             y
+    //           }
+    //           ... on I3 {
+    //             z
+    //           }
+    //         }
+    //
+    //         {
+    //           i2 {
+    //             ...FragOnI1
+    //           }
+    //         }
+    //       `,
+    //       expanded: `
+    //         {
+    //           i2 {
+    //             ... on I1 {
+    //               ... on I2 {
+    //                 y
+    //               }
+    //               ... on I3 {
+    //                 z
+    //               }
+    //             }
+    //           }
+    //         }
+    //       `,
+    //     });
+    //   });
+}
+
+#[test]
+fn handles_fragments_on_union_in_context_with_limited_intersection() {
+    //test('handles fragments on union in context with limited intersection', () => {
+    //     const schema = parseSchema(`
+    //       type Query {
+    //         t1: T1
+    //       }
+    //
+    //       union U = T1 | T2
+    //
+    //       type T1 {
+    //         x: Int
+    //       }
+    //
+    //       type T2 {
+    //         y: Int
+    //       }
+    //     `);
+    //
+    //     testFragmentsRoundtrip({
+    //       schema,
+    //       query: `
+    //         fragment OnU on U {
+    //           ... on T1 {
+    //             x
+    //           }
+    //           ... on T2 {
+    //             y
+    //           }
+    //         }
+    //
+    //         {
+    //           t1 {
+    //             ...OnU
+    //           }
+    //         }
+    //       `,
+    //       expanded: `
+    //         {
+    //           t1 {
+    //             x
+    //           }
+    //         }
+    //       `,
+    //     });
+    //   });
+}
+
+#[test]
+fn off_by_1_error() {
+    //test('off by 1 error', () => {
+    //     const schema = buildSchema(`#graphql
+    //       type Query {
+    //         t: T
+    //       }
+    //       type T {
+    //         id: String!
+    //         a: A
+    //         v: V
+    //       }
+    //       type A {
+    //         id: String!
+    //       }
+    //       type V {
+    //         t: T!
+    //       }
+    //     `);
+    //
+    //     const operation = parseOperation(schema, `
+    //       {
+    //         t {
+    //           ...TFrag
+    //           v {
+    //             t {
+    //               id
+    //               a {
+    //                 __typename
+    //                 id
+    //               }
+    //             }
+    //           }
+    //         }
+    //       }
+    //
+    //       fragment TFrag on T {
+    //         __typename
+    //         id
+    //       }
+    //     `);
+    //
+    //     const withoutFragments = operation.expandAllFragments();
+    //     expect(withoutFragments.toString()).toMatchString(`
+    //       {
+    //         t {
+    //           __typename
+    //           id
+    //           v {
+    //             t {
+    //               id
+    //               a {
+    //                 __typename
+    //                 id
+    //               }
+    //             }
+    //           }
+    //         }
+    //       }
+    //     `);
+    //
+    //     const optimized = withoutFragments.optimize(operation.fragments!);
+    //     expect(optimized.toString()).toMatchString(`
+    //       fragment TFrag on T {
+    //         __typename
+    //         id
+    //       }
+    //
+    //       {
+    //         t {
+    //           ...TFrag
+    //           v {
+    //             t {
+    //               ...TFrag
+    //               a {
+    //                 __typename
+    //                 id
+    //               }
+    //             }
+    //           }
+    //         }
+    //       }
+    //     `);
+    //   });
+}
+
+#[test]
+fn removes_all_unused_fragments() {
+    //test('does not leave unused fragments', () => {
+    //     const schema = parseSchema(`
+    //       type Query {
+    //         t1: T1
+    //       }
+    //
+    //       union U1 = T1 | T2 | T3
+    //       union U2 =      T2 | T3
+    //
+    //       type T1 {
+    //         x: Int
+    //       }
+    //
+    //       type T2 {
+    //         y: Int
+    //       }
+    //
+    //       type T3 {
+    //         z: Int
+    //       }
+    //     `);
+    //     const gqlSchema = schema.toGraphQLJSSchema();
+    //
+    //     const operation = parseOperation(schema, `
+    //       query {
+    //         t1 {
+    //           ...Outer
+    //         }
+    //       }
+    //
+    //       fragment Outer on U1 {
+    //         ... on T1 {
+    //           x
+    //         }
+    //         ... on T2 {
+    //           ... Inner
+    //         }
+    //         ... on T3 {
+    //           ... Inner
+    //         }
+    //       }
+    //
+    //       fragment Inner on U2 {
+    //         ... on T2 {
+    //           y
+    //         }
+    //       }
+    //     `);
+    //     expect(validate(gqlSchema, parse(operation.toString()))).toStrictEqual([]);
+    //
+    //     const withoutFragments = operation.expandAllFragments();
+    //     expect(withoutFragments.toString()).toMatchString(`
+    //       {
+    //         t1 {
+    //           x
+    //         }
+    //       }
+    //     `);
+    //
+    //     // This is a bit of contrived example, but the reusing code will be able
+    //     // to figure out that the `Outer` fragment can be reused and will initially
+    //     // do so, but it's only use once, so it will expand it, which yields:
+    //     // {
+    //     //   t1 {
+    //     //     ... on T1 {
+    //     //       x
+    //     //     }
+    //     //     ... on T2 {
+    //     //       ... Inner
+    //     //     }
+    //     //     ... on T3 {
+    //     //       ... Inner
+    //     //     }
+    //     //   }
+    //     // }
+    //     // and so `Inner` will not be expanded (it's used twice). Except that
+    //     // the `normalize` code is apply then and will _remove_ both instances
+    //     // of `.... Inner`. Which is ok, but we must make sure the fragment
+    //     // itself is removed since it is not used now, which this test ensures.
+    //     const optimized = withoutFragments.optimize(operation.fragments!, 2);
+    //     expect(validate(gqlSchema, parse(optimized.toString()))).toStrictEqual([]);
+    //
+    //     expect(optimized.toString()).toMatchString(`
+    //       {
+    //         t1 {
+    //           x
+    //         }
+    //       }
+    //     `);
+    //   });
+}
+
+#[test]
+fn removes_fragments_only_used_by_unused_fragments() {
+    //test('does not leave fragments only used by unused fragments', () => {
+    //     // Similar to the previous test, but we artificially add a
+    //     // fragment that is only used by the fragment that is finally
+    //     // unused.
+    //
+    //     const schema = parseSchema(`
+    //       type Query {
+    //         t1: T1
+    //       }
+    //
+    //       union U1 = T1 | T2 | T3
+    //       union U2 =      T2 | T3
+    //
+    //       type T1 {
+    //         x: Int
+    //       }
+    //
+    //       type T2 {
+    //         y1: Y
+    //         y2: Y
+    //       }
+    //
+    //       type T3 {
+    //         z: Int
+    //       }
+    //
+    //       type Y {
+    //         v: Int
+    //       }
+    //     `);
+    //     const gqlSchema = schema.toGraphQLJSSchema();
+    //
+    //     const operation = parseOperation(schema, `
+    //       query {
+    //         t1 {
+    //           ...Outer
+    //         }
+    //       }
+    //
+    //       fragment Outer on U1 {
+    //         ... on T1 {
+    //           x
+    //         }
+    //         ... on T2 {
+    //           ... Inner
+    //         }
+    //         ... on T3 {
+    //           ... Inner
+    //         }
+    //       }
+    //
+    //       fragment Inner on U2 {
+    //         ... on T2 {
+    //           y1 {
+    //             ...WillBeUnused
+    //           }
+    //           y2 {
+    //             ...WillBeUnused
+    //           }
+    //         }
+    //       }
+    //
+    //       fragment WillBeUnused on Y {
+    //         v
+    //       }
+    //     `);
+    //     expect(validate(gqlSchema, parse(operation.toString()))).toStrictEqual([]);
+    //
+    //     const withoutFragments = operation.expandAllFragments();
+    //     expect(withoutFragments.toString()).toMatchString(`
+    //       {
+    //         t1 {
+    //           x
+    //         }
+    //       }
+    //     `);
+    //
+    //     const optimized = withoutFragments.optimize(operation.fragments!, 2);
+    //     expect(validate(gqlSchema, parse(optimized.toString()))).toStrictEqual([]);
+    //
+    //     expect(optimized.toString()).toMatchString(`
+    //       {
+    //         t1 {
+    //           x
+    //         }
+    //       }
+    //     `);
+    //   });
+}
+
+#[test]
+fn keeps_fragments_used_by_other_fragments() {
+    // test('keeps fragments only used by other fragments (if they are used enough times)', () => {
+    //     const schema = parseSchema(`
+    //       type Query {
+    //         t1: T
+    //         t2: T
+    //       }
+    //
+    //       type T {
+    //         a1: Int
+    //         a2: Int
+    //         b1: B
+    //         b2: B
+    //       }
+    //
+    //       type B {
+    //         x: Int
+    //         y: Int
+    //       }
+    //     `);
+    //     const gqlSchema = schema.toGraphQLJSSchema();
+    //
+    //     const operation = parseOperation(schema, `
+    //       query {
+    //         t1 {
+    //           ...TFields
+    //         }
+    //         t2 {
+    //           ...TFields
+    //         }
+    //       }
+    //
+    //       fragment TFields on T {
+    //         ...DirectFieldsOfT
+    //         b1 {
+    //           ...BFields
+    //         }
+    //         b2 {
+    //           ...BFields
+    //         }
+    //       }
+    //
+    //       fragment DirectFieldsOfT on T {
+    //         a1
+    //         a2
+    //       }
+    //
+    //       fragment BFields on B {
+    //         x
+    //         y
+    //       }
+    //     `);
+    //     expect(validate(gqlSchema, parse(operation.toString()))).toStrictEqual([]);
+    //
+    //     const withoutFragments = operation.expandAllFragments();
+    //     expect(withoutFragments.toString()).toMatchString(`
+    //       {
+    //         t1 {
+    //           a1
+    //           a2
+    //           b1 {
+    //             x
+    //             y
+    //           }
+    //           b2 {
+    //             x
+    //             y
+    //           }
+    //         }
+    //         t2 {
+    //           a1
+    //           a2
+    //           b1 {
+    //             x
+    //             y
+    //           }
+    //           b2 {
+    //             x
+    //             y
+    //           }
+    //         }
+    //       }
+    //     `);
+    //
+    //     const optimized = withoutFragments.optimize(operation.fragments!, 2);
+    //     expect(validate(gqlSchema, parse(optimized.toString()))).toStrictEqual([]);
+    //
+    //     // The `DirectFieldsOfT` fragments should not be kept as it is used only once within `TFields`,
+    //     // but the `BFields` one should be kept.
+    //     expect(optimized.toString()).toMatchString(`
+    //       fragment BFields on B {
+    //         x
+    //         y
+    //       }
+    //
+    //       fragment TFields on T {
+    //         a1
+    //         a2
+    //         b1 {
+    //           ...BFields
+    //         }
+    //         b2 {
+    //           ...BFields
+    //         }
+    //       }
+    //
+    //       {
+    //         t1 {
+    //           ...TFields
+    //         }
+    //         t2 {
+    //           ...TFields
+    //         }
+    //       }
+    //     `);
+    //   });
+}
+
+///
+/// applied directives
+///
+
+#[test]
+fn reuse_fragments_with_same_directive_on_the_fragment() {
+    // test('reuse fragments with directives on the fragment, but only when there is those directives', () => {
+    //       const schema = parseSchema(`
+    //         type Query {
+    //           t1: T
+    //           t2: T
+    //           t3: T
+    //         }
+    //
+    //         type T {
+    //           a: Int
+    //           b: Int
+    //           c: Int
+    //           d: Int
+    //         }
+    //       `);
+    //
+    //       testFragmentsRoundtrip({
+    //         schema,
+    //         query: `
+    //           fragment DirectiveOnDef on T @include(if: $cond1) {
+    //             a
+    //           }
+    //
+    //           query myQuery($cond1: Boolean!, $cond2: Boolean!) {
+    //             t1 {
+    //               ...DirectiveOnDef
+    //             }
+    //             t2 {
+    //               ... on T @include(if: $cond2) {
+    //                 a
+    //               }
+    //             }
+    //             t3 {
+    //               ...DirectiveOnDef @include(if: $cond2)
+    //             }
+    //           }
+    //         `,
+    //         expanded: `
+    //           query myQuery($cond1: Boolean!, $cond2: Boolean!) {
+    //             t1 {
+    //               ... on T @include(if: $cond1) {
+    //                 a
+    //               }
+    //             }
+    //             t2 {
+    //               ... on T @include(if: $cond2) {
+    //                 a
+    //               }
+    //             }
+    //             t3 {
+    //               ... on T @include(if: $cond1) @include(if: $cond2) {
+    //                 a
+    //               }
+    //             }
+    //           }
+    //         `,
+    //       });
+    //     });
+}
+
+#[test]
+fn reuse_fragments_with_same_directive_in_the_fragment_selection() {
+    //test('reuse fragments with directives in the fragment selection, but only when there is those directives', () => {
+    //       const schema = parseSchema(`
+    //         type Query {
+    //           t1: T
+    //           t2: T
+    //           t3: T
+    //         }
+    //
+    //         type T {
+    //           a: Int
+    //           b: Int
+    //           c: Int
+    //           d: Int
+    //         }
+    //       `);
+    //
+    //       testFragmentsRoundtrip({
+    //         schema,
+    //         query: `
+    //           fragment DirectiveInDef on T {
+    //             a @include(if: $cond1)
+    //           }
+    //
+    //           query myQuery($cond1: Boolean!, $cond2: Boolean!) {
+    //             t1 {
+    //               a
+    //             }
+    //             t2 {
+    //               ...DirectiveInDef
+    //             }
+    //             t3 {
+    //               a @include(if: $cond2)
+    //             }
+    //           }
+    //         `,
+    //         expanded: `
+    //           query myQuery($cond1: Boolean!, $cond2: Boolean!) {
+    //             t1 {
+    //               a
+    //             }
+    //             t2 {
+    //               a @include(if: $cond1)
+    //             }
+    //             t3 {
+    //               a @include(if: $cond2)
+    //             }
+    //           }
+    //         `,
+    //       });
+    //     });
+}
+
+#[test]
+fn reuse_fragments_with_directives_on_inline_fragments() {
+    //test('reuse fragments with directives on spread, but only when there is those directives', () => {
+    //       const schema = parseSchema(`
+    //         type Query {
+    //           t1: T
+    //           t2: T
+    //           t3: T
+    //         }
+    //
+    //         type T {
+    //           a: Int
+    //           b: Int
+    //           c: Int
+    //           d: Int
+    //         }
+    //       `);
+    //
+    //       testFragmentsRoundtrip({
+    //         schema,
+    //         query: `
+    //           fragment NoDirectiveDef on T {
+    //             a
+    //           }
+    //
+    //           query myQuery($cond1: Boolean!) {
+    //             t1 {
+    //               ...NoDirectiveDef
+    //             }
+    //             t2 {
+    //               ...NoDirectiveDef @include(if: $cond1)
+    //             }
+    //           }
+    //         `,
+    //         expanded: `
+    //           query myQuery($cond1: Boolean!) {
+    //             t1 {
+    //               a
+    //             }
+    //             t2 {
+    //               ... on T @include(if: $cond1) {
+    //                 a
+    //               }
+    //             }
+    //           }
+    //         `,
+    //       });
+    //     });
+}
+
+///
+/// empty branches removal
+///
+
+#[test]
+fn operation_not_modified_if_no_empty_branches() {
+    //  it.each([
+    //     '{ t { a } }',
+    //     '{ t { a b } }',
+    //     '{ t { a c { x y } } }',
+    //   ])('is identity if there is no empty branch', (op) => {
+    //     expect(withoutEmptyBranches(op)).toBe(op);
+    //   });
+}
+
+#[test]
+fn removes_simple_empty_branches() {
+    //it('removes simple empty branches', () => {
+    //     expect(withoutEmptyBranches(
+    //       astSSet(
+    //         astField('t', astSSet(
+    //           astField('a'),
+    //           astField('c', astSSet()),
+    //         ))
+    //       )
+    //     )).toBe('{ t { a } }');
+    //
+    //     expect(withoutEmptyBranches(
+    //       astSSet(
+    //         astField('t', astSSet(
+    //           astField('c', astSSet()),
+    //           astField('a'),
+    //         ))
+    //       )
+    //     )).toBe('{ t { a } }');
+    //
+    //     expect(withoutEmptyBranches(
+    //       astSSet(
+    //         astField('t', astSSet())
+    //       )
+    //     )).toBeUndefined();
+    //   });
+}
+
+#[test]
+fn removes_cascading_empty_branches() {
+    //it('removes cascading empty branches', () => {
+    //     expect(withoutEmptyBranches(
+    //       astSSet(
+    //         astField('t', astSSet(
+    //           astField('c', astSSet()),
+    //         ))
+    //       )
+    //     )).toBeUndefined();
+    //
+    //     expect(withoutEmptyBranches(
+    //       astSSet(
+    //         astField('u'),
+    //         astField('t', astSSet(
+    //           astField('c', astSSet()),
+    //         ))
+    //       )
+    //     )).toBe('{ u }');
+    //
+    //     expect(withoutEmptyBranches(
+    //       astSSet(
+    //         astField('t', astSSet(
+    //           astField('c', astSSet()),
+    //         )),
+    //         astField('u'),
+    //       )
+    //     )).toBe('{ u }');
+    //   });
+}

--- a/tests/query_plan/operation_tests.rs
+++ b/tests/query_plan/operation_tests.rs
@@ -25,8 +25,9 @@ type T {
   v2: String
 }
 "#;
-    let (schema, mut executable_document) =
-        apollo_compiler::parse_mixed(operation_string, "document.graphql");
+    let (schema, executable_document) =
+        apollo_compiler::parse_mixed_validate(operation_string, "document.graphql").unwrap();
+    let mut executable_document = executable_document.into_inner();
     if let Some((_, operation)) = executable_document.named_operations.first_mut() {
         let operation = operation.make_mut();
         normalize_operation(operation, &schema, &executable_document.fragments);
@@ -64,8 +65,10 @@ type T {
   v2: String
 }
 "#;
-    let (schema, mut executable_document) =
-        apollo_compiler::parse_mixed(operation_with_directives, "document.graphql");
+    let (schema, executable_document) =
+        apollo_compiler::parse_mixed_validate(operation_with_directives, "document.graphql")
+            .unwrap();
+    let mut executable_document = executable_document.into_inner();
     if let Some((_, operation)) = executable_document.named_operations.first_mut() {
         let operation = operation.make_mut();
         normalize_operation(operation, &schema, &executable_document.fragments);
@@ -105,10 +108,12 @@ type T {
   v2: String
 }
 "#;
-    let (schema, mut executable_document) = apollo_compiler::parse_mixed(
+    let (schema, executable_document) = apollo_compiler::parse_mixed_validate(
         operation_with_directives_different_arg_order,
         "document.graphql",
-    );
+    )
+    .unwrap();
+    let mut executable_document = executable_document.into_inner();
     if let Some((_, operation)) = executable_document.named_operations.first_mut() {
         let operation = operation.make_mut();
         normalize_operation(operation, &schema, &executable_document.fragments);
@@ -146,8 +151,12 @@ type T {
   v2: String
 }
 "#;
-    let (schema, mut executable_document) =
-        apollo_compiler::parse_mixed(operation_one_field_with_directives, "document.graphql");
+    let (schema, executable_document) = apollo_compiler::parse_mixed_validate(
+        operation_one_field_with_directives,
+        "document.graphql",
+    )
+    .unwrap();
+    let mut executable_document = executable_document.into_inner();
     if let Some((_, operation)) = executable_document.named_operations.first_mut() {
         let operation = operation.make_mut();
         normalize_operation(operation, &schema, &executable_document.fragments);
@@ -187,8 +196,10 @@ type T {
   v2: String
 }
 "#;
-    let (schema, mut executable_document) =
-        apollo_compiler::parse_mixed(operation_different_directives, "document.graphql");
+    let (schema, executable_document) =
+        apollo_compiler::parse_mixed_validate(operation_different_directives, "document.graphql")
+            .unwrap();
+    let mut executable_document = executable_document.into_inner();
     if let Some((_, operation)) = executable_document.named_operations.first_mut() {
         let operation = operation.make_mut();
         normalize_operation(operation, &schema, &executable_document.fragments);
@@ -207,6 +218,8 @@ type T {
     }
 }
 
+// TODO enable when @defer is available in apollo-rs
+#[ignore]
 #[test]
 fn do_not_merge_fields_with_defer_directive() {
     let operation_defer_fields = r#"
@@ -228,8 +241,9 @@ type T {
   v2: String
 }
 "#;
-    let (schema, mut executable_document) =
-        apollo_compiler::parse_mixed(operation_defer_fields, "document.graphql");
+    let (schema, executable_document) =
+        apollo_compiler::parse_mixed_validate(operation_defer_fields, "document.graphql").unwrap();
+    let mut executable_document = executable_document.into_inner();
     if let Some((_, operation)) = executable_document.named_operations.first_mut() {
         let operation = operation.make_mut();
         normalize_operation(operation, &schema, &executable_document.fragments);
@@ -248,6 +262,8 @@ type T {
     }
 }
 
+// TODO enable when @defer is available in apollo-rs
+#[ignore]
 #[test]
 fn merge_nested_field_selections() {
     let nested_operation = r#"
@@ -282,8 +298,9 @@ type V {
   v2: String
 }
 "#;
-    let (schema, mut executable_document) =
-        apollo_compiler::parse_mixed(nested_operation, "document.graphql");
+    let (schema, executable_document) =
+        apollo_compiler::parse_mixed_validate(nested_operation, "document.graphql").unwrap();
+    let mut executable_document = executable_document.into_inner();
     if let Some((_, operation)) = executable_document.named_operations.first_mut() {
         let operation = operation.make_mut();
         normalize_operation(operation, &schema, &executable_document.fragments);
@@ -333,8 +350,10 @@ type T {
   v2: String
 }
 "#;
-    let (schema, mut executable_document) =
-        apollo_compiler::parse_mixed(operation_with_fragments, "document.graphql");
+    let (schema, executable_document) =
+        apollo_compiler::parse_mixed_validate(operation_with_fragments, "document.graphql")
+            .unwrap();
+    let mut executable_document = executable_document.into_inner();
     if let Some((_, operation)) = executable_document.named_operations.first_mut() {
         let operation = operation.make_mut();
         normalize_operation(operation, &schema, &executable_document.fragments);
@@ -374,8 +393,12 @@ type T {
   v2: String
 }
 "#;
-    let (schema, mut executable_document) =
-        apollo_compiler::parse_mixed(operation_fragments_with_directives, "document.graphql");
+    let (schema, executable_document) = apollo_compiler::parse_mixed_validate(
+        operation_fragments_with_directives,
+        "document.graphql",
+    )
+    .unwrap();
+    let mut executable_document = executable_document.into_inner();
     if let Some((_, operation)) = executable_document.named_operations.first_mut() {
         let operation = operation.make_mut();
         normalize_operation(operation, &schema, &executable_document.fragments);
@@ -419,10 +442,12 @@ type T {
   v2: String
 }
 "#;
-    let (schema, mut executable_document) = apollo_compiler::parse_mixed(
+    let (schema, executable_document) = apollo_compiler::parse_mixed_validate(
         operation_fragments_with_directives_args_order,
         "document.graphql",
-    );
+    )
+    .unwrap();
+    let mut executable_document = executable_document.into_inner();
     if let Some((_, operation)) = executable_document.named_operations.first_mut() {
         let operation = operation.make_mut();
         normalize_operation(operation, &schema, &executable_document.fragments);
@@ -464,8 +489,12 @@ type T {
   v2: String
 }
 "#;
-    let (schema, mut executable_document) =
-        apollo_compiler::parse_mixed(operation_one_fragment_with_directive, "document.graphql");
+    let (schema, executable_document) = apollo_compiler::parse_mixed_validate(
+        operation_one_fragment_with_directive,
+        "document.graphql",
+    )
+    .unwrap();
+    let mut executable_document = executable_document.into_inner();
     if let Some((_, operation)) = executable_document.named_operations.first_mut() {
         let operation = operation.make_mut();
         normalize_operation(operation, &schema, &executable_document.fragments);
@@ -507,10 +536,12 @@ type T {
   v2: String
 }
 "#;
-    let (schema, mut executable_document) = apollo_compiler::parse_mixed(
+    let (schema, executable_document) = apollo_compiler::parse_mixed_validate(
         operation_fragments_with_different_directive,
         "document.graphql",
-    );
+    )
+    .unwrap();
+    let mut executable_document = executable_document.into_inner();
     if let Some((_, operation)) = executable_document.named_operations.first_mut() {
         let operation = operation.make_mut();
         normalize_operation(operation, &schema, &executable_document.fragments);
@@ -531,6 +562,8 @@ type T {
     }
 }
 
+// TODO enable when @defer is available in apollo-rs
+#[ignore]
 #[test]
 fn do_not_merge_fragments_with_defer_directive() {
     let operation_fragments_with_defer = r#"
@@ -554,8 +587,10 @@ type T {
   v2: String
 }
 "#;
-    let (schema, mut executable_document) =
-        apollo_compiler::parse_mixed(operation_fragments_with_defer, "document.graphql");
+    let (schema, executable_document) =
+        apollo_compiler::parse_mixed_validate(operation_fragments_with_defer, "document.graphql")
+            .unwrap();
+    let mut executable_document = executable_document.into_inner();
     if let Some((_, operation)) = executable_document.named_operations.first_mut() {
         let operation = operation.make_mut();
         normalize_operation(operation, &schema, &executable_document.fragments);
@@ -576,6 +611,8 @@ type T {
     }
 }
 
+// TODO enable when @defer is available in apollo-rs
+#[ignore]
 #[test]
 fn merge_nested_fragments() {
     let operation_nested_fragments = r#"
@@ -618,8 +655,10 @@ type V {
   v2: String
 }
 "#;
-    let (schema, mut executable_document) =
-        apollo_compiler::parse_mixed(operation_nested_fragments, "document.graphql");
+    let (schema, executable_document) =
+        apollo_compiler::parse_mixed_validate(operation_nested_fragments, "document.graphql")
+            .unwrap();
+    let mut executable_document = executable_document.into_inner();
     if let Some((_, operation)) = executable_document.named_operations.first_mut() {
         let operation = operation.make_mut();
         normalize_operation(operation, &schema, &executable_document.fragments);

--- a/tests/query_plan/operation_tests.rs
+++ b/tests/query_plan/operation_tests.rs
@@ -1,0 +1,478 @@
+use apollo_federation::query_plan::operation::normalize_operation;
+
+#[test]
+fn basic_operation() {
+    //test('forEachElement', () => {
+    //     // We collect a pair of (parent type, field-or-fragment).
+    //     const actual: [string, string][] = [];
+    //     operation.selectionSet.forEachElement((elt) => actual.push([elt.parentType.name, elt.toString()]));
+    //     expect(actual).toStrictEqual([
+    //       ['Query', 't'],
+    //       ['T', 'v1'],
+    //       ['T', 'v3'],
+    //       ['I', 'x'],
+    //       ['Query', 'i'],
+    //       ['I', '... on A'],
+    //       ['A', 'a1'],
+    //       ['A', 'a2'],
+    //       ['I', '... on B'],
+    //       ['B', 'y'],
+    //       ['B', 'b2'],
+    //       ['T', 'v2'],
+    //     ]);
+    //   })
+}
+
+#[test]
+fn merge_same_fields_without_directives() {
+    let operation_string = r#"
+query Test {
+  t {
+    v1
+  }
+  t {
+    v2
+ }
+}
+
+type Query {
+  t: T
+}
+
+type T {
+  v1: Int
+  v2: String
+}
+"#;
+    let (schema, mut executable_document) =
+        apollo_compiler::parse_mixed(operation_string, "document.graphql");
+    if let Some((_, operation)) = executable_document.named_operations.first_mut() {
+        let operation = operation.make_mut();
+        normalize_operation(operation, &schema, &executable_document.fragments);
+        let expected = r#"query Test {
+  t {
+    v1
+    v2
+  }
+}"#;
+        let actual = format!("{}", operation);
+        assert_eq!(expected, actual);
+    } else {
+        panic!("unable to parse document")
+    }
+}
+
+#[test]
+fn merge_same_fields_with_same_directive() {
+    let operation_with_directives = r#"
+query Test($skipIf: Boolean!) {
+  t @skip(if: $skipIf) {
+    v1
+  }
+  t @skip(if: $skipIf) {
+    v2
+  }
+}
+
+type Query {
+  t: T
+}
+
+type T {
+  v1: Int
+  v2: String
+}
+"#;
+    let (schema, mut executable_document) =
+        apollo_compiler::parse_mixed(operation_with_directives, "document.graphql");
+    if let Some((_, operation)) = executable_document.named_operations.first_mut() {
+        let operation = operation.make_mut();
+        normalize_operation(operation, &schema, &executable_document.fragments);
+        let expected = r#"query Test($skipIf: Boolean!) {
+  t @skip(if: $skipIf) {
+    v1
+    v2
+  }
+}"#;
+        let actual = format!("{}", operation);
+        assert_eq!(expected, actual);
+    } else {
+        panic!("unable to parse document")
+    }
+}
+
+#[test]
+fn merge_same_fields_with_same_directive_but_different_arg_order() {
+    // test('do merge when both have the _same_ directive, even if argument order differs', () => {
+    //       const operation = operationFromDocument(schema, gql`
+    //         query Test($skipIf: Boolean!) {
+    //           t @customSkip(if: $skipIf, label: "foo") {
+    //             v1
+    //           }
+    //           t @customSkip(label: "foo", if: $skipIf) {
+    //             v2
+    //           }
+    //         }
+    //       `);
+    //
+    //       expect(operation.toString()).toMatchString(`
+    //         query Test($skipIf: Boolean!) {
+    //           t @customSkip(if: $skipIf, label: "foo") {
+    //             v1
+    //             v2
+    //           }
+    //         }
+    //       `);
+    //     });
+}
+
+#[test]
+fn do_not_merge_when_only_one_field_specifies_directive() {
+    let operation_one_field_with_directives = r#"
+query Test($skipIf: Boolean!) {
+  t {
+    v1
+  }
+  t @skip(if: $skipIf) {
+    v2
+  }
+}
+
+type Query {
+  t: T
+}
+
+type T {
+  v1: Int
+  v2: String
+}
+"#;
+    let (schema, mut executable_document) =
+        apollo_compiler::parse_mixed(operation_one_field_with_directives, "document.graphql");
+    if let Some((_, operation)) = executable_document.named_operations.first_mut() {
+        let operation = operation.make_mut();
+        normalize_operation(operation, &schema, &executable_document.fragments);
+        let expected = r#"query Test($skipIf: Boolean!) {
+  t {
+    v1
+  }
+  t @skip(if: $skipIf) {
+    v2
+  }
+}"#;
+        let actual = format!("{}", operation);
+        assert_eq!(expected, actual);
+    } else {
+        panic!("unable to parse document")
+    }
+}
+
+#[test]
+fn do_not_merge_when_fields_have_different_directives() {
+    let operation_different_directives = r#"
+query Test($skip1: Boolean!, $skip2: Boolean!) {
+  t @skip(if: $skip1) {
+    v1
+  }
+  t @skip(if: $skip2) {
+    v2
+  }
+}
+
+type Query {
+  t: T
+}
+
+type T {
+  v1: Int
+  v2: String
+}
+"#;
+    let (schema, mut executable_document) =
+        apollo_compiler::parse_mixed(operation_different_directives, "document.graphql");
+    if let Some((_, operation)) = executable_document.named_operations.first_mut() {
+        let operation = operation.make_mut();
+        normalize_operation(operation, &schema, &executable_document.fragments);
+        let expected = r#"query Test($skip1: Boolean!, $skip2: Boolean!) {
+  t @skip(if: $skip1) {
+    v1
+  }
+  t @skip(if: $skip2) {
+    v2
+  }
+}"#;
+        let actual = format!("{}", operation);
+        assert_eq!(expected, actual);
+    } else {
+        panic!("unable to parse document")
+    }
+}
+
+#[test]
+fn do_not_merge_fields_with_defer_directive() {
+    //test('do not merge @defer directive, even if applied the same way', () => {
+    //       const operation = operationFromDocument(schema, gql`
+    //         query Test {
+    //           t @defer {
+    //             v1
+    //           }
+    //           t @defer {
+    //             v2
+    //           }
+    //         }
+    //       `);
+    //
+    //       expect(operation.toString()).toMatchString(`
+    //         query Test {
+    //           t @defer {
+    //             v1
+    //           }
+    //           t @defer {
+    //             v2
+    //           }
+    //         }
+    //       `);
+    //     });
+}
+
+///
+/// fragments
+///
+
+#[test]
+fn merge_same_fragment_without_directives() {
+    let operation_with_fragments = r#"
+query Test {
+  t {
+    ... on T {
+      v1
+    }
+    ... on T {
+      v2
+    }
+  }
+}
+
+type Query {
+  t: T
+}
+
+type T {
+  v1: Int
+  v2: String
+}
+"#;
+    let (schema, mut executable_document) =
+        apollo_compiler::parse_mixed(operation_with_fragments, "document.graphql");
+    if let Some((_, operation)) = executable_document.named_operations.first_mut() {
+        let operation = operation.make_mut();
+        normalize_operation(operation, &schema, &executable_document.fragments);
+        let expected = r#"query Test {
+  t {
+    ... on T {
+      v1
+      v2
+    }
+  }
+}"#;
+        let actual = format!("{}", operation);
+        assert_eq!(expected, actual);
+    } else {
+        panic!("unable to parse document")
+    }
+}
+
+#[test]
+fn merge_same_fragments_with_same_directives() {
+    let operation_fragments_with_directives = r#"
+query Test($skipIf: Boolean!) {
+  t {
+    ... on T @skip(if: $skipIf) {
+      v1
+    }
+    ... on T @skip(if: $skipIf) {
+      v2
+    }
+  }
+}
+
+type Query {
+  t: T
+}
+
+type T {
+  v1: Int
+  v2: String
+}
+"#;
+    let (schema, mut executable_document) =
+        apollo_compiler::parse_mixed(operation_fragments_with_directives, "document.graphql");
+    if let Some((_, operation)) = executable_document.named_operations.first_mut() {
+        let operation = operation.make_mut();
+        normalize_operation(operation, &schema, &executable_document.fragments);
+        let expected = r#"query Test($skipIf: Boolean!) {
+  t {
+    ... on T @skip(if: $skipIf) {
+      v1
+      v2
+    }
+  }
+}"#;
+        let actual = format!("{}", operation);
+        assert_eq!(expected, actual);
+    } else {
+        panic!("unable to parse document")
+    }
+}
+
+#[test]
+fn merge_same_fragments_with_same_directive_but_different_arg_order() {
+    //test('do merge when both have the _same_ directive, even if argument order differs', () => {
+    //       const operation = operationFromDocument(schema, gql`
+    //         query Test($skipIf: Boolean!) {
+    //           t {
+    //             ... on T @customSkip(if: $skipIf, label: "foo") {
+    //               v1
+    //             }
+    //             ... on T @customSkip(label: "foo", if: $skipIf) {
+    //               v2
+    //             }
+    //           }
+    //         }
+    //       `);
+    //
+    //       expect(operation.toString()).toMatchString(`
+    //         query Test($skipIf: Boolean!) {
+    //           t {
+    //             ... on T @customSkip(if: $skipIf, label: "foo") {
+    //               v1
+    //               v2
+    //             }
+    //           }
+    //         }
+    //       `);
+    //     });
+}
+
+#[test]
+fn do_not_merge_when_only_one_fragment_specifies_directive() {
+    let operation_one_fragment_with_directive = r#"
+query Test($skipIf: Boolean!) {
+  t {
+    ... on T {
+      v1
+    }
+    ... on T @skip(if: $skipIf) {
+      v2
+    }
+  }
+}
+
+type Query {
+  t: T
+}
+
+type T {
+  v1: Int
+  v2: String
+}
+"#;
+    let (schema, mut executable_document) =
+        apollo_compiler::parse_mixed(operation_one_fragment_with_directive, "document.graphql");
+    if let Some((_, operation)) = executable_document.named_operations.first_mut() {
+        let operation = operation.make_mut();
+        normalize_operation(operation, &schema, &executable_document.fragments);
+        let expected = r#"query Test($skipIf: Boolean!) {
+  t {
+    ... on T {
+      v1
+    }
+    ... on T @skip(if: $skipIf) {
+      v2
+    }
+  }
+}"#;
+        let actual = format!("{}", operation);
+        assert_eq!(expected, actual);
+    } else {
+        panic!("unable to parse document")
+    }
+}
+
+#[test]
+fn do_not_merge_when_fragments_have_different_directives() {
+    let operation_fragments_with_different_directive = r#"
+query Test($skip1: Boolean!, $skip2: Boolean!) {
+  t {
+    ... on T @skip(if: $skip1) {
+      v1
+    }
+    ... on T @skip(if: $skip2) {
+      v2
+    }
+  }
+}
+
+type Query {
+  t: T
+}
+
+type T {
+  v1: Int
+  v2: String
+}
+"#;
+    let (schema, mut executable_document) = apollo_compiler::parse_mixed(
+        operation_fragments_with_different_directive,
+        "document.graphql",
+    );
+    if let Some((_, operation)) = executable_document.named_operations.first_mut() {
+        let operation = operation.make_mut();
+        normalize_operation(operation, &schema, &executable_document.fragments);
+        let expected = r#"query Test($skip1: Boolean!, $skip2: Boolean!) {
+  t {
+    ... on T @skip(if: $skip1) {
+      v1
+    }
+    ... on T @skip(if: $skip2) {
+      v2
+    }
+  }
+}"#;
+        let actual = format!("{}", operation);
+        assert_eq!(expected, actual);
+    } else {
+        panic!("unable to parse document")
+    }
+}
+
+#[test]
+fn do_not_merge_fragments_with_defer_directive() {
+    //test('do not merge @defer directive, even if applied the same way', () => {
+    //       const operation = operationFromDocument(schema, gql`
+    //         query Test {
+    //           t {
+    //             ... on T @defer {
+    //               v1
+    //             }
+    //             ... on T @defer {
+    //               v2
+    //             }
+    //           }
+    //         }
+    //       `);
+    //
+    //       expect(operation.toString()).toMatchString(`
+    //         query Test {
+    //           t {
+    //             ... on T @defer {
+    //               v1
+    //             }
+    //             ... on T @defer {
+    //               v2
+    //             }
+    //           }
+    //         }
+    //       `);
+    //     });
+}

--- a/tests/query_plan/operation_tests.rs
+++ b/tests/query_plan/operation_tests.rs
@@ -101,8 +101,10 @@ type T {
   v2: String
 }
 "#;
-    let (schema, mut executable_document) =
-        apollo_compiler::parse_mixed(operation_with_directives_different_arg_order, "document.graphql");
+    let (schema, mut executable_document) = apollo_compiler::parse_mixed(
+        operation_with_directives_different_arg_order,
+        "document.graphql",
+    );
     if let Some((_, operation)) = executable_document.named_operations.first_mut() {
         let operation = operation.make_mut();
         normalize_operation(operation, &schema, &executable_document.fragments);
@@ -343,8 +345,10 @@ type T {
   v2: String
 }
 "#;
-    let (schema, mut executable_document) =
-        apollo_compiler::parse_mixed(operation_fragments_with_directives_args_order, "document.graphql");
+    let (schema, mut executable_document) = apollo_compiler::parse_mixed(
+        operation_fragments_with_directives_args_order,
+        "document.graphql",
+    );
     if let Some((_, operation)) = executable_document.named_operations.first_mut() {
         let operation = operation.make_mut();
         normalize_operation(operation, &schema, &executable_document.fragments);

--- a/tests/query_plan/operation_tests.rs
+++ b/tests/query_plan/operation_tests.rs
@@ -1,29 +1,6 @@
 use apollo_federation::query_plan::operation::normalize_operation;
 
 #[test]
-fn basic_operation() {
-    //test('forEachElement', () => {
-    //     // We collect a pair of (parent type, field-or-fragment).
-    //     const actual: [string, string][] = [];
-    //     operation.selectionSet.forEachElement((elt) => actual.push([elt.parentType.name, elt.toString()]));
-    //     expect(actual).toStrictEqual([
-    //       ['Query', 't'],
-    //       ['T', 'v1'],
-    //       ['T', 'v3'],
-    //       ['I', 'x'],
-    //       ['Query', 'i'],
-    //       ['I', '... on A'],
-    //       ['A', 'a1'],
-    //       ['A', 'a2'],
-    //       ['I', '... on B'],
-    //       ['B', 'y'],
-    //       ['B', 'b2'],
-    //       ['T', 'v2'],
-    //     ]);
-    //   })
-}
-
-#[test]
 fn merge_same_fields_without_directives() {
     let operation_string = r#"
 query Test {
@@ -103,27 +80,43 @@ type T {
 
 #[test]
 fn merge_same_fields_with_same_directive_but_different_arg_order() {
-    // test('do merge when both have the _same_ directive, even if argument order differs', () => {
-    //       const operation = operationFromDocument(schema, gql`
-    //         query Test($skipIf: Boolean!) {
-    //           t @customSkip(if: $skipIf, label: "foo") {
-    //             v1
-    //           }
-    //           t @customSkip(label: "foo", if: $skipIf) {
-    //             v2
-    //           }
-    //         }
-    //       `);
-    //
-    //       expect(operation.toString()).toMatchString(`
-    //         query Test($skipIf: Boolean!) {
-    //           t @customSkip(if: $skipIf, label: "foo") {
-    //             v1
-    //             v2
-    //           }
-    //         }
-    //       `);
-    //     });
+    let operation_with_directives_different_arg_order = r#"
+query Test($skipIf: Boolean!) {
+  t @customSkip(if: $skipIf, label: "foo") {
+    v1
+  }
+  t @customSkip(label: "foo", if: $skipIf) {
+    v2
+  }
+}
+
+directive @customSkip(if: Boolean!, label: String!) on FIELD | INLINE_FRAGMENT
+
+type Query {
+  t: T
+}
+
+type T {
+  v1: Int
+  v2: String
+}
+"#;
+    let (schema, mut executable_document) =
+        apollo_compiler::parse_mixed(operation_with_directives_different_arg_order, "document.graphql");
+    if let Some((_, operation)) = executable_document.named_operations.first_mut() {
+        let operation = operation.make_mut();
+        normalize_operation(operation, &schema, &executable_document.fragments);
+        let expected = r#"query Test($skipIf: Boolean!) {
+  t @customSkip(if: $skipIf, label: "foo") {
+    v1
+    v2
+  }
+}"#;
+        let actual = format!("{}", operation);
+        assert_eq!(expected, actual);
+    } else {
+        panic!("unable to parse document")
+    }
 }
 
 #[test]
@@ -210,6 +203,7 @@ type T {
 
 #[test]
 fn do_not_merge_fields_with_defer_directive() {
+    // TODO
     //test('do not merge @defer directive, even if applied the same way', () => {
     //       const operation = operationFromDocument(schema, gql`
     //         query Test {
@@ -238,7 +232,6 @@ fn do_not_merge_fields_with_defer_directive() {
 ///
 /// fragments
 ///
-
 #[test]
 fn merge_same_fragment_without_directives() {
     let operation_with_fragments = r#"
@@ -327,31 +320,47 @@ type T {
 
 #[test]
 fn merge_same_fragments_with_same_directive_but_different_arg_order() {
-    //test('do merge when both have the _same_ directive, even if argument order differs', () => {
-    //       const operation = operationFromDocument(schema, gql`
-    //         query Test($skipIf: Boolean!) {
-    //           t {
-    //             ... on T @customSkip(if: $skipIf, label: "foo") {
-    //               v1
-    //             }
-    //             ... on T @customSkip(label: "foo", if: $skipIf) {
-    //               v2
-    //             }
-    //           }
-    //         }
-    //       `);
-    //
-    //       expect(operation.toString()).toMatchString(`
-    //         query Test($skipIf: Boolean!) {
-    //           t {
-    //             ... on T @customSkip(if: $skipIf, label: "foo") {
-    //               v1
-    //               v2
-    //             }
-    //           }
-    //         }
-    //       `);
-    //     });
+    let operation_fragments_with_directives_args_order = r#"
+query Test($skipIf: Boolean!) {
+  t {
+    ... on T @customSkip(if: $skipIf, label: "foo") {
+      v1
+    }
+    ... on T @customSkip(label: "foo", if: $skipIf) {
+      v2
+    }
+  }
+}
+
+directive @customSkip(if: Boolean!, label: String!) on FIELD | INLINE_FRAGMENT
+
+type Query {
+  t: T
+}
+
+type T {
+  v1: Int
+  v2: String
+}
+"#;
+    let (schema, mut executable_document) =
+        apollo_compiler::parse_mixed(operation_fragments_with_directives_args_order, "document.graphql");
+    if let Some((_, operation)) = executable_document.named_operations.first_mut() {
+        let operation = operation.make_mut();
+        normalize_operation(operation, &schema, &executable_document.fragments);
+        let expected = r#"query Test($skipIf: Boolean!) {
+  t {
+    ... on T @customSkip(if: $skipIf, label: "foo") {
+      v1
+      v2
+    }
+  }
+}"#;
+        let actual = format!("{}", operation);
+        assert_eq!(expected, actual);
+    } else {
+        panic!("unable to parse document")
+    }
 }
 
 #[test]
@@ -448,6 +457,7 @@ type T {
 
 #[test]
 fn do_not_merge_fragments_with_defer_directive() {
+    // TODO
     //test('do not merge @defer directive, even if applied the same way', () => {
     //       const operation = operationFromDocument(schema, gql`
     //         query Test {

--- a/tests/query_plan/operation_validations_tests.rs
+++ b/tests/query_plan/operation_validations_tests.rs
@@ -1,0 +1,1035 @@
+///
+/// validations
+///
+
+#[test]
+fn reject_defer_on_mutation() {
+    //test.each([
+    //     { directive: '@defer', rootKind: 'mutation' },
+    //     { directive: '@defer', rootKind: 'subscription' },
+    //     { directive: '@stream', rootKind: 'mutation' },
+    //     { directive: '@stream', rootKind: 'subscription' },
+    //   ])('reject $directive on $rootKind type', ({ directive, rootKind }) => {
+    //     const schema = parseSchema(`
+    //       type Query {
+    //         x: String
+    //       }
+    //
+    //       type Mutation {
+    //         x: String
+    //       }
+    //
+    //       type Subscription {
+    //         x: String
+    //       }
+    //     `);
+    //
+    //     expect(() => {
+    //       parseOperation(schema, `
+    //         ${rootKind} {
+    //           ... ${directive} {
+    //             x
+    //           }
+    //         }
+    //       `)
+    //     }).toThrowError(new GraphQLError(`The @defer and @stream directives cannot be used on ${rootKind} root type "${defaultRootName(rootKind as SchemaRootKind)}"`));
+    //   });
+}
+
+#[test]
+fn reject_defer_on_subscription() {
+    // see reject_defer_on_mutation
+}
+
+#[test]
+fn reject_stream_on_mutation() {
+    // see reject_defer_on_mutation
+}
+
+#[test]
+fn reject_stream_on_subscription() {
+    //// see reject_defer_on_mutation
+}
+
+#[test]
+fn allows_nullable_variable_for_non_nullable_input_field_with_default() {
+    //test('allows nullable variable for non-nullable input field with default', () => {
+    //     const schema = parseSchema(`
+    //       input I {
+    //         x: Int! = 42
+    //       }
+    //
+    //       type Query {
+    //         f(i: I): Int
+    //       }
+    //     `);
+    //
+    //     // Just testing that this parse correctly and does not throw an exception.
+    //     parseOperation(schema, `
+    //       query test($x: Int) {
+    //         f(i: { x: $x })
+    //       }
+    //     `);
+    //   });
+}
+
+///
+/// conflicts
+///
+
+#[test]
+fn conflict_between_selection_and_reused_fragment() {
+    //test('due to conflict between selection and reused fragment', () => {
+    //       const schema = parseSchema(`
+    //         type Query {
+    //           t1: T1
+    //           i: I
+    //         }
+    //
+    //         interface I {
+    //           id: ID!
+    //         }
+    //
+    //         interface WithF {
+    //           f(arg: Int): Int
+    //         }
+    //
+    //         type T1 implements I {
+    //           id: ID!
+    //           f(arg: Int): Int
+    //         }
+    //
+    //         type T2 implements I & WithF {
+    //           id: ID!
+    //           f(arg: Int): Int
+    //         }
+    //       `);
+    //       const gqlSchema = schema.toGraphQLJSSchema();
+    //
+    //       const operation = parseOperation(schema, `
+    //         query {
+    //           t1 {
+    //             id
+    //             f(arg: 0)
+    //           }
+    //           i {
+    //             ...F1
+    //           }
+    //         }
+    //
+    //         fragment F1 on I {
+    //           id
+    //           ... on WithF {
+    //             f(arg: 1)
+    //           }
+    //         }
+    //       `);
+    //       expect(validate(gqlSchema, parse(operation.toString()))).toStrictEqual([]);
+    //
+    //       const withoutFragments = operation.expandAllFragments();
+    //       expect(withoutFragments.toString()).toMatchString(`
+    //         {
+    //           t1 {
+    //             id
+    //             f(arg: 0)
+    //           }
+    //           i {
+    //             id
+    //             ... on WithF {
+    //               f(arg: 1)
+    //             }
+    //           }
+    //         }
+    //       `);
+    //
+    //       // Note that technically, `t1` has return type `T1` which is a `I`, so `F1` can be spread
+    //       // within `t1`, and `t1 { ...F1 }` is just `t1 { id }` (because `T!` does not implement `WithF`),
+    //       // so that it would appear that it could be valid to optimize this query into:
+    //       //   {
+    //       //     t1 {
+    //       //       ...F1       // Notice the use of F1 here, which does expand to `id` in this context
+    //       //       f(arg: 0)
+    //       //     }
+    //       //     i {
+    //       //       ...F1
+    //       //     }
+    //       //   }
+    //       // And while doing this may look "dumb" in that toy example (we're replacing `id` with `...F1`
+    //       // which is longer so less optimal really), it's easy to expand this to example where re-using
+    //       // `F1` this way _does_ make things smaller.
+    //       //
+    //       // But the query above is actually invalid. And it is invalid because the validation of graphQL
+    //       // does not take into account the fact that the `... on WithF` part of `F1` is basically dead
+    //       // code within `t1`. And so it finds a conflict between `f(arg: 0)` and the `f(arg: 1)` in `F1`
+    //       // (even though, again, the later is statically known to never apply, but graphQL does not
+    //       // include such static analysis in its validation).
+    //       //
+    //       // And so this test does make sure we do not generate the query above (do not use `F1` in `t1`).
+    //       const optimized = withoutFragments.optimize(operation.fragments!, 1);
+    //       expect(validate(gqlSchema, parse(optimized.toString()))).toStrictEqual([]);
+    //
+    //       expect(optimized.toString()).toMatchString(`
+    //         fragment F1 on I {
+    //           id
+    //           ... on WithF {
+    //             f(arg: 1)
+    //           }
+    //         }
+    //
+    //         {
+    //           t1 {
+    //             id
+    //             f(arg: 0)
+    //           }
+    //           i {
+    //             ...F1
+    //           }
+    //         }
+    //       `);
+    //     });
+}
+
+#[test]
+fn conflict_between_reused_fragment_and_another_trimmed_fragment() {
+    //test('due to conflict between the active selection of a reused fragment and the trimmed part of another fragments', () => {
+    //       const schema = parseSchema(`
+    //         type Query {
+    //           t1: T1
+    //           i: I
+    //         }
+    //
+    //         interface I {
+    //           id: ID!
+    //         }
+    //
+    //         interface WithF {
+    //           f(arg: Int): Int
+    //         }
+    //
+    //         type T1 implements I {
+    //           id: ID!
+    //           f(arg: Int): Int
+    //         }
+    //
+    //         type T2 implements I & WithF {
+    //           id: ID!
+    //           f(arg: Int): Int
+    //         }
+    //       `);
+    //       const gqlSchema = schema.toGraphQLJSSchema();
+    //
+    //       const operation = parseOperation(schema, `
+    //         query {
+    //           t1 {
+    //             id
+    //             ...F1
+    //           }
+    //           i {
+    //             ...F2
+    //           }
+    //         }
+    //
+    //         fragment F1 on T1 {
+    //           f(arg: 0)
+    //         }
+    //
+    //         fragment F2 on I {
+    //           id
+    //           ... on WithF {
+    //             f(arg: 1)
+    //           }
+    //         }
+    //
+    //       `);
+    //       expect(validate(gqlSchema, parse(operation.toString()))).toStrictEqual([]);
+    //
+    //       const withoutFragments = operation.expandAllFragments();
+    //       expect(withoutFragments.toString()).toMatchString(`
+    //         {
+    //           t1 {
+    //             id
+    //             f(arg: 0)
+    //           }
+    //           i {
+    //             id
+    //             ... on WithF {
+    //               f(arg: 1)
+    //             }
+    //           }
+    //         }
+    //       `);
+    //
+    //       // See the comments on the previous test. The only different here is that `F1` is applied
+    //       // first, and then we need to make sure we do not apply `F2` even though it's restriction
+    //       // inside `t1` matches its selection set.
+    //       const optimized = withoutFragments.optimize(operation.fragments!, 1);
+    //       expect(validate(gqlSchema, parse(optimized.toString()))).toStrictEqual([]);
+    //
+    //       expect(optimized.toString()).toMatchString(`
+    //         fragment F1 on T1 {
+    //           f(arg: 0)
+    //         }
+    //
+    //         fragment F2 on I {
+    //           id
+    //           ... on WithF {
+    //             f(arg: 1)
+    //           }
+    //         }
+    //
+    //         {
+    //           t1 {
+    //             ...F1
+    //             id
+    //           }
+    //           i {
+    //             ...F2
+    //           }
+    //         }
+    //       `);
+    //     });
+}
+
+#[test]
+fn conflict_between_trimmed_parts_of_two_fragments() {
+    //test('due to conflict between the trimmed parts of 2 fragments', () => {
+    //       const schema = parseSchema(`
+    //         type Query {
+    //           t1: T1
+    //           i1: I
+    //           i2: I
+    //         }
+    //
+    //         interface I {
+    //           id: ID!
+    //           a: Int
+    //           b: Int
+    //         }
+    //
+    //         interface WithF {
+    //           f(arg: Int): Int
+    //         }
+    //
+    //         type T1 implements I {
+    //           id: ID!
+    //           a: Int
+    //           b: Int
+    //           f(arg: Int): Int
+    //         }
+    //
+    //         type T2 implements I & WithF {
+    //           id: ID!
+    //           a: Int
+    //           b: Int
+    //           f(arg: Int): Int
+    //         }
+    //       `);
+    //       const gqlSchema = schema.toGraphQLJSSchema();
+    //
+    //       const operation = parseOperation(schema, `
+    //         query {
+    //           t1 {
+    //             id
+    //             a
+    //             b
+    //           }
+    //           i1 {
+    //             ...F1
+    //           }
+    //           i2 {
+    //             ...F2
+    //           }
+    //         }
+    //
+    //         fragment F1 on I {
+    //           id
+    //           a
+    //           ... on WithF {
+    //             f(arg: 0)
+    //           }
+    //         }
+    //
+    //         fragment F2 on I {
+    //           id
+    //           b
+    //           ... on WithF {
+    //             f(arg: 1)
+    //           }
+    //         }
+    //
+    //       `);
+    //       expect(validate(gqlSchema, parse(operation.toString()))).toStrictEqual([]);
+    //
+    //       const withoutFragments = operation.expandAllFragments();
+    //       expect(withoutFragments.toString()).toMatchString(`
+    //         {
+    //           t1 {
+    //             id
+    //             a
+    //             b
+    //           }
+    //           i1 {
+    //             id
+    //             a
+    //             ... on WithF {
+    //               f(arg: 0)
+    //             }
+    //           }
+    //           i2 {
+    //             id
+    //             b
+    //             ... on WithF {
+    //               f(arg: 1)
+    //             }
+    //           }
+    //         }
+    //       `);
+    //
+    //       // Here, `F1` in `T1` reduces to `{ id a }` and F2 reduces to `{ id b }`, so theoretically both could be used
+    //       // within the first `T1` branch. But they can't both be used because their `... on WithF` part conflict,
+    //       // and even though that part is dead in `T1`, this would still be illegal graphQL.
+    //       const optimized = withoutFragments.optimize(operation.fragments!, 1);
+    //       expect(validate(gqlSchema, parse(optimized.toString()))).toStrictEqual([]);
+    //
+    //       expect(optimized.toString()).toMatchString(`
+    //         fragment F1 on I {
+    //           id
+    //           a
+    //           ... on WithF {
+    //             f(arg: 0)
+    //           }
+    //         }
+    //
+    //         fragment F2 on I {
+    //           id
+    //           b
+    //           ... on WithF {
+    //             f(arg: 1)
+    //           }
+    //         }
+    //
+    //         {
+    //           t1 {
+    //             ...F1
+    //             b
+    //           }
+    //           i1 {
+    //             ...F1
+    //           }
+    //           i2 {
+    //             ...F2
+    //           }
+    //         }
+    //       `);
+    //     });
+}
+
+#[test]
+fn conflict_between_selection_and_reused_fragment_at_different_level() {
+    // test('due to conflict between selection and reused fragment at different levels', () => {
+    //       const schema = parseSchema(`
+    //         type Query {
+    //           t1: SomeV
+    //           t2: SomeV
+    //         }
+    //
+    //         union SomeV = V1 | V2 | V3
+    //
+    //         type V1 {
+    //           x: String
+    //         }
+    //
+    //         type V2 {
+    //           y: String!
+    //         }
+    //
+    //         type V3 {
+    //           x: Int
+    //         }
+    //       `);
+    //       const gqlSchema = schema.toGraphQLJSSchema();
+    //
+    //       const operation = parseOperation(schema, `
+    //         fragment onV1V2 on SomeV {
+    //           ... on V1 {
+    //             x
+    //           }
+    //           ... on V2 {
+    //             y
+    //           }
+    //         }
+    //
+    //         query {
+    //           t1 {
+    //             ...onV1V2
+    //           }
+    //           t2 {
+    //             ... on V2 {
+    //               y
+    //             }
+    //             ... on V3 {
+    //               x
+    //             }
+    //           }
+    //         }
+    //       `);
+    //       expect(validate(gqlSchema, parse(operation.toString()))).toStrictEqual([]);
+    //
+    //       const withoutFragments = operation.expandAllFragments();
+    //       expect(withoutFragments.toString()).toMatchString(`
+    //         {
+    //           t1 {
+    //             ... on V1 {
+    //               x
+    //             }
+    //             ... on V2 {
+    //               y
+    //             }
+    //           }
+    //           t2 {
+    //             ... on V2 {
+    //               y
+    //             }
+    //             ... on V3 {
+    //               x
+    //             }
+    //           }
+    //         }
+    //       `);
+    //
+    //       const optimized = withoutFragments.optimize(operation.fragments!, 1);
+    //       expect(validate(gqlSchema, parse(optimized.toString()))).toStrictEqual([]);
+    //
+    //       expect(optimized.toString()).toMatchString(`
+    //         fragment onV1V2 on SomeV {
+    //           ... on V1 {
+    //             x
+    //           }
+    //           ... on V2 {
+    //             y
+    //           }
+    //         }
+    //
+    //         {
+    //           t1 {
+    //             ...onV1V2
+    //           }
+    //           t2 {
+    //             ... on V2 {
+    //               y
+    //             }
+    //             ... on V3 {
+    //               x
+    //             }
+    //           }
+    //         }
+    //       `);
+    //     });
+}
+
+#[test]
+fn conflict_between_fragments_at_different_levels() {
+    //test('due to conflict between the trimmed parts of 2 fragments at different levels', () => {
+    //       const schema = parseSchema(`
+    //         type Query {
+    //           t1: SomeV
+    //           t2: SomeV
+    //           t3: OtherV
+    //         }
+    //
+    //         union SomeV = V1 | V2 | V3
+    //         union OtherV = V3
+    //
+    //         type V1 {
+    //           x: String
+    //         }
+    //
+    //         type V2 {
+    //           x: Int
+    //         }
+    //
+    //         type V3 {
+    //           y: String!
+    //           z: String!
+    //         }
+    //       `);
+    //       const gqlSchema = schema.toGraphQLJSSchema();
+    //
+    //       const operation = parseOperation(schema, `
+    //         fragment onV1V3 on SomeV {
+    //           ... on V1 {
+    //             x
+    //           }
+    //           ... on V3 {
+    //             y
+    //           }
+    //         }
+    //
+    //         fragment onV2V3 on SomeV {
+    //           ... on V2 {
+    //             x
+    //           }
+    //           ... on V3 {
+    //             z
+    //           }
+    //         }
+    //
+    //         query {
+    //           t1 {
+    //             ...onV1V3
+    //           }
+    //           t2 {
+    //             ...onV2V3
+    //           }
+    //           t3 {
+    //             ... on V3 {
+    //               y
+    //               z
+    //             }
+    //           }
+    //         }
+    //       `);
+    //       expect(validate(gqlSchema, parse(operation.toString()))).toStrictEqual([]);
+    //
+    //       const withoutFragments = operation.expandAllFragments();
+    //       expect(withoutFragments.toString()).toMatchString(`
+    //         {
+    //           t1 {
+    //             ... on V1 {
+    //               x
+    //             }
+    //             ... on V3 {
+    //               y
+    //             }
+    //           }
+    //           t2 {
+    //             ... on V2 {
+    //               x
+    //             }
+    //             ... on V3 {
+    //               z
+    //             }
+    //           }
+    //           t3 {
+    //             ... on V3 {
+    //               y
+    //               z
+    //             }
+    //           }
+    //         }
+    //       `);
+    //
+    //       const optimized = withoutFragments.optimize(operation.fragments!, 1);
+    //       expect(validate(gqlSchema, parse(optimized.toString()))).toStrictEqual([]);
+    //
+    //       expect(optimized.toString()).toMatchString(`
+    //         fragment onV1V3 on SomeV {
+    //           ... on V1 {
+    //             x
+    //           }
+    //           ... on V3 {
+    //             y
+    //           }
+    //         }
+    //
+    //         fragment onV2V3 on SomeV {
+    //           ... on V2 {
+    //             x
+    //           }
+    //           ... on V3 {
+    //             z
+    //           }
+    //         }
+    //
+    //         {
+    //           t1 {
+    //             ...onV1V3
+    //           }
+    //           t2 {
+    //             ...onV2V3
+    //           }
+    //           t3 {
+    //             ...onV1V3
+    //             ... on V3 {
+    //               z
+    //             }
+    //           }
+    //         }
+    //       `);
+    //     });
+}
+
+#[test]
+fn conflict_between_two_sibling_branches() {
+    // test('due to conflict between 2 sibling branches', () => {
+    //       const schema = parseSchema(`
+    //         type Query {
+    //           t1: SomeV
+    //           i: I
+    //         }
+    //
+    //         interface I {
+    //           id: ID!
+    //         }
+    //
+    //         type T1 implements I {
+    //           id: ID!
+    //           t2: SomeV
+    //         }
+    //
+    //         type T2 implements I {
+    //           id: ID!
+    //           t2: SomeV
+    //         }
+    //
+    //         union SomeV = V1 | V2 | V3
+    //
+    //         type V1 {
+    //           x: String
+    //         }
+    //
+    //         type V2 {
+    //           y: String!
+    //         }
+    //
+    //         type V3 {
+    //           x: Int
+    //         }
+    //       `);
+    //       const gqlSchema = schema.toGraphQLJSSchema();
+    //
+    //       const operation = parseOperation(schema, `
+    //         fragment onV1V2 on SomeV {
+    //           ... on V1 {
+    //             x
+    //           }
+    //           ... on V2 {
+    //             y
+    //           }
+    //         }
+    //
+    //         query {
+    //           t1 {
+    //             ...onV1V2
+    //           }
+    //           i {
+    //             ... on T1 {
+    //               t2 {
+    //                 ... on V2 {
+    //                   y
+    //                 }
+    //               }
+    //             }
+    //             ... on T2 {
+    //               t2 {
+    //                 ... on V3 {
+    //                   x
+    //                 }
+    //               }
+    //             }
+    //           }
+    //         }
+    //       `);
+    //       expect(validate(gqlSchema, parse(operation.toString()))).toStrictEqual([]);
+    //
+    //       const withoutFragments = operation.expandAllFragments();
+    //       expect(withoutFragments.toString()).toMatchString(`
+    //         {
+    //           t1 {
+    //             ... on V1 {
+    //               x
+    //             }
+    //             ... on V2 {
+    //               y
+    //             }
+    //           }
+    //           i {
+    //             ... on T1 {
+    //               t2 {
+    //                 ... on V2 {
+    //                   y
+    //                 }
+    //               }
+    //             }
+    //             ... on T2 {
+    //               t2 {
+    //                 ... on V3 {
+    //                   x
+    //                 }
+    //               }
+    //             }
+    //           }
+    //         }
+    //       `);
+    //
+    //       const optimized = withoutFragments.optimize(operation.fragments!, 1);
+    //       expect(validate(gqlSchema, parse(optimized.toString()))).toStrictEqual([]);
+    //
+    //       expect(optimized.toString()).toMatchString(`
+    //         fragment onV1V2 on SomeV {
+    //           ... on V1 {
+    //             x
+    //           }
+    //           ... on V2 {
+    //             y
+    //           }
+    //         }
+    //
+    //         {
+    //           t1 {
+    //             ...onV1V2
+    //           }
+    //           i {
+    //             ... on T1 {
+    //               t2 {
+    //                 ... on V2 {
+    //                   y
+    //                 }
+    //               }
+    //             }
+    //             ... on T2 {
+    //               t2 {
+    //                 ... on V3 {
+    //                   x
+    //                 }
+    //               }
+    //             }
+    //           }
+    //         }
+    //       `);
+    //     });
+}
+
+#[test]
+fn conflict_when_inline_fragment_should_be_normalized() {
+    //  test('when a spread inside an expanded fragment should be "normalized away"', () => {
+    //       const schema = parseSchema(`
+    //         type Query {
+    //           t1: T1
+    //           i: I
+    //         }
+    //
+    //         interface I {
+    //           id: ID!
+    //         }
+    //
+    //         type T1 implements I {
+    //           id: ID!
+    //           a: Int
+    //         }
+    //
+    //         type T2 implements I {
+    //           id: ID!
+    //           b: Int
+    //           c: Int
+    //         }
+    //       `);
+    //       const gqlSchema = schema.toGraphQLJSSchema();
+    //
+    //       const operation = parseOperation(schema, `
+    //         {
+    //           t1 {
+    //             ...GetAll
+    //           }
+    //           i {
+    //             ...GetT2
+    //           }
+    //         }
+    //
+    //         fragment GetAll on I {
+    //            ... on T1 {
+    //              a
+    //            }
+    //            ...GetT2
+    //            ... on T2 {
+    //              c
+    //            }
+    //         }
+    //
+    //         fragment GetT2 on T2 {
+    //            b
+    //         }
+    //       `);
+    //       expect(validate(gqlSchema, parse(operation.toString()))).toStrictEqual([]);
+    //
+    //       const withoutFragments = operation.expandAllFragments();
+    //       expect(withoutFragments.toString()).toMatchString(`
+    //         {
+    //           t1 {
+    //             a
+    //           }
+    //           i {
+    //             ... on T2 {
+    //               b
+    //             }
+    //           }
+    //         }
+    //       `);
+    //
+    //       // As we re-optimize, we will initially generated the initial query. But
+    //       // as we ask to only optimize fragments used more than once, the `GetAll`
+    //       // fragment will be re-expanded (`GetT2` will not because the code will say
+    //       // that it is used both in the expanded `GetAll` but also inside `i`).
+    //       // But because `GetAll` is within `t1: T1`, that expansion should actually
+    //       // get rid of anything `T2`-related.
+    //       // This test exists because a previous version of the code was not correctly
+    //       // "getting rid" of the `...GetT2` spread, keeping in the query, which is
+    //       // invalid (we cannot have `...GetT2` inside `t1`).
+    //       const optimized = withoutFragments.optimize(operation.fragments!, 2);
+    //       expect(validate(gqlSchema, parse(optimized.toString()))).toStrictEqual([]);
+    //
+    //       expect(optimized.toString()).toMatchString(`
+    //         fragment GetT2 on T2 {
+    //           b
+    //         }
+    //
+    //         {
+    //           t1 {
+    //             a
+    //           }
+    //           i {
+    //             ...GetT2
+    //           }
+    //         }
+    //       `);
+    //     });
+}
+
+#[test]
+fn conflict_due_to_trimmed_selections_of_nested_fragments() {
+    //test('due to the trimmed selection of nested fragments', () => {
+    //       const schema = parseSchema(`
+    //         type Query {
+    //           u1: U
+    //           u2: U
+    //           u3: U
+    //         }
+    //
+    //         union U = S | T
+    //
+    //         type T  {
+    //           id: ID!
+    //           vt: Int
+    //         }
+    //
+    //         interface I {
+    //           vs: Int
+    //         }
+    //
+    //         type S implements I {
+    //           vs: Int!
+    //         }
+    //       `);
+    //       const gqlSchema = schema.toGraphQLJSSchema();
+    //
+    //       const operation = parseOperation(schema, `
+    //         {
+    //           u1 {
+    //             ...F1
+    //           }
+    //           u2 {
+    //             ...F3
+    //           }
+    //           u3 {
+    //             ...F3
+    //           }
+    //         }
+    //
+    //         fragment F1 on U {
+    //            ... on S {
+    //              __typename
+    //              vs
+    //            }
+    //            ... on T {
+    //              __typename
+    //              vt
+    //            }
+    //         }
+    //
+    //         fragment F2 on T {
+    //            __typename
+    //            vt
+    //         }
+    //
+    //         fragment F3 on U {
+    //            ... on I {
+    //              vs
+    //            }
+    //            ...F2
+    //         }
+    //       `);
+    //       expect(validate(gqlSchema, parse(operation.toString()))).toStrictEqual([]);
+    //
+    //       const withoutFragments = operation.expandAllFragments();
+    //       expect(withoutFragments.toString()).toMatchString(`
+    //         {
+    //           u1 {
+    //             ... on S {
+    //               __typename
+    //               vs
+    //             }
+    //             ... on T {
+    //               __typename
+    //               vt
+    //             }
+    //           }
+    //           u2 {
+    //             ... on I {
+    //               vs
+    //             }
+    //             ... on T {
+    //               __typename
+    //               vt
+    //             }
+    //           }
+    //           u3 {
+    //             ... on I {
+    //               vs
+    //             }
+    //             ... on T {
+    //               __typename
+    //               vt
+    //             }
+    //           }
+    //         }
+    //       `);
+    //
+    //       // We use `mapToExpandedSelectionSets` with a no-op mapper because this will still expand the selections
+    //       // and re-optimize them, which 1) happens to match what happens in the query planner and 2) is necessary
+    //       // for reproducing a bug that this test was initially added to cover.
+    //       const newFragments = operation.fragments!.mapToExpandedSelectionSets((s) => s);
+    //       const optimized = withoutFragments.optimize(newFragments, 2);
+    //       expect(validate(gqlSchema, parse(optimized.toString()))).toStrictEqual([]);
+    //
+    //       expect(optimized.toString()).toMatchString(`
+    //         fragment F3 on U {
+    //           ... on I {
+    //             vs
+    //           }
+    //           ... on T {
+    //             __typename
+    //             vt
+    //           }
+    //         }
+    //
+    //         {
+    //           u1 {
+    //             ... on S {
+    //               __typename
+    //               vs
+    //             }
+    //             ... on T {
+    //               __typename
+    //               vt
+    //             }
+    //           }
+    //           u2 {
+    //             ...F3
+    //           }
+    //           u3 {
+    //             ...F3
+    //           }
+    //         }
+    //       `);
+    //     });
+}

--- a/tests/query_plan/operation_validations_tests.rs
+++ b/tests/query_plan/operation_validations_tests.rs
@@ -51,28 +51,6 @@ fn reject_stream_on_subscription() {
     //// see reject_defer_on_mutation
 }
 
-#[test]
-fn allows_nullable_variable_for_non_nullable_input_field_with_default() {
-    //test('allows nullable variable for non-nullable input field with default', () => {
-    //     const schema = parseSchema(`
-    //       input I {
-    //         x: Int! = 42
-    //       }
-    //
-    //       type Query {
-    //         f(i: I): Int
-    //       }
-    //     `);
-    //
-    //     // Just testing that this parse correctly and does not throw an exception.
-    //     parseOperation(schema, `
-    //       query test($x: Int) {
-    //         f(i: { x: $x })
-    //       }
-    //     `);
-    //   });
-}
-
 ///
 /// conflicts
 ///


### PR DESCRIPTION
Initial version of operation normalization logic that auto-expands all fragments, deduplicates the fields and removes top level introspection fields.

related: #88 