### PR TITLE
Replace name conversion functions with error conversion impls

### DIFF
--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1,4 +1,4 @@
-use apollo_compiler::schema::Name;
+use apollo_compiler::ast::InvalidNameError;
 use lazy_static::lazy_static;
 use std::fmt::{Display, Formatter, Write};
 
@@ -352,15 +352,18 @@ impl SingleFederationError {
     }
 }
 
-// TODO: Once InvalidNameError includes the invalid name in the error, we can replace this with an
-// implementation for From<InvalidNameError>.
-pub(crate) fn graphql_name(name: &str) -> Result<Name, FederationError> {
-    Name::new(name).map_err(|_| {
+impl From<InvalidNameError> for SingleFederationError {
+    fn from(err: InvalidNameError) -> Self {
         SingleFederationError::InvalidGraphQL {
-            message: format!("Invalid GraphQL name \"{}\"", name,),
+            message: format!("Invalid GraphQL name \"{}\"", err.0),
         }
-        .into()
-    })
+    }
+}
+
+impl From<InvalidNameError> for FederationError {
+    fn from(err: InvalidNameError) -> Self {
+        SingleFederationError::from(err).into()
+    }
 }
 
 #[derive(Debug, Clone, thiserror::Error)]

--- a/src/link/spec_definition.rs
+++ b/src/link/spec_definition.rs
@@ -1,4 +1,4 @@
-use crate::error::{graphql_name, FederationError, SingleFederationError};
+use crate::error::{FederationError, SingleFederationError};
 use crate::link::spec::{Identity, Url, Version};
 use crate::link::Link;
 use crate::schema::FederationSchema;
@@ -62,7 +62,9 @@ pub(crate) trait SpecDefinition {
         let Some(link) = self.link_in_schema(schema)? else {
             return Ok(None);
         };
-        graphql_name(&link.directive_name_in_schema(name_in_spec)).map(Some)
+        Ok(Some(
+            link.directive_name_in_schema(name_in_spec).try_into()?,
+        ))
     }
 
     fn type_name_in_schema(
@@ -73,7 +75,7 @@ pub(crate) trait SpecDefinition {
         let Some(link) = self.link_in_schema(schema)? else {
             return Ok(None);
         };
-        graphql_name(&link.type_name_in_schema(name_in_spec)).map(Some)
+        Ok(Some(link.type_name_in_schema(name_in_spec).try_into()?))
     }
 
     fn directive_definition<'schema>(

--- a/src/query_graph/extract_subgraphs_from_supergraph.rs
+++ b/src/query_graph/extract_subgraphs_from_supergraph.rs
@@ -1,4 +1,4 @@
-use crate::error::{graphql_name, FederationError, SingleFederationError};
+use crate::error::{FederationError, SingleFederationError};
 use crate::link::federation_spec_definition::{FederationSpecDefinition, FEDERATION_VERSIONS};
 use crate::link::join_spec_definition::{
     FieldDirectiveArguments, JoinSpecDefinition, TypeDirectiveArguments, JOIN_VERSIONS,
@@ -727,7 +727,7 @@ fn extract_object_type_content(
             )?;
             pos.insert_implements_interface(
                 &mut subgraph.schema,
-                ComponentName::from(graphql_name(&implements_directive_application.interface)?),
+                ComponentName::from(Name::new(implements_directive_application.interface)?),
             )?;
         }
 
@@ -916,7 +916,7 @@ fn extract_interface_type_content(
                 ObjectOrInterfaceTypeDefinitionPosition::Object(pos) => {
                     pos.insert_implements_interface(
                         &mut subgraph.schema,
-                        ComponentName::from(graphql_name(
+                        ComponentName::from(Name::new(
                             &implements_directive_application.interface,
                         )?),
                     )?;
@@ -924,7 +924,7 @@ fn extract_interface_type_content(
                 ObjectOrInterfaceTypeDefinitionPosition::Interface(pos) => {
                     pos.insert_implements_interface(
                         &mut subgraph.schema,
-                        ComponentName::from(graphql_name(
+                        ComponentName::from(Name::new(
                             &implements_directive_application.interface,
                         )?),
                     )?;
@@ -1099,7 +1099,7 @@ fn extract_union_type_content(
                 // broken @join__unionMember).
                 pos.insert_member(
                     &mut subgraph.schema,
-                    ComponentName::from(graphql_name(&union_member_directive_application.member)?),
+                    ComponentName::from(Name::new(&union_member_directive_application.member)?),
                 )?;
             }
         }

--- a/src/schema/position.rs
+++ b/src/schema/position.rs
@@ -1,4 +1,4 @@
-use crate::error::{graphql_name, FederationError, SingleFederationError};
+use crate::error::{FederationError, SingleFederationError};
 use crate::link::database::links_metadata;
 use crate::link::spec_definition::SpecDefinition;
 use crate::schema::referencer::{
@@ -559,7 +559,7 @@ impl SchemaDefinitionPosition {
                 let link_name_in_schema = link_spec_definition
                     .directive_name_in_schema(
                         schema,
-                        &graphql_name(&link_spec_definition.identity().name)?,
+                        &Name::new(&link_spec_definition.identity().name)?,
                     )?
                     .ok_or_else(|| SingleFederationError::Internal {
                         message: "Unexpectedly could not find core/link spec usage".to_owned(),


### PR DESCRIPTION
`InvalidNameError` now contains the input string since compiler beta 7.