### PR TITLE
feat: Inter-subgraph logic of federated query graph creation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ autotests = false # Integration tests are modules of tests/main.rs
 
 [dependencies]
 apollo-compiler = "=1.0.0-beta.7"
+derive_more = "0.99.17"
 salsa = "0.16.1"
 indexmap = "2.0.2"
 thiserror = "1.0"

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -371,6 +371,22 @@ pub struct MultipleFederationErrors {
     pub errors: Vec<SingleFederationError>,
 }
 
+impl MultipleFederationErrors {
+    pub fn push(&mut self, error: FederationError) {
+        match error {
+            FederationError::SingleFederationError(error) => {
+                self.errors.push(error);
+            }
+            FederationError::MultipleFederationErrors(errors) => {
+                self.errors.extend(errors.errors);
+            }
+            FederationError::AggregateFederationError(errors) => {
+                self.errors.extend(errors.causes);
+            }
+        }
+    }
+}
+
 impl Display for MultipleFederationErrors {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "The following errors occurred:")?;

--- a/src/query_graph/build_query_graph.rs
+++ b/src/query_graph/build_query_graph.rs
@@ -18,11 +18,10 @@ use crate::schema::FederationSchema;
 use apollo_compiler::executable::{Selection, SelectionSet};
 use apollo_compiler::schema::{DirectiveList as ComponentDirectiveList, ExtendedType, Name};
 use apollo_compiler::{Node, NodeStr, Schema};
-use indexmap::{Equivalent, IndexMap, IndexSet};
+use indexmap::{IndexMap, IndexSet};
 use petgraph::graph::{EdgeIndex, NodeIndex};
 use petgraph::visit::EdgeRef;
 use petgraph::Direction;
-use std::hash::Hash;
 use std::sync::Arc;
 use strum::IntoEnumIterator;
 
@@ -1943,13 +1942,10 @@ impl FederatedQueryGraphBuilderSubgraphs {
         Ok(subgraphs)
     }
 
-    fn get<Q: ?Sized>(
+    fn get(
         &self,
-        source: &Q,
-    ) -> Result<&FederatedQueryGraphBuilderSubgraphData, FederationError>
-    where
-        Q: Hash + Equivalent<NodeStr>,
-    {
+        source: &str,
+    ) -> Result<&FederatedQueryGraphBuilderSubgraphData, FederationError> {
         self.map.get(source).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: "Subgraph data unexpectedly missing".to_owned(),

--- a/src/query_graph/build_query_graph.rs
+++ b/src/query_graph/build_query_graph.rs
@@ -26,12 +26,12 @@ use std::hash::Hash;
 use std::sync::Arc;
 use strum::IntoEnumIterator;
 
-// Builds a "federated" query graph based on the provided supergraph and API schema.
-//
-// A federated query graph is one that is used to reason about queries made by a router against a
-// set of federated subgraph services.
-//
-// Assumes the given schemas have been validated.
+/// Builds a "federated" query graph based on the provided supergraph and API schema.
+///
+/// A federated query graph is one that is used to reason about queries made by a router against a
+/// set of federated subgraph services.
+///
+/// Assumes the given schemas have been validated.
 pub fn build_federated_query_graph(
     supergraph_schema: Arc<FederationSchema>,
     api_schema: Arc<FederationSchema>,
@@ -195,8 +195,8 @@ struct SchemaQueryGraphBuilderSubgraphData {
 }
 
 impl SchemaQueryGraphBuilder {
-    // If api_schema is given, then this builder assumes the schema is a subgraph schema, and that
-    // a subgraph query graph is being built.
+    /// If api_schema is given, then this builder assumes the schema is a subgraph schema, and that
+    /// a subgraph query graph is being built.
     fn new(
         query_graph: QueryGraph,
         source: NodeStr,
@@ -264,12 +264,12 @@ impl SchemaQueryGraphBuilder {
         })
     }
 
-    // Adds a node for the provided root object type (marking that node as a root node for the
-    // provided `kind`) and recursively descends into the type definition to add the related nodes
-    // and edges.
-    //
-    // In other words, calling this method on, say, the root query type of a schema will add nodes
-    // and edges for all the types reachable from that root query type.
+    /// Adds a node for the provided root object type (marking that node as a root node for the
+    /// provided `kind`) and recursively descends into the type definition to add the related nodes
+    /// and edges.
+    ///
+    /// In other words, calling this method on, say, the root query type of a schema will add nodes
+    /// and edges for all the types reachable from that root query type.
     fn add_recursively_from_root(
         &mut self,
         root: SchemaRootDefinitionPosition,
@@ -296,9 +296,9 @@ impl SchemaQueryGraphBuilder {
         self.base.set_as_root(node, root.root_kind.clone())
     }
 
-    // Adds in a node for the provided type in the in-building query graph, and recursively adds
-    // edges and nodes corresponding to the type definition (so for object types, it will add edges
-    // for each field and recursively add nodes for each field's type, etc...).
+    /// Adds in a node for the provided type in the in-building query graph, and recursively adds
+    /// edges and nodes corresponding to the type definition (so for object types, it will add edges
+    /// for each field and recursively add nodes for each field's type, etc...).
     fn add_type_recursively(
         &mut self,
         output_type_definition_position: OutputTypeDefinitionPosition,
@@ -579,72 +579,72 @@ impl SchemaQueryGraphBuilder {
         Ok(())
     }
 
-    // We've added edges that avoid type-explosion _directly_ from an interface, but it means that
-    // so far we always type-explode unions to all their implementation types, and always
-    // type-explode when we go through 2 unrelated interfaces. For instance, say we have
-    // ```
-    // type Query {
-    //   i1: I1
-    //   i2: I2
-    //   u: U
-    // }
-    //
-    // interface I1 {
-    //   x: Int
-    // }
-    //
-    // interface I2 {
-    //   y: Int
-    // }
-    //
-    // type A implements I1 & I2 {
-    //   x: Int
-    //   y: Int
-    // }
-    //
-    // type B implements I1 & I2 {
-    //   x: Int
-    //   y: Int
-    // }
-    //
-    // union U = A | B
-    // ```
-    // If we query:
-    // ```
-    // {
-    //   u {
-    //     ... on I1 {
-    //       x
-    //     }
-    //   }
-    // }
-    // ```
-    // then we currently have no edge between `U` and `I1` whatsoever, so query planning would have
-    // to type-explode `U` even though that's not necessary (assuming everything is in the same
-    // subgraph, we'd want to send the query "as-is").
-    // Same thing for:
-    // ```
-    // {
-    //   i1 {
-    //     x
-    //     ... on I2 {
-    //       y
-    //     }
-    //   }
-    // }
-    // ```
-    // due to not having edges from `I1` to `I2` (granted, in that example, type-exploding is not
-    // all that worse, but it gets worse with more implementations/fields).
-    //
-    // And so this method is about adding such edges. Essentially, every time 2 abstract types have
-    // an intersection of runtime types > 1, we add an edge.
-    //
-    // Do note that in practice we only add those edges when we build a query graph for query
-    // planning purposes, because not type-exploding is only an optimization but type-exploding will
-    // always "work" and for composition validation, we don't care about being optimal, while
-    // limiting edges make validation faster by limiting the choices to explore. Also, query
-    // planning is careful, as it walks those edges, to compute the actual possible runtime types we
-    // could have to avoid later type-exploding in impossible runtime types.
+    /// We've added edges that avoid type-explosion _directly_ from an interface, but it means that
+    /// so far we always type-explode unions to all their implementation types, and always
+    /// type-explode when we go through 2 unrelated interfaces. For instance, say we have
+    /// ```graphql
+    /// type Query {
+    ///   i1: I1
+    ///   i2: I2
+    ///   u: U
+    /// }
+    ///
+    /// interface I1 {
+    ///   x: Int
+    /// }
+    ///
+    /// interface I2 {
+    ///   y: Int
+    /// }
+    ///
+    /// type A implements I1 & I2 {
+    ///   x: Int
+    ///   y: Int
+    /// }
+    ///
+    /// type B implements I1 & I2 {
+    ///   x: Int
+    ///   y: Int
+    /// }
+    ///
+    /// union U = A | B
+    /// ```
+    /// If we query:
+    /// ```graphql
+    /// {
+    ///   u {
+    ///     ... on I1 {
+    ///       x
+    ///     }
+    ///   }
+    /// }
+    /// ```
+    /// then we currently have no edge between `U` and `I1` whatsoever, so query planning would have
+    /// to type-explode `U` even though that's not necessary (assuming everything is in the same
+    /// subgraph, we'd want to send the query "as-is").
+    /// Same thing for:
+    /// ```graphql
+    /// {
+    ///   i1 {
+    ///     x
+    ///     ... on I2 {
+    ///       y
+    ///     }
+    ///   }
+    /// }
+    /// ```
+    /// due to not having edges from `I1` to `I2` (granted, in that example, type-exploding is not
+    /// all that worse, but it gets worse with more implementations/fields).
+    ///
+    /// And so this method is about adding such edges. Essentially, every time 2 abstract types have
+    /// an intersection of runtime types > 1, we add an edge.
+    ///
+    /// Do note that in practice we only add those edges when we build a query graph for query
+    /// planning purposes, because not type-exploding is only an optimization but type-exploding
+    /// will always "work" and for composition validation, we don't care about being optimal, while
+    /// limiting edges make validation faster by limiting the choices to explore. Also, query
+    /// planning is careful, as it walks those edges, to compute the actual possible runtime types
+    /// we could have to avoid later type-exploding in impossible runtime types.
     fn add_additional_abstract_type_edges(&mut self) -> Result<(), FederationError> {
         // As mentioned above, we only care about this on subgraph query graphs during query
         // planning. But if this ever gets called in some other code path, ignore this.
@@ -831,24 +831,24 @@ impl SchemaQueryGraphBuilder {
         Ok(())
     }
 
-    // In a subgraph, all entity object types will be "automatically" reachable (from the root query
-    // type) because of the `_entities` field (it returns `_Entity`, which is a union of all entity
-    // object types, making those reachable.
-    //
-    // However, we also want entity interface types (interfaces with an @key) to be reachable in a
-    // similar way, because the `_entities` field is also technically the one resolving them, and
-    // not having them reachable would break plenty of code that assume that by traversing a query
-    // graph from root, we get to everything that can be queried.
-    //
-    // But because GraphQL unions cannot have interface types, they are not part of the `_Entity`
-    // union (and cannot be). This is ok as far as the typing of the schema goes, because even when
-    // `_entities` is called to resolve an interface type, it technically returns a concrete object,
-    // and so, since every implementation of an entity interface is also an entity, this is captured
-    // by the `_Entity` union.
-    //
-    // But it does mean we want to manually add the corresponding edges now for interfaces, or
-    // @key on interfaces wouldn't work properly (at least, when the interface is not otherwise
-    // reachable by an operation on the subgraph).
+    /// In a subgraph, all entity object types will be "automatically" reachable (from the root
+    /// query type) because of the `_entities` field (it returns `_Entity`, which is a union of all
+    /// entity object types, making those reachable.
+    ///
+    /// However, we also want entity interface types (interfaces with an @key) to be reachable in a
+    /// similar way, because the `_entities` field is also technically the one resolving them, and
+    /// not having them reachable would break plenty of code that assume that by traversing a query
+    /// graph from root, we get to everything that can be queried.
+    ///
+    /// But because GraphQL unions cannot have interface types, they are not part of the `_Entity`
+    /// union (and cannot be). This is ok as far as the typing of the schema goes, because even when
+    /// `_entities` is called to resolve an interface type, it technically returns a concrete
+    /// object, and so, since every implementation of an entity interface is also an entity, this is
+    /// captured by the `_Entity` union.
+    ///
+    /// But it does mean we want to manually add the corresponding edges now for interfaces, or @key
+    /// on interfaces wouldn't work properly (at least, when the interface is not otherwise
+    /// reachable by an operation on the subgraph).
     fn add_interface_entity_edges(&mut self) -> Result<(), FederationError> {
         let Some(subgraph) = &self.subgraph else {
             return Err(SingleFederationError::Internal {
@@ -994,10 +994,10 @@ impl FederatedQueryGraphBuilder {
         Ok(())
     }
 
-    // Add the edges from supergraph roots to the subgraph ones. Also, for each root kind, we also
-    // add edges from the corresponding root type of each subgraph to the root type of other
-    // subgraphs (and for @defer, like for @key, we also add self-node loops). This encodes the fact
-    // that if a field returns a root type, we can always query any subgraph from that point.
+    /// Add the edges from supergraph roots to the subgraph ones. Also, for each root kind, we also
+    /// add edges from the corresponding root type of each subgraph to the root type of other
+    /// subgraphs (and for @defer, like for @key, we also add self-node loops). This encodes the
+    /// fact that if a field returns a root type, we can always query any subgraph from that point.
     fn add_root_edges(&mut self) -> Result<(), FederationError> {
         let mut new_edges = Vec::new();
         for (source, root_kinds_to_nodes) in &self.base.query_graph.root_kinds_to_nodes_by_source {
@@ -1044,7 +1044,7 @@ impl FederatedQueryGraphBuilder {
         Ok(())
     }
 
-    // Handle @key by adding the appropriate key-resolution edges.
+    /// Handle @key by adding the appropriate key-resolution edges.
     fn handle_key(&mut self) -> Result<(), FederationError> {
         // We'll look at adding edges from "other subgraphs" to the current type. So the tail of
         // all the edges we'll build here is always going to be the same.
@@ -1253,7 +1253,7 @@ impl FederatedQueryGraphBuilder {
         Ok(())
     }
 
-    // Handle @requires by updating the appropriate field-collecting edges.
+    /// Handle @requires by updating the appropriate field-collecting edges.
     fn handle_requires(&mut self) -> Result<(), FederationError> {
         // We'll look at any field-collecting edges with @requires and adding their conditions to
         // those edges.
@@ -1322,7 +1322,7 @@ impl FederatedQueryGraphBuilder {
         Ok(())
     }
 
-    // Handle @provides by copying the appropriate nodes/edges.
+    /// Handle @provides by copying the appropriate nodes/edges.
     fn handle_provides(&mut self) -> Result<(), FederationError> {
         let mut provide_id = 0;
         for edge in self.base.query_graph.graph.edge_indices() {
@@ -1609,7 +1609,7 @@ impl FederatedQueryGraphBuilder {
         Ok(())
     }
 
-    // Copies the given node and its outgoing edges, returning the new node's index.
+    /// Copies the given node and its outgoing edges, returning the new node's index.
     fn copy_for_provides(
         base: &mut BaseQueryGraphBuilder,
         node: NodeIndex,
@@ -1673,7 +1673,7 @@ impl FederatedQueryGraphBuilder {
         Ok((new_node, type_pos))
     }
 
-    // Handle @interfaceObject by adding the appropriate fake-downcast self-edges.
+    /// Handle @interfaceObject by adding the appropriate fake-downcast self-edges.
     fn handle_interface_object(&mut self) -> Result<(), FederationError> {
         // There are cases where only an/some implementation(s) of an interface are queried, and
         // that could apply to an interface that is an @interfaceObject in some subgraph. Consider
@@ -1806,7 +1806,7 @@ impl FederatedQueryGraphBuilder {
         Ok(())
     }
 
-    // Precompute which followup edges for a given edge are non-trivial.
+    /// Precompute which followup edges for a given edge are non-trivial.
     fn precompute_non_trivial_followup_edges(&mut self) -> Result<(), FederationError> {
         for edge in self.base.query_graph.graph.edge_indices() {
             let edge_weight = self.base.query_graph.edge_weight(edge)?;

--- a/src/query_graph/build_query_graph.rs
+++ b/src/query_graph/build_query_graph.rs
@@ -1104,7 +1104,7 @@ impl FederatedQueryGraphBuilder {
                 };
                 let conditions = Node::new(parse_field_set(
                     schema.schema(),
-                    type_pos.clone().into(),
+                    type_pos.type_name().clone(),
                     application.fields.clone(),
                 )?);
 
@@ -1227,7 +1227,9 @@ impl FederatedQueryGraphBuilder {
                                 other_schema.get_type(implementation_type_in_supergraph_pos.type_name.clone())?.try_into()?;
                             let Ok(implementation_conditions) = parse_field_set(
                                 other_schema.schema(),
-                                implementation_type_in_other_subgraph_pos.clone(),
+                                implementation_type_in_other_subgraph_pos
+                                    .type_name()
+                                    .clone(),
                                 application.fields.clone(),
                             ) else {
                                 // Ignored on purpose: it just means the key is not usable on this
@@ -1292,7 +1294,7 @@ impl FederatedQueryGraphBuilder {
                     .requires_directive_arguments(directive)?;
                 let conditions = parse_field_set(
                     schema.schema(),
-                    field_definition_position.parent().clone(),
+                    field_definition_position.parent().type_name().clone(),
                     application.fields,
                 )?;
                 all_conditions.push(conditions);
@@ -1351,8 +1353,11 @@ impl FederatedQueryGraphBuilder {
                     .provides_directive_arguments(directive)?;
                 let field_type_pos: CompositeTypeDefinitionPosition =
                     field_type_pos.clone().try_into()?;
-                let conditions =
-                    parse_field_set(schema.schema(), field_type_pos, application.fields)?;
+                let conditions = parse_field_set(
+                    schema.schema(),
+                    field_type_pos.type_name().clone(),
+                    application.fields,
+                )?;
                 all_conditions.push(conditions);
             }
             if all_conditions.is_empty() {
@@ -1774,7 +1779,7 @@ impl FederatedQueryGraphBuilder {
                 };
                 let conditions = Node::new(parse_field_set(
                     schema.schema(),
-                    type_in_supergraph_pos.clone().into(),
+                    type_in_supergraph_pos.type_name.clone(),
                     NodeStr::from_static(&"__typename"),
                 )?);
                 for implementation_type_in_supergraph_pos in self

--- a/src/query_graph/build_query_graph.rs
+++ b/src/query_graph/build_query_graph.rs
@@ -1,27 +1,28 @@
 use crate::error::{FederationError, SingleFederationError};
 use crate::link::federation_spec_definition::{
-    FederationSpecDefinition, KeyDirectiveArguments, FEDERATION_VERSIONS,
+    get_federation_spec_definition_from_subgraph, FederationSpecDefinition, KeyDirectiveArguments,
 };
-use crate::link::spec::Identity;
-use crate::link::spec_definition::spec_definitions;
 use crate::query_graph::extract_subgraphs_from_supergraph::extract_subgraphs_from_supergraph;
+use crate::query_graph::field_set::{equal_selection_sets, merge_selection_sets, parse_field_set};
 use crate::query_graph::{
     QueryGraph, QueryGraphEdge, QueryGraphEdgeTransition, QueryGraphNode, QueryGraphNodeType,
 };
 use crate::schema::position::{
-    AbstractTypeDefinitionPosition, FieldDefinitionPosition, InterfaceTypeDefinitionPosition,
-    ObjectFieldDefinitionPosition, ObjectTypeDefinitionPosition, OutputTypeDefinitionPosition,
-    SchemaRootDefinitionKind, SchemaRootDefinitionPosition, TypeDefinitionPosition,
-    UnionTypeDefinitionPosition,
+    AbstractTypeDefinitionPosition, CompositeTypeDefinitionPosition, FieldDefinitionPosition,
+    InterfaceTypeDefinitionPosition, ObjectFieldDefinitionPosition,
+    ObjectOrInterfaceTypeDefinitionPosition, ObjectTypeDefinitionPosition,
+    OutputTypeDefinitionPosition, SchemaRootDefinitionKind, SchemaRootDefinitionPosition,
+    TypeDefinitionPosition, UnionTypeDefinitionPosition,
 };
 use crate::schema::FederationSchema;
-use apollo_compiler::executable::SelectionSet;
-use apollo_compiler::schema::{Component, Directive, ExtendedType, Name};
-use apollo_compiler::{NodeStr, Schema};
-use indexmap::{IndexMap, IndexSet};
-use petgraph::graph::NodeIndex;
+use apollo_compiler::executable::{Selection, SelectionSet};
+use apollo_compiler::schema::{DirectiveList as ComponentDirectiveList, ExtendedType, Name};
+use apollo_compiler::{Node, NodeStr, Schema};
+use indexmap::{Equivalent, IndexMap, IndexSet};
+use petgraph::graph::{EdgeIndex, NodeIndex};
+use petgraph::visit::EdgeRef;
 use petgraph::Direction;
-use std::ops::Deref;
+use std::hash::Hash;
 use std::sync::Arc;
 use strum::IntoEnumIterator;
 
@@ -32,7 +33,7 @@ use strum::IntoEnumIterator;
 //
 // Assumes the given schemas have been validated.
 pub fn build_federated_query_graph(
-    supergraph_schema: Schema,
+    supergraph_schema: Arc<FederationSchema>,
     api_schema: Arc<FederationSchema>,
     validate_extracted_subgraphs: Option<bool>,
     for_query_planning: Option<bool>,
@@ -40,7 +41,7 @@ pub fn build_federated_query_graph(
     let for_query_planning = for_query_planning.unwrap_or(true);
     let mut query_graph = QueryGraph {
         // Note this name is a dummy initial name that gets overridden as we build the query graph.
-        name: NodeStr::new(""),
+        current_source: NodeStr::new(""),
         graph: Default::default(),
         sources: Default::default(),
         types_to_nodes_by_source: Default::default(),
@@ -48,45 +49,28 @@ pub fn build_federated_query_graph(
         non_trivial_followup_edges: Default::default(),
     };
     let subgraphs =
-        extract_subgraphs_from_supergraph(supergraph_schema, validate_extracted_subgraphs)?;
+        extract_subgraphs_from_supergraph(&supergraph_schema, validate_extracted_subgraphs)?;
     for (subgraph_name, subgraph) in subgraphs {
-        let federation_link = &subgraph
-            .schema
-            .metadata()
-            .as_ref()
-            .and_then(|metadata| metadata.for_identity(&Identity::federation_identity()))
-            .ok_or_else(|| SingleFederationError::Internal {
-                message: "Subgraph unexpectedly does not use federation spec".to_owned(),
-            })?;
-        let federation_spec_definition = spec_definitions(FEDERATION_VERSIONS.deref())?
-            .find(&federation_link.url.version)
-            .ok_or_else(|| SingleFederationError::Internal {
-                message: "Subgraph unexpectedly does not use a supported federation spec version"
-                    .to_owned(),
-            })?;
         let builder = SchemaQueryGraphBuilder::new(
             query_graph,
             NodeStr::new(&subgraph_name),
             subgraph.schema,
-            Some(SchemaQueryGraphBuilderSubgraphData {
-                federation_spec_definition,
-                api_schema: api_schema.clone(),
-            }),
+            Some(api_schema.clone()),
             for_query_planning,
-        );
+        )?;
         query_graph = builder.build()?;
     }
-
+    let federated_builder = FederatedQueryGraphBuilder::new(query_graph, supergraph_schema)?;
+    query_graph = federated_builder.build()?;
     Ok(query_graph)
 }
 struct BaseQueryGraphBuilder {
-    source: NodeStr,
     query_graph: QueryGraph,
 }
 
 impl BaseQueryGraphBuilder {
     fn new(mut query_graph: QueryGraph, source: NodeStr, schema: FederationSchema) -> Self {
-        query_graph.name = source.clone();
+        query_graph.current_source = source.clone();
         query_graph.sources.insert(source.clone(), schema);
         query_graph
             .types_to_nodes_by_source
@@ -94,10 +78,7 @@ impl BaseQueryGraphBuilder {
         query_graph
             .root_kinds_to_nodes_by_source
             .insert(source.clone(), IndexMap::new());
-        Self {
-            source,
-            query_graph,
-        }
+        Self { query_graph }
     }
 
     fn build(self) -> QueryGraph {
@@ -109,7 +90,7 @@ impl BaseQueryGraphBuilder {
         head: NodeIndex,
         tail: NodeIndex,
         transition: QueryGraphEdgeTransition,
-        conditions: Option<SelectionSet>,
+        conditions: Option<Node<SelectionSet>>,
     ) -> Result<(), FederationError> {
         self.query_graph.graph.add_edge(
             head,
@@ -164,7 +145,7 @@ impl BaseQueryGraphBuilder {
     fn create_new_node(&mut self, type_: QueryGraphNodeType) -> Result<NodeIndex, FederationError> {
         let node = self.query_graph.graph.add_node(QueryGraphNode {
             type_: type_.clone(),
-            source: self.source.clone(),
+            source: self.query_graph.current_source.clone(),
             has_reachable_cross_subgraph_edges: false,
             provide_id: None,
             root_kind: None,
@@ -214,19 +195,30 @@ struct SchemaQueryGraphBuilderSubgraphData {
 }
 
 impl SchemaQueryGraphBuilder {
+    // If api_schema is given, then this builder assumes the schema is a subgraph schema, and that
+    // a subgraph query graph is being built.
     fn new(
         query_graph: QueryGraph,
         source: NodeStr,
         schema: FederationSchema,
-        subgraph: Option<SchemaQueryGraphBuilderSubgraphData>,
+        api_schema: Option<Arc<FederationSchema>>,
         for_query_planning: bool,
-    ) -> Self {
+    ) -> Result<Self, FederationError> {
+        let subgraph = if let Some(api_schema) = api_schema {
+            let federation_spec_definition = get_federation_spec_definition_from_subgraph(&schema)?;
+            Some(SchemaQueryGraphBuilderSubgraphData {
+                federation_spec_definition,
+                api_schema,
+            })
+        } else {
+            None
+        };
         let base = BaseQueryGraphBuilder::new(query_graph, source, schema);
-        SchemaQueryGraphBuilder {
+        Ok(SchemaQueryGraphBuilder {
             base,
             subgraph,
             for_query_planning,
-        }
+        })
     }
 
     fn build(mut self) -> Result<QueryGraph, FederationError> {
@@ -249,7 +241,7 @@ impl SchemaQueryGraphBuilder {
         if self.for_query_planning {
             self.add_additional_abstract_type_edges()?;
         }
-        Ok(self.base.query_graph)
+        Ok(self.base.build())
     }
 
     fn is_external(
@@ -328,9 +320,9 @@ impl SchemaQueryGraphBuilder {
                 };
             }
         }
-        let node = self.base.create_new_node(QueryGraphNodeType::SubgraphType(
-            output_type_definition_position.clone(),
-        ))?;
+        let node = self
+            .base
+            .create_new_node(output_type_definition_position.clone().into())?;
         match output_type_definition_position {
             OutputTypeDefinitionPosition::Object(pos) => {
                 self.add_object_type_edges(pos, node)?;
@@ -428,34 +420,19 @@ impl SchemaQueryGraphBuilder {
         skip_edge: bool,
     ) -> Result<(), FederationError> {
         let field = field_definition_position.get(self.base.query_graph.schema()?.schema())?;
-        let tail_pos = match self
+        let tail_pos: OutputTypeDefinitionPosition = self
             .base
             .query_graph
             .schema()?
             .get_type(field.ty.inner_named_type().clone())?
-        {
-            TypeDefinitionPosition::Scalar(pos) => pos.into(),
-            TypeDefinitionPosition::Object(pos) => pos.into(),
-            TypeDefinitionPosition::Interface(pos) => pos.into(),
-            TypeDefinitionPosition::Union(pos) => pos.into(),
-            TypeDefinitionPosition::Enum(pos) => pos.into(),
-            TypeDefinitionPosition::InputObject(pos) => {
-                return Err(SingleFederationError::Internal {
-                    message: format!(
-                        "Field \"{}\" has non-output type \"{}\"",
-                        field_definition_position, pos,
-                    ),
-                }
-                .into());
-            }
-        };
+            .try_into()?;
         let tail = self.add_type_recursively(tail_pos)?;
-        let transition = QueryGraphEdgeTransition::FieldCollection {
-            source: self.base.source.clone(),
-            field_definition_position,
-            is_part_of_provide: false,
-        };
         if !skip_edge {
+            let transition = QueryGraphEdgeTransition::FieldCollection {
+                source: self.base.query_graph.current_source.clone(),
+                field_definition_position,
+                is_part_of_provides: false,
+            };
             self.base.add_edge(head, tail, transition, None)?;
         }
         Ok(())
@@ -593,7 +570,7 @@ impl SchemaQueryGraphBuilder {
         for pos in implementations {
             let tail = self.add_type_recursively(pos.clone().into())?;
             let transition = QueryGraphEdgeTransition::Downcast {
-                source: self.base.source.clone(),
+                source: self.base.query_graph.current_source.clone(),
                 from_type_position: abstract_type_definition_position.clone().into(),
                 to_type_position: pos.into(),
             };
@@ -833,7 +810,7 @@ impl SchemaQueryGraphBuilder {
                     )?;
                     if add_t1_to_t2 {
                         let transition = QueryGraphEdgeTransition::Downcast {
-                            source: self.base.source.clone(),
+                            source: self.base.query_graph.current_source.clone(),
                             from_type_position: t1.abstract_type_definition_position.clone().into(),
                             to_type_position: t2.abstract_type_definition_position.clone().into(),
                         };
@@ -841,7 +818,7 @@ impl SchemaQueryGraphBuilder {
                     }
                     if add_t2_to_t1 {
                         let transition = QueryGraphEdgeTransition::Downcast {
-                            source: self.base.source.clone(),
+                            source: self.base.query_graph.current_source.clone(),
                             from_type_position: t2.abstract_type_definition_position.clone().into(),
                             to_type_position: t1.abstract_type_definition_position.clone().into(),
                         };
@@ -918,7 +895,7 @@ impl SchemaQueryGraphBuilder {
             let interface_type_node =
                 self.add_type_recursively(interface_type_definition_position.clone().into())?;
             let transition = QueryGraphEdgeTransition::Downcast {
-                source: self.base.source.clone(),
+                source: self.base.query_graph.current_source.clone(),
                 from_type_position: UnionTypeDefinitionPosition {
                     type_name: entity_type_name.clone(),
                 }
@@ -939,16 +916,1072 @@ struct AbstractTypeWithRuntimeTypes {
     api_runtime_type_positions: IndexSet<ObjectTypeDefinitionPosition>,
 }
 
+struct FederatedQueryGraphBuilder {
+    base: BaseQueryGraphBuilder,
+    supergraph_schema: Arc<FederationSchema>,
+    subgraphs: FederatedQueryGraphBuilderSubgraphs,
+}
+
+impl FederatedQueryGraphBuilder {
+    fn new(
+        query_graph: QueryGraph,
+        supergraph_schema: Arc<FederationSchema>,
+    ) -> Result<Self, FederationError> {
+        let base = BaseQueryGraphBuilder::new(
+            query_graph,
+            NodeStr::new(FEDERATED_GRAPH_ROOT_SOURCE),
+            FederationSchema::new(Schema::new())?,
+        );
+        let subgraphs = FederatedQueryGraphBuilderSubgraphs::new(&base)?;
+        Ok(FederatedQueryGraphBuilder {
+            base,
+            supergraph_schema,
+            subgraphs,
+        })
+    }
+
+    fn build(mut self) -> Result<QueryGraph, FederationError> {
+        self.add_federated_root_nodes()?;
+        self.copy_types_to_nodes()?;
+        self.add_root_edges()?;
+        self.handle_key()?;
+        self.handle_requires()?;
+        // Note that @provides must be handled last when building since it requires copying nodes
+        // and their edges, and it's easier to reason about this if we know previous
+        self.handle_provides()?;
+        // The exception to the above rule is @interaceObject handling, where we explicitly don't
+        // want to add self-edges for copied @provides nodes. (See the comments in this method for
+        // more details).
+        self.handle_interface_object()?;
+        // This method adds no nodes/edges, but just precomputes followup edge information.
+        self.precompute_non_trivial_followup_edges()?;
+        Ok(self.base.build())
+    }
+
+    fn add_federated_root_nodes(&mut self) -> Result<(), FederationError> {
+        let mut root_kinds = IndexSet::new();
+        for (source, root_kinds_to_nodes) in &self.base.query_graph.root_kinds_to_nodes_by_source {
+            if *source == self.base.query_graph.current_source {
+                continue;
+            }
+            for root_kind in root_kinds_to_nodes.keys() {
+                root_kinds.insert(root_kind.clone());
+            }
+        }
+        for root_kind in root_kinds {
+            self.base
+                .create_root_node(root_kind.clone().into(), root_kind)?;
+        }
+        Ok(())
+    }
+
+    fn copy_types_to_nodes(&mut self) -> Result<(), FederationError> {
+        let mut federated_type_to_nodes = IndexMap::new();
+        for (source, types_to_nodes) in &self.base.query_graph.types_to_nodes_by_source {
+            if *source == self.base.query_graph.current_source {
+                continue;
+            }
+            for (type_name, nodes) in types_to_nodes {
+                let federated_nodes = federated_type_to_nodes
+                    .entry(type_name.clone())
+                    .or_insert_with(IndexSet::new);
+                for node in nodes {
+                    federated_nodes.insert(*node);
+                }
+            }
+        }
+        *self.base.query_graph.types_to_nodes_mut()? = federated_type_to_nodes;
+        Ok(())
+    }
+
+    // Add the edges from supergraph roots to the subgraph ones. Also, for each root kind, we also
+    // add edges from the corresponding root type of each subgraph to the root type of other
+    // subgraphs (and for @defer, like for @key, we also add self-node loops). This encodes the fact
+    // that if a field returns a root type, we can always query any subgraph from that point.
+    fn add_root_edges(&mut self) -> Result<(), FederationError> {
+        let mut new_edges = Vec::new();
+        for (source, root_kinds_to_nodes) in &self.base.query_graph.root_kinds_to_nodes_by_source {
+            if *source == self.base.query_graph.current_source {
+                continue;
+            }
+            for (root_kind, root_node) in root_kinds_to_nodes {
+                let federated_root_node = self
+                    .base
+                    .query_graph
+                    .root_kinds_to_nodes()?
+                    .get(root_kind)
+                    .ok_or_else(|| SingleFederationError::Internal {
+                        message: "Federated root node unexpectedly missing".to_owned(),
+                    })?;
+                new_edges.push(QueryGraphEdgeData {
+                    head: *federated_root_node,
+                    tail: *root_node,
+                    transition: QueryGraphEdgeTransition::SubgraphEnteringTransition,
+                    conditions: None,
+                });
+                for (other_source, other_root_kinds_to_nodes) in
+                    &self.base.query_graph.root_kinds_to_nodes_by_source
+                {
+                    if *other_source == self.base.query_graph.current_source {
+                        continue;
+                    }
+                    if let Some(other_root_node) = other_root_kinds_to_nodes.get(root_kind) {
+                        new_edges.push(QueryGraphEdgeData {
+                            head: *root_node,
+                            tail: *other_root_node,
+                            transition: QueryGraphEdgeTransition::RootTypeResolution {
+                                root_kind: root_kind.clone(),
+                            },
+                            conditions: None,
+                        })
+                    }
+                }
+            }
+        }
+        for new_edge in new_edges {
+            new_edge.add_to(&mut self.base)?;
+        }
+        Ok(())
+    }
+
+    // Handle @key by adding the appropriate key-resolution edges.
+    fn handle_key(&mut self) -> Result<(), FederationError> {
+        // We'll look at adding edges from "other subgraphs" to the current type. So the tail of
+        // all the edges we'll build here is always going to be the same.
+        for tail in self.base.query_graph.graph.node_indices() {
+            let mut new_edges = Vec::new();
+            let tail_weight = self.base.query_graph.node_weight(tail)?;
+            let source = &tail_weight.source;
+            if *source == self.base.query_graph.current_source {
+                continue;
+            }
+            // Ignore federated root nodes.
+            let QueryGraphNodeType::SubgraphType(type_pos) = &tail_weight.type_ else {
+                continue;
+            };
+            let schema = self.base.query_graph.schema_by_source(source)?;
+            let directives = schema
+                .schema()
+                .types
+                .get(type_pos.type_name())
+                .ok_or_else(|| SingleFederationError::Internal {
+                    message: format!(
+                        "Type \"{}\" unexpectedly missing from subgraph \"{}\"",
+                        type_pos, source,
+                    ),
+                })?
+                .directives();
+            let subgraph_data = self.subgraphs.get(source)?;
+            let is_interface_object = matches!(type_pos, OutputTypeDefinitionPosition::Object(_))
+                && directives.has(&subgraph_data.interface_object_directive_definition_name);
+
+            for application in resolvable_key_applications(
+                directives,
+                &subgraph_data.key_directive_definition_name,
+                subgraph_data.federation_spec_definition,
+            )? {
+                // The @key directive creates an edge from every subgraph having that type to
+                // the current subgraph. In other words, the fact this subgraph has a @key means
+                // that the current subgraph can be queried for the entity (through _entities)
+                // as long as "the other side" can provide the proper field values. Note that we
+                // only require that "the other side" can gather the key fields (through
+                // the path conditions; note that it's possible those conditions are never
+                // satisfiable), but we don't care that it defines the same key, because it's
+                // not a technical requirement (and in general while we probably don't want to
+                // allow a type to be an entity in some subgraphs but not others, this is not
+                // the place to impose that restriction, and this may be at least temporarily
+                // useful to allow convert a type to an entity).
+                let Ok(type_pos): Result<ObjectOrInterfaceTypeDefinitionPosition, _> =
+                    type_pos.clone().try_into()
+                else {
+                    return Err(SingleFederationError::Internal {
+                            message: format!(
+                                "Invalid \"@key\" application on non-object/interface type \"{}\" in subgraph \"{}\"",
+                                type_pos,
+                                source,
+                            )
+                        }.into());
+                };
+                let conditions = Node::new(parse_field_set(
+                    schema.schema(),
+                    type_pos.clone().into(),
+                    application.fields.clone(),
+                )?);
+
+                // Note that each subgraph has a key edge to itself (when head == tail below).
+                // We usually ignore these edges, but they exist for the special case of @defer,
+                // where we technically may have to take such "edges to self" as meaning to
+                // "re-enter" a subgraph for a deferred section.
+                for (other_source, other_types_to_nodes) in
+                    &self.base.query_graph.types_to_nodes_by_source
+                {
+                    if *other_source == self.base.query_graph.current_source {
+                        continue;
+                    }
+
+                    let other_nodes = other_types_to_nodes.get(type_pos.type_name());
+                    if let Some(other_nodes) = other_nodes {
+                        let head = other_nodes.first().ok_or_else(|| {
+                            SingleFederationError::Internal {
+                                message: format!(
+                                    "Types-to-nodes set unexpectedly empty for type \"{}\" in subgraph \"{}\"",
+                                    type_pos,
+                                    other_source,
+                                ),
+                            }
+                        })?;
+                        // Note that later, when we've handled @provides, this might not be true
+                        // anymore as @provides may create copy of a certain type. But for now, it's
+                        // true.
+                        if other_nodes.len() > 1 {
+                            return Err(
+                                SingleFederationError::Internal {
+                                    message: format!(
+                                        "Types-to-nodes set unexpectedly had more than one element for type \"{}\" in subgraph \"{}\"",
+                                        type_pos,
+                                        other_source,
+                                    ),
+                                }
+                                    .into()
+                            );
+                        }
+                        // The edge goes from the other subgraph to this one.
+                        new_edges.push(QueryGraphEdgeData {
+                            head: *head,
+                            tail,
+                            transition: QueryGraphEdgeTransition::KeyResolution,
+                            conditions: Some(conditions.clone()),
+                        })
+                    }
+
+                    // Additionally, if the key is on an @interfaceObject and this "other" subgraph
+                    // has some of the implementations of the corresponding interface, then we need
+                    // an edge from each of those implementations (to the @interfaceObject). This is
+                    // used when an entity of a specific implementation is queried first, but then
+                    // some of the requested fields are only provided by that @interfaceObject.
+                    if is_interface_object {
+                        let type_in_supergraph_pos = self
+                            .supergraph_schema
+                            .get_type(type_pos.type_name().clone())?;
+                        let TypeDefinitionPosition::Interface(type_in_supergraph_pos) =
+                            type_in_supergraph_pos
+                        else {
+                            return Err(SingleFederationError::Internal {
+                                    message: format!(
+                                        "Type \"{}\" was marked with \"@interfaceObject\" in subgraph \"{}\", but was non-interface in supergraph",
+                                        type_pos,
+                                        other_source,
+                                    )
+                                }.into());
+                        };
+                        for implementation_type_in_supergraph_pos in self
+                            .supergraph_schema
+                            .possible_runtime_types(type_in_supergraph_pos.into())?
+                        {
+                            // That implementation type may or may not exists in the "other
+                            // subgraph". If it doesn't, we just have nothing to do for that
+                            // particular implementation. If it does, we'll add the proper edge, but
+                            // note that we're guaranteed to have at most one node for the same
+                            // reasons as mentioned above (only the handling of @provides will make
+                            // it so that there can be more than one node per type).
+                            let Some(implementation_nodes) = self
+                                .base
+                                .query_graph
+                                .types_to_nodes_by_source(other_source)?
+                                .get(&implementation_type_in_supergraph_pos.type_name)
+                            else {
+                                continue;
+                            };
+                            let head = implementation_nodes.first().ok_or_else(|| {
+                                SingleFederationError::Internal {
+                                    message: format!(
+                                        "Types-to-nodes set unexpectedly empty for type \"{}\" in subgraph \"{}\"",
+                                        implementation_type_in_supergraph_pos,
+                                        other_source,
+                                    ),
+                                }
+                            })?;
+                            if implementation_nodes.len() > 1 {
+                                return Err(
+                                    SingleFederationError::Internal {
+                                        message: format!(
+                                            "Types-to-nodes set unexpectedly had more than one element for type \"{}\" in subgraph \"{}\"",
+                                            implementation_type_in_supergraph_pos,
+                                            other_source,
+                                        ),
+                                    }.into()
+                                );
+                            }
+
+                            // The key goes from the implementation type in the "other subgraph" to
+                            // the @interfaceObject type in this one, so the `conditions` will be
+                            // "fetched" on the implementation type, but the `conditions` have been
+                            // parsed on the @interfaceObject type. We'd like it to use fields from
+                            // the implementation type and not the @interfaceObject type, so we
+                            // re-parse the condition using the implementation type. This could
+                            // fail, but in that case it just means that key is not usable in the
+                            // other subgraph.
+                            let other_schema =
+                                self.base.query_graph.schema_by_source(other_source)?;
+                            let implementation_type_in_other_subgraph_pos: CompositeTypeDefinitionPosition =
+                                other_schema.get_type(implementation_type_in_supergraph_pos.type_name.clone())?.try_into()?;
+                            let Ok(implementation_conditions) = parse_field_set(
+                                other_schema.schema(),
+                                implementation_type_in_other_subgraph_pos.clone(),
+                                application.fields.clone(),
+                            ) else {
+                                // Ignored on purpose: it just means the key is not usable on this
+                                // subgraph.
+                                continue;
+                            };
+                            new_edges.push(QueryGraphEdgeData {
+                                head: *head,
+                                tail,
+                                transition: QueryGraphEdgeTransition::KeyResolution,
+                                conditions: Some(Node::new(implementation_conditions)),
+                            })
+                        }
+                    }
+                }
+            }
+            for new_edge in new_edges {
+                new_edge.add_to(&mut self.base)?;
+            }
+        }
+        Ok(())
+    }
+
+    // Handle @requires by updating the appropriate field-collecting edges.
+    fn handle_requires(&mut self) -> Result<(), FederationError> {
+        // We'll look at any field-collecting edges with @requires and adding their conditions to
+        // those edges.
+        for edge in self.base.query_graph.graph.edge_indices() {
+            let edge_weight = self.base.query_graph.edge_weight(edge)?;
+            let QueryGraphEdgeTransition::FieldCollection {
+                source,
+                field_definition_position,
+                ..
+            } = &edge_weight.transition
+            else {
+                continue;
+            };
+            if *source == self.base.query_graph.current_source {
+                continue;
+            }
+            // Nothing prior to this should have set any conditions for field-collecting edges.
+            // This won't be the case after this method though.
+            if edge_weight.conditions.is_some() {
+                return Err(SingleFederationError::Internal {
+                    message: format!(
+                        "Field-collection edge for field \"{}\" unexpectedly had conditions",
+                        field_definition_position,
+                    ),
+                }
+                .into());
+            }
+            let schema = self.base.query_graph.schema_by_source(source)?;
+            let subgraph_data = self.subgraphs.get(source)?;
+            let field = field_definition_position.get(schema.schema())?;
+            let mut all_conditions = Vec::new();
+            for directive in field
+                .directives
+                .get_all(&subgraph_data.requires_directive_definition_name)
+            {
+                let application = subgraph_data
+                    .federation_spec_definition
+                    .requires_directive_arguments(directive)?;
+                let conditions = parse_field_set(
+                    schema.schema(),
+                    field_definition_position.parent().clone(),
+                    application.fields,
+                )?;
+                all_conditions.push(conditions);
+            }
+            if all_conditions.is_empty() {
+                continue;
+            }
+            // PORT_NOTE: This is an optimization to avoid unnecessary inter-conversion between
+            // the apollo-rs operation representation and the federation-next one. This wasn't a
+            // problem in the JS codebase, as it would use its own operation representation from
+            // the start. As an aside, I'm not sure when this list will ever not be a singleton
+            // list, but it's like this way in the JS codebase, so we'll mimic the behavior for now.
+            let new_conditions = if all_conditions.len() == 1 {
+                all_conditions
+                    .pop()
+                    .ok_or_else(|| SingleFederationError::Internal {
+                        message: "Singleton list was unexpectedly empty".to_owned(),
+                    })?
+            } else {
+                merge_selection_sets(&all_conditions.iter().collect::<Vec<_>>())?
+            };
+            let edge_weight_mut = self.base.query_graph.edge_weight_mut(edge)?;
+            edge_weight_mut.conditions = Some(Node::new(new_conditions));
+        }
+        Ok(())
+    }
+
+    // Handle @provides by copying the appropriate nodes/edges.
+    fn handle_provides(&mut self) -> Result<(), FederationError> {
+        let mut provide_id = 0;
+        for edge in self.base.query_graph.graph.edge_indices() {
+            let edge_weight = self.base.query_graph.edge_weight(edge)?;
+            let QueryGraphEdgeTransition::FieldCollection {
+                source,
+                field_definition_position,
+                ..
+            } = &edge_weight.transition
+            else {
+                continue;
+            };
+            if *source == self.base.query_graph.current_source {
+                continue;
+            }
+            let source = source.clone();
+            let schema = self.base.query_graph.schema_by_source(&source)?;
+            let subgraph_data = self.subgraphs.get(&source)?;
+            let field = field_definition_position.get(schema.schema())?;
+            let field_type_pos = schema.get_type(field.ty.inner_named_type().clone())?;
+            let mut all_conditions = Vec::new();
+            for directive in field
+                .directives
+                .get_all(&subgraph_data.requires_directive_definition_name)
+            {
+                let application = subgraph_data
+                    .federation_spec_definition
+                    .provides_directive_arguments(directive)?;
+                let field_type_pos: CompositeTypeDefinitionPosition =
+                    field_type_pos.clone().try_into()?;
+                let conditions =
+                    parse_field_set(schema.schema(), field_type_pos, application.fields)?;
+                all_conditions.push(conditions);
+            }
+            if all_conditions.is_empty() {
+                continue;
+            }
+            provide_id += 1;
+            // PORT_NOTE: This is an optimization to avoid unnecessary inter-conversion between
+            // the apollo-rs operation representation and the federation-next one. This wasn't a
+            // problem in the JS codebase, as it would use its own operation representation from
+            // the start. As an aside, I'm not sure when this list will ever not be a singleton
+            // list, but it's like this way in the JS codebase, so we'll mimic the behavior for now.
+            //
+            // Note that the JS codebase had a bug here when there was more than one selection set,
+            // where it would copy per @provides application, but only point the field-collecting
+            // edge toward the last copy. We do something similar to @requires instead, where we
+            // merge the selection sets before into one.
+            let new_conditions = if all_conditions.len() == 1 {
+                all_conditions
+                    .pop()
+                    .ok_or_else(|| SingleFederationError::Internal {
+                        message: "Singleton list was unexpectedly empty".to_owned(),
+                    })?
+            } else {
+                merge_selection_sets(&all_conditions.iter().collect::<Vec<_>>())?
+            };
+            // We make a copy of the tail node (representing the field's type) with all the same
+            // out-edges, and we change this particular in-edge to point to the new copy. We then
+            // add all the provides edges starting from the copy.
+            let (_, tail) = self.base.query_graph.edge_endpoints(edge)?;
+            let new_tail = Self::copy_for_provides(&mut self.base, tail, provide_id)?;
+            Self::update_edge_tail(&mut self.base, edge, new_tail)?;
+            Self::add_provides_edges(
+                &mut self.base,
+                &source,
+                new_tail,
+                &new_conditions,
+                provide_id,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn add_provides_edges(
+        base: &mut BaseQueryGraphBuilder,
+        source: &NodeStr,
+        head: NodeIndex,
+        provided: &SelectionSet,
+        provide_id: u32,
+    ) -> Result<(), FederationError> {
+        let mut stack = vec![(head, provided)];
+        while let Some((node, selection_set)) = stack.pop() {
+            // We iterate through the selections to cancel out the reversing that the stack does.
+            for selection in selection_set.selections.iter().rev() {
+                match selection {
+                    Selection::Field(field) => {
+                        let existing_edge_info = base
+                            .query_graph
+                            .graph
+                            .edges_directed(node, Direction::Outgoing)
+                            .find_map(|edge_ref| {
+                                let edge_weight = edge_ref.weight();
+                                let QueryGraphEdgeTransition::FieldCollection {
+                                    field_definition_position,
+                                    ..
+                                } = &edge_weight.transition
+                                else {
+                                    return None;
+                                };
+                                if *field_definition_position.field_name() == field.name {
+                                    Some((edge_ref.id(), edge_ref.target()))
+                                } else {
+                                    None
+                                }
+                            });
+                        if let Some((edge, tail)) = existing_edge_info {
+                            // If this is a leaf field, then we don't really have anything to do.
+                            // Otherwise, we need to copy the tail and continue propagating the
+                            // provided selections from there.
+                            if !field.selection_set.selections.is_empty() {
+                                let new_tail = Self::copy_for_provides(base, tail, provide_id)?;
+                                Self::update_edge_tail(base, edge, new_tail)?;
+                                stack.push((new_tail, &field.selection_set))
+                            }
+                        } else {
+                            // There are no existing edges, which means that it's an edge added by
+                            // an @provides to an @external field. We find the existing node it
+                            // leads to.
+                            //
+                            // PORT_NOTE: The JS codebase would create the node if it didn't exist,
+                            // but this is a holdover from when subgraph query graph building
+                            // would skip @external fields completely instead of just recursing
+                            // into the type.
+                            //
+                            // Also, the JS codebase appears to have a bug where they find some node
+                            // with the appropriate source and type name, but they don't guarantee
+                            // that the node has no provide_id (i.e. it may be a copied node), which
+                            // means they may have extra edges that accordingly can't be taken. We
+                            // fix this below by filtering by provide_id.
+                            let tail_type = field.definition.ty.inner_named_type();
+                            let possible_tails = base
+                                .query_graph
+                                .types_to_nodes_by_source(source)?
+                                .get(tail_type)
+                                .ok_or_else(|| SingleFederationError::Internal {
+                                    message: format!(
+                                        "Types-to-nodes map missing type \"{}\" in subgraph \"{}\"",
+                                        tail_type, source,
+                                    ),
+                                })?;
+                            // Note because this is an IndexSet, the non-provides should be first
+                            // since it was added first, but it's a bit fragile so we fallback to
+                            // checking the whole set if it's not first.
+                            let mut tail: Option<NodeIndex> = None;
+                            for possible_tail in possible_tails {
+                                let possible_tail_weight =
+                                    base.query_graph.node_weight(*possible_tail)?;
+                                if possible_tail_weight.provide_id.is_none() {
+                                    tail = Some(*possible_tail);
+                                    break;
+                                }
+                            }
+                            let Some(tail) = tail else {
+                                return Err(
+                                    SingleFederationError::Internal {
+                                        message: format!(
+                                            "Missing non-provides node for type \"{}\" in subgraph \"{}\"",
+                                            tail_type,
+                                            source,
+                                        )
+                                    }.into()
+                                );
+                            };
+                            // If this is a leaf field, then just create the new edge and we're
+                            // done. Otherwise, we should copy the node, add the edge, and continue
+                            // propagating.
+                            let node_weight = base.query_graph.node_weight(node)?;
+                            let QueryGraphNodeType::SubgraphType(node_type_pos) =
+                                node_weight.type_.clone()
+                            else {
+                                return Err(SingleFederationError::Internal {
+                                    message: "Unexpectedly found @provides containing federated root node".to_owned(),
+                                }
+                                    .into());
+                            };
+                            let node_type_pos: CompositeTypeDefinitionPosition =
+                                node_type_pos.try_into()?;
+                            let field_pos = node_type_pos.field(field.name.clone())?;
+                            let transition = QueryGraphEdgeTransition::FieldCollection {
+                                source: source.clone(),
+                                field_definition_position: field_pos,
+                                is_part_of_provides: true,
+                            };
+                            if !field.selection_set.selections.is_empty() {
+                                let new_tail = Self::copy_for_provides(base, tail, provide_id)?;
+                                base.add_edge(node, new_tail, transition, None)?;
+                                stack.push((new_tail, &field.selection_set))
+                            } else {
+                                base.add_edge(node, tail, transition, None)?;
+                            }
+                        }
+                    }
+                    Selection::InlineFragment(inline_fragment) => {
+                        if let Some(type_condition_name) = &inline_fragment.type_condition {
+                            // We should always have an edge: otherwise it would mean we list a type
+                            // condition for a type that isn't in the subgraph, but the @provides
+                            // shouldn't have validated in the first place (another way to put this
+                            // is, contrary to fields, there is no way currently to mark a full type
+                            // as @external).
+                            //
+                            // TODO: Query graph creation during composition only creates Downcast
+                            // edges between abstract types and their possible runtime object types,
+                            // so the requirement above effectively prohibits the use of type
+                            // conditions containing abstract types in @provides. This is fine for
+                            // query planning since we have the same Downcast edges (additionally
+                            // for query planning, there are usually edges between abstract types
+                            // when their intersection is at least size 2). However, when this code
+                            // gets used in composition, the assertion below will be the error users
+                            // will see in those cases, and it would be better to do a formal check
+                            // with better messaging during merging instead of during query graph
+                            // construction.
+                            let (edge, tail) = base
+                                .query_graph
+                                .graph
+                                .edges_directed(node, Direction::Outgoing)
+                                .find_map(|edge_ref| {
+                                    let edge_weight = edge_ref.weight();
+                                    let QueryGraphEdgeTransition::Downcast {
+                                        to_type_position, ..
+                                    } = &edge_weight.transition
+                                    else {
+                                        return None;
+                                    };
+                                    if to_type_position.type_name() == type_condition_name {
+                                        Some((edge_ref.id(), edge_ref.target()))
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .ok_or_else(|| {
+                                    SingleFederationError::Internal {
+                                        message: format!(
+                                            "Shouldn't have selection \"{}\" in an @provides, as its type condition has no query graph edge",
+                                            selection.serialize().no_indent(),
+                                        )
+                                    }
+                                })?;
+                            let new_tail = Self::copy_for_provides(base, tail, provide_id)?;
+                            Self::update_edge_tail(base, edge, new_tail)?;
+                            stack.push((new_tail, &inline_fragment.selection_set))
+                        } else {
+                            // Essentially ignore the condition in this case, and continue
+                            // propagating the provided selections.
+                            stack.push((node, &inline_fragment.selection_set));
+                        }
+                    }
+                    Selection::FragmentSpread(_) => {
+                        return Err(SingleFederationError::Internal {
+                            message: "Unexpectedly found named fragment in FieldSet scalar"
+                                .to_owned(),
+                        }
+                        .into());
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn update_edge_tail(
+        base: &mut BaseQueryGraphBuilder,
+        edge: EdgeIndex,
+        tail: NodeIndex,
+    ) -> Result<(), FederationError> {
+        // Note that petgraph has no method to directly update an edge's endpoints. Instead, you
+        // must:
+        // 1. Add a new edge, with the same weight but updated endpoints. This edge then becomes the
+        //    last edge in the graph (i.e. the one with highest edge index).
+        // 2. Remove the old edge. As per the API docs, this causes the last edge's index to change
+        //    to be the one that was removed.
+        // This results in a Graph where it looks like only the edge's endpoints have changed while
+        // its index and weight are unchanged, but really its weight has been cloned (which is
+        // cheap).
+        let (new_edge_head, _) = base.query_graph.edge_endpoints(edge)?;
+        let new_edge_weight = base.query_graph.edge_weight(edge)?.clone();
+        base.query_graph
+            .graph
+            .add_edge(new_edge_head, tail, new_edge_weight);
+        base.query_graph.graph.remove_edge(edge);
+        Ok(())
+    }
+
+    // Copies the given node and its outgoing edges, returning the new node's index.
+    fn copy_for_provides(
+        base: &mut BaseQueryGraphBuilder,
+        node: NodeIndex,
+        provide_id: u32,
+    ) -> Result<NodeIndex, FederationError> {
+        let current_source = base.query_graph.current_source.clone();
+        let result = Self::copy_for_provides_internal(base, node, provide_id);
+        // Ensure that the current source resets, even if the copy unexpectedly fails.
+        base.query_graph.current_source = current_source;
+        let (new_node, type_pos) = result?;
+        base.query_graph
+            .types_to_nodes_mut()?
+            .get_mut(type_pos.type_name())
+            .ok_or_else(|| SingleFederationError::Internal {
+                message: format!(
+                    "Unexpectedly missing @provides type \"{}\" in types-to-nodes map",
+                    type_pos,
+                ),
+            })?
+            .insert(new_node);
+        Ok(new_node)
+    }
+
+    fn copy_for_provides_internal(
+        base: &mut BaseQueryGraphBuilder,
+        node: NodeIndex,
+        provide_id: u32,
+    ) -> Result<(NodeIndex, OutputTypeDefinitionPosition), FederationError> {
+        let node_weight = base.query_graph.node_weight(node)?;
+        let QueryGraphNodeType::SubgraphType(type_pos) = node_weight.type_.clone() else {
+            return Err(SingleFederationError::Internal {
+                message: "Unexpectedly found @provides for federated root node".to_owned(),
+            }
+            .into());
+        };
+        let has_reachable_cross_subgraph_edges = node_weight.has_reachable_cross_subgraph_edges;
+        base.query_graph.current_source = node_weight.source.clone();
+        let new_node = base.create_new_node(type_pos.clone().into())?;
+        let new_node_weight = base.query_graph.node_weight_mut(new_node)?;
+        new_node_weight.provide_id = Some(provide_id);
+        new_node_weight.has_reachable_cross_subgraph_edges = has_reachable_cross_subgraph_edges;
+
+        let mut new_edges = Vec::new();
+        for edge_ref in base
+            .query_graph
+            .graph
+            .edges_directed(node, Direction::Outgoing)
+        {
+            let edge_tail = edge_ref.target();
+            let edge_weight = edge_ref.weight();
+            new_edges.push(QueryGraphEdgeData {
+                head: new_node,
+                tail: edge_tail,
+                transition: edge_weight.transition.clone(),
+                conditions: edge_weight.conditions.clone(),
+            });
+        }
+        for new_edge in new_edges {
+            new_edge.add_to(base)?;
+        }
+        Ok((new_node, type_pos))
+    }
+
+    // Handle @interfaceObject by adding the appropriate fake-downcast self-edges.
+    fn handle_interface_object(&mut self) -> Result<(), FederationError> {
+        // There are cases where only an/some implementation(s) of an interface are queried, and
+        // that could apply to an interface that is an @interfaceObject in some subgraph. Consider
+        // the following example:
+        // ```graphql
+        // type Query {
+        //   getIs: [I]
+        // }
+        //
+        // type I @key(fields: "id") @interfaceObject {
+        //   id: ID!
+        //   x: Int
+        // }
+        // ```
+        // where we suppose that `I` has some implementations `A`, `B`, and `C` in some other subgraph.
+        // Now, consider query:
+        // ```graphql
+        // {
+        //   getIs {
+        //     ... on B {
+        //       x
+        //     }
+        //   }
+        // }
+        // ```
+        // So here, we query `x` (which the subgraph provides) but we only do so for one of the
+        // implementations. So in that case, we essentially need to figure out the `__typename` first
+        // (or more precisely, we need to know the real __typename "eventually"; we could theoretically
+        // query `x` first, and then get the __typename to know if we should keep the result or discard
+        // it, and that could be more efficient in certain cases, but as we don't know both 1) if `x`
+        // is expansive to resolve and 2) what ratio of the results from `getIs` will be `B` versus some
+        // other implementation, it is "safer" to get the __typename first and only resolve `x` when we
+        // need to).
+        //
+        // Long story short, to solve this, we create edges from @interfaceObject types to themselves
+        // for every implementation type of the interface: those edges will be taken when we try to take
+        // a `... on B` condition, and those edges have __typename have a condition, forcing us to find
+        // __typename in another subgraph first.
+        let mut new_edges = Vec::new();
+        for (source, schema) in &self.base.query_graph.sources {
+            if *source == self.base.query_graph.current_source {
+                continue;
+            }
+            let subgraph_data = self.subgraphs.get(source)?;
+            for type_pos in &schema
+                .referencers()
+                .get_directive(&subgraph_data.interface_object_directive_definition_name)?
+                .object_types
+            {
+                // This method is run after handling @provides, so there may be multiple nodes here
+                // instead of just one. We specifically just want to add the self-edges to the
+                // non-provides node. This is because any @provides in a subgraph whose field set
+                // contains an @interfaceObject object type couldn't actually place a type condition
+                // on that object type, since that field set must validate against the subgraph
+                // schema (and object types have no intersection with other object types, even if
+                // the subgraph had any implementation types). This is also why we run this method
+                // after the @provides handling instead of before (since we don't want to clone
+                // the self-edges added by this method).
+                let possible_nodes = self
+                    .base
+                    .query_graph
+                    .types_to_nodes_by_source(source)?
+                    .get(&type_pos.type_name)
+                    .ok_or_else(|| SingleFederationError::Internal {
+                        message: format!(
+                            "Types-to-nodes map missing type \"{}\" in subgraph \"{}\"",
+                            type_pos, source,
+                        ),
+                    })?;
+                // Note because this is an IndexSet, the non-provides should be first since it was
+                // added first, but it's a bit fragile so we fallback to checking the whole set if
+                // it's not first.
+                let mut node: Option<NodeIndex> = None;
+                for possible_node in possible_nodes {
+                    let possible_tail_weight = self.base.query_graph.node_weight(*possible_node)?;
+                    if possible_tail_weight.provide_id.is_none() {
+                        node = Some(*possible_node);
+                        break;
+                    }
+                }
+                let Some(node) = node else {
+                    return Err(SingleFederationError::Internal {
+                        message: format!(
+                            "Missing non-provides node for type \"{}\" in subgraph \"{}\"",
+                            type_pos, source,
+                        ),
+                    }
+                    .into());
+                };
+                let type_in_supergraph_pos = self
+                    .supergraph_schema
+                    .get_type(type_pos.type_name.clone())?;
+                let TypeDefinitionPosition::Interface(type_in_supergraph_pos) =
+                    type_in_supergraph_pos
+                else {
+                    return Err(SingleFederationError::Internal {
+                            message: format!(
+                                "Type \"{}\" was marked with \"@interfaceObject\" in subgraph \"{}\", but was non-interface in supergraph",
+                                type_pos,
+                                source,
+                            )
+                        }.into());
+                };
+                let conditions = Node::new(parse_field_set(
+                    schema.schema(),
+                    type_in_supergraph_pos.clone().into(),
+                    NodeStr::from_static(&"__typename"),
+                )?);
+                for implementation_type_in_supergraph_pos in self
+                    .supergraph_schema
+                    .possible_runtime_types(type_in_supergraph_pos.into())?
+                {
+                    let transition = QueryGraphEdgeTransition::InterfaceObjectFakeDownCast {
+                        source: source.clone(),
+                        from_type_position: type_pos.clone().into(),
+                        to_type_name: implementation_type_in_supergraph_pos.type_name,
+                    };
+                    new_edges.push(QueryGraphEdgeData {
+                        head: node,
+                        tail: node,
+                        transition,
+                        conditions: Some(conditions.clone()),
+                    });
+                }
+            }
+        }
+        for new_edge in new_edges {
+            new_edge.add_to(&mut self.base)?;
+        }
+        Ok(())
+    }
+
+    // Precompute which followup edges for a given edge are non-trivial.
+    fn precompute_non_trivial_followup_edges(&mut self) -> Result<(), FederationError> {
+        for edge in self.base.query_graph.graph.edge_indices() {
+            let edge_weight = self.base.query_graph.edge_weight(edge)?;
+            let (_, tail) = self.base.query_graph.edge_endpoints(edge)?;
+            let mut non_trivial_followups = IndexSet::new();
+            for followup_edge_ref in self
+                .base
+                .query_graph
+                .graph
+                .edges_directed(tail, Direction::Outgoing)
+            {
+                let followup_edge_weight = followup_edge_ref.weight();
+                match edge_weight.transition {
+                    QueryGraphEdgeTransition::KeyResolution => {
+                        // After taking a key from subgraph A to B, there is no point of following
+                        // that up with another key to subgraph C if that key has the same
+                        // conditions. This is because, due to the way key edges are created, if we
+                        // have a key (with some conditions X) from B to C, then we are guaranteed
+                        // to also have a key (with the same conditions X) from A to C, and so it's
+                        // that later key we should be using in the first place. In other words,
+                        // it's never better to do 2 hops rather than 1.
+                        if matches!(
+                            followup_edge_weight.transition,
+                            QueryGraphEdgeTransition::KeyResolution
+                        ) {
+                            let Some(conditions) = &edge_weight.conditions else {
+                                return Err(SingleFederationError::Internal {
+                                    message: "Key resolution edge unexpectedly missing conditions"
+                                        .to_owned(),
+                                }
+                                .into());
+                            };
+                            let Some(followup_conditions) = &followup_edge_weight.conditions else {
+                                return Err(SingleFederationError::Internal {
+                                    message: "Key resolution edge unexpectedly missing conditions"
+                                        .to_owned(),
+                                }
+                                .into());
+                            };
+                            if equal_selection_sets(conditions, followup_conditions)? {
+                                continue;
+                            }
+                        }
+                    }
+                    QueryGraphEdgeTransition::RootTypeResolution { .. } => {
+                        // A 'RootTypeResolution' means that a query reached the query type (or
+                        // another root type) in some subgraph A and we're looking at jumping to
+                        // another subgraph B. But like for keys, there is no point in trying to
+                        // jump directly to yet another subpraph C from B, since we can always jump
+                        // directly from A to C and it's better.
+                        if matches!(
+                            followup_edge_weight.transition,
+                            QueryGraphEdgeTransition::RootTypeResolution { .. }
+                        ) {
+                            continue;
+                        }
+                    }
+                    QueryGraphEdgeTransition::SubgraphEnteringTransition => {
+                        // This is somewhat similar to 'RootTypeResolution' except that we're
+                        // starting the query. Still, we shouldn't do "start of query" -> B -> C,
+                        // since we can do "start of query" -> C and that's always better.
+                        if matches!(
+                            followup_edge_weight.transition,
+                            QueryGraphEdgeTransition::SubgraphEnteringTransition
+                        ) {
+                            continue;
+                        }
+                    }
+                    _ => {}
+                }
+                non_trivial_followups.insert(followup_edge_ref.id());
+            }
+            self.base
+                .query_graph
+                .non_trivial_followup_edges
+                .insert(edge, non_trivial_followups);
+        }
+        Ok(())
+    }
+}
+
+const FEDERATED_GRAPH_ROOT_SOURCE: &str = "_";
+
+struct FederatedQueryGraphBuilderSubgraphs {
+    map: IndexMap<NodeStr, FederatedQueryGraphBuilderSubgraphData>,
+}
+
+impl FederatedQueryGraphBuilderSubgraphs {
+    fn new(base: &BaseQueryGraphBuilder) -> Result<Self, FederationError> {
+        let mut subgraphs = FederatedQueryGraphBuilderSubgraphs {
+            map: IndexMap::new(),
+        };
+        for (source, schema) in &base.query_graph.sources {
+            if *source == base.query_graph.current_source {
+                continue;
+            }
+            let federation_spec_definition = get_federation_spec_definition_from_subgraph(schema)?;
+            let key_directive_definition_name = federation_spec_definition
+                .key_directive_definition(schema)?
+                .name
+                .clone();
+            let requires_directive_definition_name = federation_spec_definition
+                .requires_directive_definition(schema)?
+                .name
+                .clone();
+            let provides_directive_definition_name = federation_spec_definition
+                .provides_directive_definition(schema)?
+                .name
+                .clone();
+            let interface_object_directive_definition_name = federation_spec_definition
+                .interface_object_directive_definition(schema)?
+                .map(|d| d.name.clone())
+                .ok_or_else(|| {
+                    // Extracted subgraphs should use the latest federation spec version, which
+                    // means they should include an @interfaceObject definition.
+                    SingleFederationError::Internal {
+                        message: format!(
+                            "Subgraph \"{}\" unexpectedly missing @interfaceObject definition",
+                            source,
+                        ),
+                    }
+                })?;
+            subgraphs.map.insert(
+                source.clone(),
+                FederatedQueryGraphBuilderSubgraphData {
+                    federation_spec_definition,
+                    key_directive_definition_name,
+                    requires_directive_definition_name,
+                    provides_directive_definition_name,
+                    interface_object_directive_definition_name,
+                },
+            );
+        }
+        Ok(subgraphs)
+    }
+
+    fn get<Q: ?Sized>(
+        &self,
+        source: &Q,
+    ) -> Result<&FederatedQueryGraphBuilderSubgraphData, FederationError>
+    where
+        Q: Hash + Equivalent<NodeStr>,
+    {
+        self.map.get(source).ok_or_else(|| {
+            SingleFederationError::Internal {
+                message: "Subgraph data unexpectedly missing".to_owned(),
+            }
+            .into()
+        })
+    }
+}
+
+struct FederatedQueryGraphBuilderSubgraphData {
+    federation_spec_definition: &'static FederationSpecDefinition,
+    key_directive_definition_name: Name,
+    requires_directive_definition_name: Name,
+    provides_directive_definition_name: Name,
+    interface_object_directive_definition_name: Name,
+}
+
+struct QueryGraphEdgeData {
+    head: NodeIndex,
+    tail: NodeIndex,
+    transition: QueryGraphEdgeTransition,
+    conditions: Option<Node<SelectionSet>>,
+}
+
+impl QueryGraphEdgeData {
+    fn add_to(self, builder: &mut BaseQueryGraphBuilder) -> Result<(), FederationError> {
+        builder.add_edge(self.head, self.tail, self.transition, self.conditions)
+    }
+}
+
 fn resolvable_key_applications(
-    directives: &[Component<Directive>],
+    directives: &ComponentDirectiveList,
     key_directive_definition_name: &Name,
     federation_spec_definition: &'static FederationSpecDefinition,
 ) -> Result<Vec<KeyDirectiveArguments>, FederationError> {
     let mut applications = Vec::new();
-    for directive in directives {
-        if directive.name != *key_directive_definition_name {
-            continue;
-        }
+    for directive in directives.get_all(key_directive_definition_name) {
         let key_directive_application =
             federation_spec_definition.key_directive_arguments(directive)?;
         if !key_directive_application.resolvable {

--- a/src/query_graph/build_query_graph.rs
+++ b/src/query_graph/build_query_graph.rs
@@ -150,7 +150,7 @@ impl BaseQueryGraphBuilder {
             provide_id: None,
             root_kind: None,
         });
-        if let QueryGraphNodeType::SubgraphType(pos) = type_ {
+        if let QueryGraphNodeType::SchemaType(pos) = type_ {
             self.query_graph
                 .types_to_nodes_mut()?
                 .entry(pos.type_name().clone())
@@ -1056,7 +1056,7 @@ impl FederatedQueryGraphBuilder {
                 continue;
             }
             // Ignore federated root nodes.
-            let QueryGraphNodeType::SubgraphType(type_pos) = &tail_weight.type_ else {
+            let QueryGraphNodeType::SchemaType(type_pos) = &tail_weight.type_ else {
                 continue;
             };
             let schema = self.base.query_graph.schema_by_source(source)?;
@@ -1494,7 +1494,7 @@ impl FederatedQueryGraphBuilder {
                             // done. Otherwise, we should copy the node, add the edge, and continue
                             // propagating.
                             let node_weight = base.query_graph.node_weight(node)?;
-                            let QueryGraphNodeType::SubgraphType(node_type_pos) =
+                            let QueryGraphNodeType::SchemaType(node_type_pos) =
                                 node_weight.type_.clone()
                             else {
                                 return Err(SingleFederationError::Internal {
@@ -1639,7 +1639,7 @@ impl FederatedQueryGraphBuilder {
         provide_id: u32,
     ) -> Result<(NodeIndex, OutputTypeDefinitionPosition), FederationError> {
         let node_weight = base.query_graph.node_weight(node)?;
-        let QueryGraphNodeType::SubgraphType(type_pos) = node_weight.type_.clone() else {
+        let QueryGraphNodeType::SchemaType(type_pos) = node_weight.type_.clone() else {
             return Err(SingleFederationError::Internal {
                 message: "Unexpectedly found @provides for federated root node".to_owned(),
             }

--- a/src/query_graph/build_query_graph.rs
+++ b/src/query_graph/build_query_graph.rs
@@ -1301,11 +1301,15 @@ impl FederatedQueryGraphBuilder {
             if all_conditions.is_empty() {
                 continue;
             }
-            // PORT_NOTE: This is an optimization to avoid unnecessary inter-conversion between
+            // PORT_NOTE: I'm not sure when this list will ever not be a singleton list, but it's
+            // like this way in the JS codebase, so we'll mimic the behavior for now.
+            //
+            // TODO: This is an optimization to avoid unnecessary inter-conversion between
             // the apollo-rs operation representation and the federation-next one. This wasn't a
             // problem in the JS codebase, as it would use its own operation representation from
-            // the start. As an aside, I'm not sure when this list will ever not be a singleton
-            // list, but it's like this way in the JS codebase, so we'll mimic the behavior for now.
+            // the start. Eventually when operation processing code is ready and we make the switch
+            // to using the federation-next representation everywhere, we can probably simplify
+            // this.
             let new_conditions = if all_conditions.len() == 1 {
                 all_conditions
                     .pop()
@@ -1363,16 +1367,20 @@ impl FederatedQueryGraphBuilder {
                 continue;
             }
             provide_id += 1;
-            // PORT_NOTE: This is an optimization to avoid unnecessary inter-conversion between
-            // the apollo-rs operation representation and the federation-next one. This wasn't a
-            // problem in the JS codebase, as it would use its own operation representation from
-            // the start. As an aside, I'm not sure when this list will ever not be a singleton
-            // list, but it's like this way in the JS codebase, so we'll mimic the behavior for now.
+            // PORT_NOTE: I'm not sure when this list will ever not be a singleton list, but it's
+            // like this way in the JS codebase, so we'll mimic the behavior for now.
             //
             // Note that the JS codebase had a bug here when there was more than one selection set,
             // where it would copy per @provides application, but only point the field-collecting
             // edge toward the last copy. We do something similar to @requires instead, where we
             // merge the selection sets before into one.
+            //
+            // TODO: This is an optimization to avoid unnecessary inter-conversion between
+            // the apollo-rs operation representation and the federation-next one. This wasn't a
+            // problem in the JS codebase, as it would use its own operation representation from
+            // the start. Eventually when operation processing code is ready and we make the switch
+            // to using the federation-next representation everywhere, we can probably simplify
+            // this.
             let new_conditions = if all_conditions.len() == 1 {
                 all_conditions
                     .pop()

--- a/src/query_graph/extract_subgraphs_from_supergraph.rs
+++ b/src/query_graph/extract_subgraphs_from_supergraph.rs
@@ -1803,7 +1803,7 @@ fn remove_inactive_applications(
                 let fields = federation_spec_definition
                     .provides_directive_arguments(directive)?
                     .fields;
-                let parent_type_pos = schema
+                let parent_type_pos: CompositeTypeDefinitionPosition = schema
                     .get_type(field.ty.inner_named_type().clone())?
                     .try_into()?;
                 (fields, parent_type_pos)
@@ -1812,10 +1812,11 @@ fn remove_inactive_applications(
                 let fields = federation_spec_definition
                     .requires_directive_arguments(directive)?
                     .fields;
-                let parent_type_pos = object_or_interface_field_definition_position
-                    .parent()
-                    .clone()
-                    .into();
+                let parent_type_pos: CompositeTypeDefinitionPosition =
+                    object_or_interface_field_definition_position
+                        .parent()
+                        .clone()
+                        .into();
                 (fields, parent_type_pos)
             }
         };
@@ -1824,7 +1825,8 @@ fn remove_inactive_applications(
         // directives instead of returning error here, as it pollutes the list of error messages
         // during composition (another site in composition will properly check for field set
         // validity and give better error messaging).
-        let mut fields = parse_field_set(schema.schema(), parent_type_pos, fields)?;
+        let mut fields =
+            parse_field_set(schema.schema(), parent_type_pos.type_name().clone(), fields)?;
         let is_modified = remove_non_external_leaf_fields(schema, &mut fields)?;
         if is_modified {
             let replacement_directive = if fields.selections.is_empty() {

--- a/src/query_graph/extract_subgraphs_from_supergraph.rs
+++ b/src/query_graph/extract_subgraphs_from_supergraph.rs
@@ -1,13 +1,17 @@
-use crate::error::{FederationError, SingleFederationError};
-use crate::link::federation_spec_definition::{FederationSpecDefinition, FEDERATION_VERSIONS};
+use crate::error::{FederationError, MultipleFederationErrors, SingleFederationError};
+use crate::link::federation_spec_definition::{
+    get_federation_spec_definition_from_subgraph, FederationSpecDefinition, FEDERATION_VERSIONS,
+};
 use crate::link::join_spec_definition::{
     FieldDirectiveArguments, JoinSpecDefinition, TypeDirectiveArguments, JOIN_VERSIONS,
 };
 use crate::link::link_spec_definition::LinkSpecDefinition;
 use crate::link::spec::{Identity, Version};
 use crate::link::spec_definition::{spec_definitions, SpecDefinition};
+use crate::query_graph::field_set::parse_field_set;
 use crate::schema::position::{
-    DirectiveDefinitionPosition, EnumTypeDefinitionPosition, InputObjectFieldDefinitionPosition,
+    is_graphql_reserved_name, CompositeTypeDefinitionPosition, DirectiveDefinitionPosition,
+    EnumTypeDefinitionPosition, FieldDefinitionPosition, InputObjectFieldDefinitionPosition,
     InputObjectTypeDefinitionPosition, InterfaceTypeDefinitionPosition,
     ObjectFieldDefinitionPosition, ObjectOrInterfaceFieldDefinitionPosition,
     ObjectOrInterfaceTypeDefinitionPosition, ObjectTypeDefinitionPosition,
@@ -16,6 +20,7 @@ use crate::schema::position::{
 };
 use crate::schema::FederationSchema;
 use apollo_compiler::ast::FieldDefinition;
+use apollo_compiler::executable::{Field, Selection, SelectionSet};
 use apollo_compiler::schema::{
     Component, ComponentName, ComponentOrigin, DirectiveDefinition, DirectiveList,
     DirectiveLocation, EnumType, EnumValueDefinition, ExtendedType, ExtensionId, InputObjectType,
@@ -32,22 +37,21 @@ use std::ops::Deref;
 // TODO: A lot of common data gets passed around in the functions called by this one, considering
 // making an e.g. ExtractSubgraphs struct to contain the data.
 pub(super) fn extract_subgraphs_from_supergraph(
-    supergraph_schema: Schema,
+    supergraph_schema: &FederationSchema,
     validate_extracted_subgraphs: Option<bool>,
 ) -> Result<FederationSubgraphs, FederationError> {
     let validate_extracted_subgraphs = validate_extracted_subgraphs.unwrap_or(true);
-    let (supergraph_schema, link_spec_definition, join_spec_definition) =
-        validate_supergraph(supergraph_schema)?;
+    let (link_spec_definition, join_spec_definition) = validate_supergraph(supergraph_schema)?;
     let is_fed_1 = *join_spec_definition.version() == Version { major: 0, minor: 1 };
     let (mut subgraphs, federation_spec_definitions, graph_enum_value_name_to_subgraph_name) =
-        collect_empty_subgraphs(&supergraph_schema, join_spec_definition)?;
+        collect_empty_subgraphs(supergraph_schema, join_spec_definition)?;
 
     let mut filtered_types = Vec::new();
     for type_definition_position in supergraph_schema.get_types() {
         if !join_spec_definition
-            .is_spec_type_name(&supergraph_schema, type_definition_position.type_name())?
+            .is_spec_type_name(supergraph_schema, type_definition_position.type_name())?
             && !link_spec_definition
-                .is_spec_type_name(&supergraph_schema, type_definition_position.type_name())?
+                .is_spec_type_name(supergraph_schema, type_definition_position.type_name())?
         {
             filtered_types.push(type_definition_position);
         }
@@ -57,7 +61,7 @@ pub(super) fn extract_subgraphs_from_supergraph(
         todo!()
     } else {
         extract_subgraphs_from_fed_2_supergraph(
-            &supergraph_schema,
+            supergraph_schema,
             &mut subgraphs,
             &graph_enum_value_name_to_subgraph_name,
             &federation_spec_definitions,
@@ -103,14 +107,11 @@ pub(super) fn extract_subgraphs_from_supergraph(
     Ok(subgraphs)
 }
 
-type ValidateSupergraphOk = (
-    FederationSchema,
-    &'static LinkSpecDefinition,
-    &'static JoinSpecDefinition,
-);
+type ValidateSupergraphOk = (&'static LinkSpecDefinition, &'static JoinSpecDefinition);
 
-fn validate_supergraph(supergraph_schema: Schema) -> Result<ValidateSupergraphOk, FederationError> {
-    let supergraph_schema = FederationSchema::new(supergraph_schema)?;
+fn validate_supergraph(
+    supergraph_schema: &FederationSchema,
+) -> Result<ValidateSupergraphOk, FederationError> {
     let Some(metadata) = supergraph_schema.metadata() else {
         return Err(SingleFederationError::InvalidFederationSupergraph {
             message: "Invalid supergraph: must be a core schema".to_owned(),
@@ -135,11 +136,7 @@ fn validate_supergraph(supergraph_schema: Schema) -> Result<ValidateSupergraphOk
             ),
         }.into());
     };
-    Ok((
-        supergraph_schema,
-        link_spec_definition,
-        join_spec_definition,
-    ))
+    Ok((link_spec_definition, join_spec_definition))
 }
 
 type CollectEmptySubgraphsOk = (
@@ -160,8 +157,7 @@ fn collect_empty_subgraphs(
     for (enum_value_name, enum_value_definition) in graph_enum.values.iter() {
         let graph_application = enum_value_definition
             .directives
-            .iter()
-            .find(|d| d.name == graph_directive_definition.name)
+            .get(&graph_directive_definition.name)
             .ok_or_else(|| SingleFederationError::InvalidFederationSupergraph {
                 message: format!(
                     "Value \"{}\" of join__Graph enum has no @join__graph directive",
@@ -376,8 +372,8 @@ fn extract_subgraphs_from_fed_2_supergraph(
         })
         .collect::<Vec<_>>();
     for subgraph in subgraphs.subgraphs.values_mut() {
-        // TODO: removeInactiveProvidesAndRequires(subgraph.schema)
-        remove_unused_types_from_subgraph(subgraph)?;
+        remove_inactive_requires_and_provides_from_subgraph(&mut subgraph.schema)?;
+        remove_unused_types_from_subgraph(&mut subgraph.schema)?;
         for definition in all_executable_directive_definitions.iter() {
             DirectiveDefinitionPosition {
                 directive_name: definition.name.clone(),
@@ -409,10 +405,7 @@ fn add_all_empty_subgraph_types(
     for type_definition_position in filtered_types {
         let type_ = type_definition_position.get(supergraph_schema.schema())?;
         let mut type_directive_applications = Vec::new();
-        for directive in type_.directives().iter() {
-            if directive.name != type_directive_definition.name {
-                continue;
-            }
+        for directive in type_.directives().get_all(&type_directive_definition.name) {
             type_directive_applications
                 .push(join_spec_definition.type_directive_arguments(directive)?);
         }
@@ -703,10 +696,10 @@ fn extract_object_type_content(
         };
         let type_ = pos.get(supergraph_schema.schema())?;
 
-        for directive in type_.directives.iter() {
-            if directive.name != implements_directive_definition.name {
-                continue;
-            }
+        for directive in type_
+            .directives
+            .get_all(&implements_directive_definition.name)
+        {
             let implements_directive_application =
                 join_spec_definition.implements_directive_arguments(directive)?;
             if !subgraph_info.contains_key(&implements_directive_application.graph) {
@@ -734,10 +727,7 @@ fn extract_object_type_content(
         for (field_name, field) in type_.fields.iter() {
             let field_pos = pos.field(field_name.clone());
             let mut field_directive_applications = Vec::new();
-            for directive in field.directives.iter() {
-                if directive.name != field_directive_definition.name {
-                    continue;
-                }
+            for directive in field.directives.get_all(&field_directive_definition.name) {
                 field_directive_applications
                     .push(join_spec_definition.field_directive_arguments(directive)?);
             }
@@ -895,10 +885,10 @@ fn extract_interface_type_content(
             })
         }
 
-        for directive in type_.directives.iter() {
-            if directive.name != implements_directive_definition.name {
-                continue;
-            }
+        for directive in type_
+            .directives
+            .get_all(&implements_directive_definition.name)
+        {
             let implements_directive_application =
                 join_spec_definition.implements_directive_arguments(directive)?;
             let subgraph = get_subgraph(
@@ -934,10 +924,7 @@ fn extract_interface_type_content(
 
         for (field_name, field) in type_.fields.iter() {
             let mut field_directive_applications = Vec::new();
-            for directive in field.directives.iter() {
-                if directive.name != field_directive_definition.name {
-                    continue;
-                }
+            for directive in field.directives.get_all(&field_directive_definition.name) {
                 field_directive_applications
                     .push(join_spec_definition.field_directive_arguments(directive)?);
             }
@@ -1042,10 +1029,10 @@ fn extract_union_type_content(
 
         let mut union_member_directive_applications = Vec::new();
         if let Some(union_member_directive_definition) = union_member_directive_definition {
-            for directive in type_.directives.iter() {
-                if directive.name != union_member_directive_definition.name {
-                    continue;
-                }
+            for directive in type_
+                .directives
+                .get_all(&union_member_directive_definition.name)
+            {
                 union_member_directive_applications
                     .push(join_spec_definition.union_member_directive_arguments(directive)?);
             }
@@ -1133,10 +1120,10 @@ fn extract_enum_type_content(
             let value_pos = pos.value(value_name.clone());
             let mut enum_value_directive_applications = Vec::new();
             if let Some(enum_value_directive_definition) = enum_value_directive_definition {
-                for directive in value.directives.iter() {
-                    if directive.name != enum_value_directive_definition.name {
-                        continue;
-                    }
+                for directive in value
+                    .directives
+                    .get_all(&enum_value_directive_definition.name)
+                {
                     enum_value_directive_applications
                         .push(join_spec_definition.enum_value_directive_arguments(directive)?);
                 }
@@ -1215,10 +1202,10 @@ fn extract_input_object_type_content(
         for (input_field_name, input_field) in type_.fields.iter() {
             let input_field_pos = pos.field(input_field_name.clone());
             let mut field_directive_applications = Vec::new();
-            for directive in input_field.directives.iter() {
-                if directive.name != field_directive_definition.name {
-                    continue;
-                }
+            for directive in input_field
+                .directives
+                .get_all(&field_directive_definition.name)
+            {
                 field_directive_applications
                     .push(join_spec_definition.field_directive_arguments(directive)?);
             }
@@ -1488,9 +1475,7 @@ lazy_static! {
     };
 }
 
-fn remove_unused_types_from_subgraph(
-    subgraph: &mut FederationSubgraph,
-) -> Result<(), FederationError> {
+fn remove_unused_types_from_subgraph(schema: &mut FederationSchema) -> Result<(), FederationError> {
     // We now do an additional path on all types because we sometimes added types to subgraphs
     // without being sure that the subgraph had the type in the first place (especially with the
     // join 0.1 spec), and because we later might not have added any fields/members to said type,
@@ -1498,7 +1483,7 @@ fn remove_unused_types_from_subgraph(
     // need to remove them. Note that need to do this _after_ the `add_external_fields()` call above
     // since it may have added (external) fields to some of the types.
     let mut type_definition_positions: Vec<TypeDefinitionPosition> = Vec::new();
-    for (type_name, type_) in subgraph.schema.schema().types.iter() {
+    for (type_name, type_) in schema.schema().types.iter() {
         match type_ {
             ExtendedType::Object(type_) => {
                 if type_.fields.is_empty() {
@@ -1549,16 +1534,16 @@ fn remove_unused_types_from_subgraph(
     for position in type_definition_positions {
         match position {
             TypeDefinitionPosition::Object(position) => {
-                position.remove_recursive(&mut subgraph.schema)?;
+                position.remove_recursive(schema)?;
             }
             TypeDefinitionPosition::Interface(position) => {
-                position.remove_recursive(&mut subgraph.schema)?;
+                position.remove_recursive(schema)?;
             }
             TypeDefinitionPosition::Union(position) => {
-                position.remove_recursive(&mut subgraph.schema)?;
+                position.remove_recursive(schema)?;
             }
             TypeDefinitionPosition::InputObject(position) => {
-                position.remove_recursive(&mut subgraph.schema)?;
+                position.remove_recursive(schema)?;
             }
             _ => {
                 return Err(SingleFederationError::Internal {
@@ -1633,11 +1618,7 @@ fn add_federation_operations(
             let ExtendedType::Object(type_) = type_ else {
                 return None;
             };
-            if !type_
-                .directives
-                .iter()
-                .any(|d| d.name == key_directive_definition.name)
-            {
+            if !type_.directives.has(&key_directive_definition.name) {
                 return None;
             }
             Some(ComponentName::from(type_name))
@@ -1728,4 +1709,271 @@ fn add_federation_operations(
     )?;
 
     Ok(())
+}
+
+// It makes no sense to have a @requires/@provides on a non-external leaf field, and we usually
+// reject it during schema validation. But this function remove such fields for when:
+//  1. We extract subgraphs from a Fed 1 supergraph, where such validations haven't been run.
+//  2. Fed 1 subgraphs are upgraded to Fed 2 subgraphs.
+//
+// The reason we do this (and generally reject it) is that such @requires/@provides have a negative
+// impact on later query planning, because it sometimes make us try type-exploding some interfaces
+// unnecessarily. Besides, if a usage adds something useless, there is a chance it hasn't fully
+// understood something, and warning about that fact through an error is more helpful.
+fn remove_inactive_requires_and_provides_from_subgraph(
+    schema: &mut FederationSchema,
+) -> Result<(), FederationError> {
+    let federation_spec_definition = get_federation_spec_definition_from_subgraph(schema)?;
+    let requires_directive_definition_name = federation_spec_definition
+        .requires_directive_definition(schema)?
+        .name
+        .clone();
+    let provides_directive_definition_name = federation_spec_definition
+        .provides_directive_definition(schema)?
+        .name
+        .clone();
+
+    for type_pos in schema.get_types() {
+        // Ignore introspection types.
+        if is_graphql_reserved_name(type_pos.type_name()) {
+            continue;
+        }
+
+        // Ignore non-object/interface types.
+        let Ok(type_pos): Result<ObjectOrInterfaceTypeDefinitionPosition, _> = type_pos.try_into()
+        else {
+            continue;
+        };
+
+        let object_or_interface_field_definition_positions: Vec<
+            ObjectOrInterfaceFieldDefinitionPosition,
+        > = match type_pos {
+            ObjectOrInterfaceTypeDefinitionPosition::Object(type_pos) => type_pos
+                .get(schema.schema())?
+                .fields
+                .keys()
+                .map(|field_name| type_pos.field(field_name.clone()).into())
+                .collect(),
+            ObjectOrInterfaceTypeDefinitionPosition::Interface(type_pos) => type_pos
+                .get(schema.schema())?
+                .fields
+                .keys()
+                .map(|field_name| type_pos.field(field_name.clone()).into())
+                .collect(),
+        };
+
+        for pos in object_or_interface_field_definition_positions {
+            remove_inactive_applications(
+                schema,
+                federation_spec_definition,
+                FieldSetDirectiveKind::Requires,
+                &requires_directive_definition_name,
+                pos.clone(),
+            )?;
+            remove_inactive_applications(
+                schema,
+                federation_spec_definition,
+                FieldSetDirectiveKind::Provides,
+                &provides_directive_definition_name,
+                pos,
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+enum FieldSetDirectiveKind {
+    Provides,
+    Requires,
+}
+
+fn remove_inactive_applications(
+    schema: &mut FederationSchema,
+    federation_spec_definition: &'static FederationSpecDefinition,
+    directive_kind: FieldSetDirectiveKind,
+    name_in_schema: &Name,
+    object_or_interface_field_definition_position: ObjectOrInterfaceFieldDefinitionPosition,
+) -> Result<(), FederationError> {
+    let mut replacement_directives = Vec::new();
+    let field = object_or_interface_field_definition_position.get(schema.schema())?;
+    for directive in field.directives.get_all(name_in_schema) {
+        let (fields, parent_type_pos) = match directive_kind {
+            FieldSetDirectiveKind::Provides => {
+                let fields = federation_spec_definition
+                    .provides_directive_arguments(directive)?
+                    .fields;
+                let parent_type_pos = schema
+                    .get_type(field.ty.inner_named_type().clone())?
+                    .try_into()?;
+                (fields, parent_type_pos)
+            }
+            FieldSetDirectiveKind::Requires => {
+                let fields = federation_spec_definition
+                    .requires_directive_arguments(directive)?
+                    .fields;
+                let parent_type_pos = object_or_interface_field_definition_position
+                    .parent()
+                    .clone()
+                    .into();
+                (fields, parent_type_pos)
+            }
+        };
+        // TODO: In the JS codebase, this function ends up getting additionally used in the schema
+        // upgrader, where parsing the field set may error. In such cases, we end up skipping those
+        // directives instead of returning error here, as it pollutes the list of error messages
+        // during composition (another site in composition will properly check for field set
+        // validity and give better error messaging).
+        let mut fields = parse_field_set(schema.schema(), parent_type_pos, fields)?;
+        let is_modified = remove_non_external_leaf_fields(schema, &mut fields)?;
+        if is_modified {
+            let replacement_directive = if fields.selections.is_empty() {
+                None
+            } else {
+                let fields = NodeStr::from(fields.serialize().no_indent().to_string());
+                Some(Node::new(match directive_kind {
+                    FieldSetDirectiveKind::Provides => {
+                        federation_spec_definition.provides_directive(schema, fields)?
+                    }
+                    FieldSetDirectiveKind::Requires => {
+                        federation_spec_definition.requires_directive(schema, fields)?
+                    }
+                }))
+            };
+            replacement_directives.push((directive.clone(), replacement_directive))
+        }
+    }
+
+    for (old_directive, new_directive) in replacement_directives {
+        object_or_interface_field_definition_position.remove_directive(schema, &old_directive);
+        if let Some(new_directive) = new_directive {
+            object_or_interface_field_definition_position
+                .insert_directive(schema, new_directive)?;
+        }
+    }
+    Ok(())
+}
+
+// Removes any non-external leaf fields from the selection set, returning true if the selection
+// set was modified.
+fn remove_non_external_leaf_fields(
+    schema: &FederationSchema,
+    selection_set: &mut SelectionSet,
+) -> Result<bool, FederationError> {
+    let federation_spec_definition = get_federation_spec_definition_from_subgraph(schema)?;
+    let external_directive_definition_name = federation_spec_definition
+        .external_directive_definition(schema)?
+        .name
+        .clone();
+    remove_non_external_leaf_fields_internal(
+        schema,
+        &external_directive_definition_name,
+        selection_set,
+    )
+}
+
+fn remove_non_external_leaf_fields_internal(
+    schema: &FederationSchema,
+    external_directive_definition_name: &Name,
+    selection_set: &mut SelectionSet,
+) -> Result<bool, FederationError> {
+    let mut is_modified = false;
+    let mut errors = MultipleFederationErrors { errors: Vec::new() };
+    selection_set.selections.retain_mut(|selection| {
+        let child_selection_set = match selection {
+            Selection::Field(field) => {
+                match is_external_or_has_external_implementations(
+                    schema,
+                    external_directive_definition_name,
+                    &selection_set.ty,
+                    field,
+                ) {
+                    Ok(is_external) => {
+                        if is_external {
+                            // Either the field or one of its implementors is external, so we keep
+                            // the entire selection in that case.
+                            return true;
+                        }
+                    }
+                    Err(error) => {
+                        errors.push(error);
+                        return false;
+                    }
+                };
+                if field.selection_set.selections.is_empty() {
+                    // An empty selection set means this is a leaf field. We would have returned
+                    // earlier if this were external, so this is a non-external leaf field.
+                    is_modified = true;
+                    return false;
+                }
+                &mut field.make_mut().selection_set
+            }
+            Selection::InlineFragment(inline_fragment) => {
+                &mut inline_fragment.make_mut().selection_set
+            }
+            Selection::FragmentSpread(_) => {
+                errors.push(
+                    SingleFederationError::Internal {
+                        message: "Unexpectedly found named fragment in FieldSet scalar".to_owned(),
+                    }
+                    .into(),
+                );
+                return false;
+            }
+        };
+        // At this point, we either have a non-leaf non-external field, or an inline fragment. In
+        // either case, we recurse into its selection set.
+        match remove_non_external_leaf_fields_internal(
+            schema,
+            external_directive_definition_name,
+            child_selection_set,
+        ) {
+            Ok(is_child_modified) => {
+                if is_child_modified {
+                    is_modified = true;
+                }
+            }
+            Err(error) => {
+                errors.push(error);
+                return false;
+            }
+        }
+        // If the recursion resulted in the selection set becoming empty, we remove this selection.
+        // Note that it shouldn't have started out empty, so if it became empty, is_child_modified
+        // would have been true, which means is_modified has already been set appropriately.
+        !child_selection_set.selections.is_empty()
+    });
+    if errors.errors.is_empty() {
+        Ok(is_modified)
+    } else {
+        Err(errors.into())
+    }
+}
+
+fn is_external_or_has_external_implementations(
+    schema: &FederationSchema,
+    external_directive_definition_name: &Name,
+    parent_type_name: &NamedType,
+    selection: &Node<Field>,
+) -> Result<bool, FederationError> {
+    let type_pos: CompositeTypeDefinitionPosition =
+        schema.get_type(parent_type_name.clone())?.try_into()?;
+    let field_pos = type_pos.field(selection.name.clone())?;
+    let field = field_pos.get(schema.schema())?;
+    if field.directives.has(external_directive_definition_name) {
+        return Ok(true);
+    }
+    if let FieldDefinitionPosition::Interface(field_pos) = field_pos {
+        for runtime_object_pos in schema.possible_runtime_types(field_pos.parent().into())? {
+            let runtime_field_pos = runtime_object_pos.field(field_pos.field_name.clone());
+            let runtime_field = runtime_field_pos.get(schema.schema())?;
+            if runtime_field
+                .directives
+                .has(external_directive_definition_name)
+            {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
 }

--- a/src/query_graph/extract_subgraphs_from_supergraph.rs
+++ b/src/query_graph/extract_subgraphs_from_supergraph.rs
@@ -32,10 +32,10 @@ use lazy_static::lazy_static;
 use std::collections::BTreeMap;
 use std::ops::Deref;
 
-// Assumes the given schema has been validated.
-//
-// TODO: A lot of common data gets passed around in the functions called by this one, considering
-// making an e.g. ExtractSubgraphs struct to contain the data.
+/// Assumes the given schema has been validated.
+///
+/// TODO: A lot of common data gets passed around in the functions called by this one, considering
+/// making an e.g. ExtractSubgraphs struct to contain the data.
 pub(super) fn extract_subgraphs_from_supergraph(
     supergraph_schema: &FederationSchema,
     validate_extracted_subgraphs: Option<bool>,
@@ -196,7 +196,7 @@ fn collect_empty_subgraphs(
     ))
 }
 
-// TODO: Use the JS/programmatic approach instead of hard-coding definitions.
+/// TODO: Use the JS/programmatic approach instead of hard-coding definitions.
 pub(crate) fn new_empty_fed_2_subgraph_schema() -> Result<FederationSchema, FederationError> {
     FederationSchema::new(Schema::parse(
         r#"
@@ -1711,15 +1711,15 @@ fn add_federation_operations(
     Ok(())
 }
 
-// It makes no sense to have a @requires/@provides on a non-external leaf field, and we usually
-// reject it during schema validation. But this function remove such fields for when:
-//  1. We extract subgraphs from a Fed 1 supergraph, where such validations haven't been run.
-//  2. Fed 1 subgraphs are upgraded to Fed 2 subgraphs.
-//
-// The reason we do this (and generally reject it) is that such @requires/@provides have a negative
-// impact on later query planning, because it sometimes make us try type-exploding some interfaces
-// unnecessarily. Besides, if a usage adds something useless, there is a chance it hasn't fully
-// understood something, and warning about that fact through an error is more helpful.
+/// It makes no sense to have a @requires/@provides on a non-external leaf field, and we usually
+/// reject it during schema validation. But this function remove such fields for when:
+///  1. We extract subgraphs from a Fed 1 supergraph, where such validations haven't been run.
+///  2. Fed 1 subgraphs are upgraded to Fed 2 subgraphs.
+///
+/// The reason we do this (and generally reject it) is that such @requires/@provides have a negative
+/// impact on later query planning, because it sometimes make us try type-exploding some interfaces
+/// unnecessarily. Besides, if a usage adds something useless, there is a chance it hasn't fully
+/// understood something, and warning about that fact through an error is more helpful.
 fn remove_inactive_requires_and_provides_from_subgraph(
     schema: &mut FederationSchema,
 ) -> Result<(), FederationError> {
@@ -1856,8 +1856,8 @@ fn remove_inactive_applications(
     Ok(())
 }
 
-// Removes any non-external leaf fields from the selection set, returning true if the selection
-// set was modified.
+/// Removes any non-external leaf fields from the selection set, returning true if the selection
+/// set was modified.
 fn remove_non_external_leaf_fields(
     schema: &FederationSchema,
     selection_set: &mut SelectionSet,

--- a/src/query_graph/field_set.rs
+++ b/src/query_graph/field_set.rs
@@ -1,0 +1,73 @@
+use crate::error::{FederationError, MultipleFederationErrors, SingleFederationError};
+use crate::schema::position::CompositeTypeDefinitionPosition;
+use apollo_compiler::executable::{FieldSet, SelectionSet};
+use apollo_compiler::{NodeStr, Schema};
+
+// TODO: In the JS codebase, this optionally runs an additional validation to forbid aliases, and
+// has some error-rewriting to help give the user better hints around non-existent fields.
+pub(super) fn parse_field_set(
+    schema: &Schema,
+    parent_composite_type_definition_position: CompositeTypeDefinitionPosition,
+    value: NodeStr,
+) -> Result<SelectionSet, FederationError> {
+    // Note this parsing takes care of adding curly braces ("{" and "}") if they aren't in the
+    // string.
+    let field_set = FieldSet::parse(
+        schema,
+        parent_composite_type_definition_position
+            .type_name()
+            .clone(),
+        value.as_str(),
+        "field_set.graphql",
+    );
+    field_set
+        .validate(schema)
+        .map_err(|d| MultipleFederationErrors {
+            errors: d
+                .iter()
+                .map(|e| SingleFederationError::InvalidGraphQL {
+                    message: e.message().to_string(),
+                })
+                .collect(),
+        })?;
+    merge_selection_sets(&[&field_set.selection_set])
+}
+
+pub(super) fn merge_selection_sets(
+    _selection_sets: &[&SelectionSet],
+) -> Result<SelectionSet, FederationError> {
+    // TODO: Once operation processing is done, we should be able to call into that logic here.
+    // We're specifically wanting the equivalent of something like
+    // ```
+    // SelectionSetUpdates()
+    //   .add(selectionSetOfNode(...))
+    //   .add(selectionSetOfNode(...))
+    //   ...
+    //   .add(selectionSetOfNode(...))
+    //   .toSelectionSetNode(...);
+    // ```
+    // from the JS codebase. It may be more performant for federation-next to use its own
+    // representation instead of repeatedly inter-converting between its representation and the
+    // apollo-rs one, but we'll cross that bridge if we come to it.
+    //
+    // Note this is unrelated to the concept of "normalization" in the JS codebase, which
+    // specifically refers to the "SelectionSet.normalize()" method. The above is primarily useful
+    // in merging fields/fragments with the same "key" (which could be thought of as some kind of
+    // normalization, but is distinct from the kind of normalization in "SelectionSet.normalize()").
+    todo!();
+}
+
+pub(super) fn equal_selection_sets(
+    _a: &SelectionSet,
+    _b: &SelectionSet,
+) -> Result<bool, FederationError> {
+    // TODO: Once operation processing is done, we should be able to call into that logic here.
+    // We're specifically wanting the equivalent of something like
+    // ```
+    // selectionSetOfNode(...).equals(selectionSetOfNode(...));
+    // ```
+    // from the JS codebase. It may be more performant for federation-next to use its own
+    // representation instead of repeatedly inter-converting between its representation and the
+    // apollo-rs one, but we'll cross that bridge if we come to it.
+    todo!();
+}

--- a/src/query_graph/field_set.rs
+++ b/src/query_graph/field_set.rs
@@ -1,4 +1,4 @@
-use crate::error::{FederationError, MultipleFederationErrors, SingleFederationError};
+use crate::error::FederationError;
 use apollo_compiler::executable::{FieldSet, SelectionSet};
 use apollo_compiler::schema::NamedType;
 use apollo_compiler::{NodeStr, Schema};
@@ -18,16 +18,7 @@ pub(super) fn parse_field_set(
         value.as_str(),
         "field_set.graphql",
     );
-    field_set
-        .validate(schema)
-        .map_err(|d| MultipleFederationErrors {
-            errors: d
-                .iter()
-                .map(|e| SingleFederationError::InvalidGraphQL {
-                    message: e.message().to_string(),
-                })
-                .collect(),
-        })?;
+    field_set.validate(schema)?;
     merge_selection_sets(&[&field_set.selection_set])
 }
 

--- a/src/query_graph/field_set.rs
+++ b/src/query_graph/field_set.rs
@@ -1,22 +1,20 @@
 use crate::error::{FederationError, MultipleFederationErrors, SingleFederationError};
-use crate::schema::position::CompositeTypeDefinitionPosition;
 use apollo_compiler::executable::{FieldSet, SelectionSet};
+use apollo_compiler::schema::NamedType;
 use apollo_compiler::{NodeStr, Schema};
 
 // TODO: In the JS codebase, this optionally runs an additional validation to forbid aliases, and
 // has some error-rewriting to help give the user better hints around non-existent fields.
 pub(super) fn parse_field_set(
     schema: &Schema,
-    parent_composite_type_definition_position: CompositeTypeDefinitionPosition,
+    parent_type_name: NamedType,
     value: NodeStr,
 ) -> Result<SelectionSet, FederationError> {
     // Note this parsing takes care of adding curly braces ("{" and "}") if they aren't in the
     // string.
     let field_set = FieldSet::parse(
         schema,
-        parent_composite_type_definition_position
-            .type_name()
-            .clone(),
+        parent_type_name,
         value.as_str(),
         "field_set.graphql",
     );

--- a/src/query_graph/mod.rs
+++ b/src/query_graph/mod.rs
@@ -7,7 +7,7 @@ use crate::schema::FederationSchema;
 use apollo_compiler::executable::SelectionSet;
 use apollo_compiler::schema::{Name, NamedType};
 use apollo_compiler::{Node, NodeStr};
-use indexmap::{Equivalent, IndexMap, IndexSet};
+use indexmap::{IndexMap, IndexSet};
 use petgraph::graph::{DiGraph, EdgeIndex, NodeIndex};
 use std::fmt::{Display, Formatter};
 use std::hash::Hash;
@@ -314,10 +314,7 @@ impl QueryGraph {
         self.schema_by_source(&self.current_source)
     }
 
-    fn schema_by_source<Q: ?Sized>(&self, source: &Q) -> Result<&FederationSchema, FederationError>
-    where
-        Q: Hash + Equivalent<NodeStr>,
-    {
+    fn schema_by_source(&self, source: &str) -> Result<&FederationSchema, FederationError> {
         self.sources.get(source).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: "Schema unexpectedly missing".to_owned(),
@@ -332,13 +329,10 @@ impl QueryGraph {
         self.types_to_nodes_by_source(&self.current_source)
     }
 
-    fn types_to_nodes_by_source<Q: ?Sized>(
+    fn types_to_nodes_by_source(
         &self,
-        source: &Q,
-    ) -> Result<&IndexMap<NamedType, IndexSet<NodeIndex>>, FederationError>
-    where
-        Q: Hash + Equivalent<NodeStr>,
-    {
+        source: &str,
+    ) -> Result<&IndexMap<NamedType, IndexSet<NodeIndex>>, FederationError> {
         self.types_to_nodes_by_source.get(source).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: "Types-to-nodes map unexpectedly missing".to_owned(),

--- a/src/query_graph/mod.rs
+++ b/src/query_graph/mod.rs
@@ -50,22 +50,10 @@ impl Display for QueryGraphNode {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, derive_more::From)]
 pub(crate) enum QueryGraphNodeType {
     SchemaType(OutputTypeDefinitionPosition),
     FederatedRootType(SchemaRootDefinitionKind),
-}
-
-impl From<OutputTypeDefinitionPosition> for QueryGraphNodeType {
-    fn from(value: OutputTypeDefinitionPosition) -> Self {
-        QueryGraphNodeType::SchemaType(value)
-    }
-}
-
-impl From<SchemaRootDefinitionKind> for QueryGraphNodeType {
-    fn from(value: SchemaRootDefinitionKind) -> Self {
-        QueryGraphNodeType::FederatedRootType(value)
-    }
 }
 
 impl Display for QueryGraphNodeType {

--- a/src/query_graph/mod.rs
+++ b/src/query_graph/mod.rs
@@ -52,13 +52,13 @@ impl Display for QueryGraphNode {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) enum QueryGraphNodeType {
-    SubgraphType(OutputTypeDefinitionPosition),
+    SchemaType(OutputTypeDefinitionPosition),
     FederatedRootType(SchemaRootDefinitionKind),
 }
 
 impl From<OutputTypeDefinitionPosition> for QueryGraphNodeType {
     fn from(value: OutputTypeDefinitionPosition) -> Self {
-        QueryGraphNodeType::SubgraphType(value)
+        QueryGraphNodeType::SchemaType(value)
     }
 }
 
@@ -71,7 +71,7 @@ impl From<SchemaRootDefinitionKind> for QueryGraphNodeType {
 impl Display for QueryGraphNodeType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            QueryGraphNodeType::SubgraphType(pos) => pos.fmt(f),
+            QueryGraphNodeType::SchemaType(pos) => pos.fmt(f),
             QueryGraphNodeType::FederatedRootType(root_kind) => {
                 write!(f, "[{}]", root_kind)
             }

--- a/src/query_graph/mod.rs
+++ b/src/query_graph/mod.rs
@@ -18,20 +18,20 @@ mod field_set;
 
 #[derive(Debug, Clone)]
 pub(crate) struct QueryGraphNode {
-    // The GraphQL type this node points to.
+    /// The GraphQL type this node points to.
     pub(crate) type_: QueryGraphNodeType,
-    // An identifier of the underlying schema containing the `type_` this node points to. This is
-    // mainly used in federated query graphs, where the `source` is a subgraph name.
+    /// An identifier of the underlying schema containing the `type_` this node points to. This is
+    /// mainly used in federated query graphs, where the `source` is a subgraph name.
     pub(crate) source: NodeStr,
-    // True if there is a cross-subgraph edge that is reachable from this node.
+    /// True if there is a cross-subgraph edge that is reachable from this node.
     pub(crate) has_reachable_cross_subgraph_edges: bool,
-    // @provides works by creating duplicates of the node/type involved in the provides and adding
-    // the provided edges only to those copies. This means that with @provides, you can have more
-    // than one node per-type-and-subgraph in a query graph. Which is fine, but this `provide_id`
-    // allows distinguishing if a node was created as part of this @provides duplication or not. The
-    // value of this field has no other meaning than to be unique per-@provide, and so all the nodes
-    // copied for a given @provides application will have the same `provide_id`. Overall, this
-    // mostly exists for debugging visualization.
+    /// @provides works by creating duplicates of the node/type involved in the provides and adding
+    /// the provided edges only to those copies. This means that with @provides, you can have more
+    /// than one node per-type-and-subgraph in a query graph. Which is fine, but this `provide_id`
+    /// allows distinguishing if a node was created as part of this @provides duplication or not.
+    /// The value of this field has no other meaning than to be unique per-@provide, and so all the
+    /// nodes copied for a given @provides application will have the same `provide_id`. Overall,
+    /// this mostly exists for debugging visualization.
     pub(crate) provide_id: Option<u32>,
     // If present, this node represents a root node of the corresponding kind.
     pub(crate) root_kind: Option<SchemaRootDefinitionKind>,
@@ -81,21 +81,21 @@ impl Display for QueryGraphNodeType {
 
 #[derive(Debug, Clone)]
 pub(crate) struct QueryGraphEdge {
-    // Indicates what kind of edge this is and what the edge does/represents. For instance, if the
-    // edge represents a field, the `transition` will be a `FieldCollection` transition and will
-    // link to the definition of the field it represents.
+    /// Indicates what kind of edge this is and what the edge does/represents. For instance, if the
+    /// edge represents a field, the `transition` will be a `FieldCollection` transition and will
+    /// link to the definition of the field it represents.
     pub(crate) transition: QueryGraphEdgeTransition,
-    // Optional conditions on an edge.
-    //
-    // Conditions are a select of selections (in the GraphQL sense) that the traversal of a query
-    // graph needs to "collect" (traverse edges with transitions corresponding to those selections)
-    // in order to be able to collect that edge.
-    //
-    // Conditions are primarily used for edges corresponding to @key, in which case they correspond
-    // to the fields composing the @key. In other words, for an @key edge, conditions basically
-    // represent the fact that you need the key to be able to use an @key edge.
-    //
-    // Outside of keys, @requires edges also rely on conditions.
+    /// Optional conditions on an edge.
+    ///
+    /// Conditions are a select of selections (in the GraphQL sense) that the traversal of a query
+    /// graph needs to "collect" (traverse edges with transitions corresponding to those selections)
+    /// in order to be able to collect that edge.
+    ///
+    /// Conditions are primarily used for edges corresponding to @key, in which case they correspond
+    /// to the fields composing the @key. In other words, for an @key edge, conditions basically
+    /// represent the fact that you need the key to be able to use an @key edge.
+    ///
+    /// Outside of keys, @requires edges also rely on conditions.
     pub(crate) conditions: Option<Node<SelectionSet>>,
 }
 
@@ -121,62 +121,62 @@ impl Display for QueryGraphEdge {
     }
 }
 
-// The type of query graph edge "transition".
-//
-// An edge transition encodes what the edge corresponds to, in the underlying GraphQL schema.
+/// The type of query graph edge "transition".
+///
+/// An edge transition encodes what the edge corresponds to, in the underlying GraphQL schema.
 #[derive(Debug, Clone)]
 pub(crate) enum QueryGraphEdgeTransition {
-    // A field edge, going from (a node for) the field parent type to the field's (base) type.
+    /// A field edge, going from (a node for) the field parent type to the field's (base) type.
     FieldCollection {
-        // The name of the schema containing the field.
+        /// The name of the schema containing the field.
         source: NodeStr,
-        // The object/interface field being collected.
+        /// The object/interface field being collected.
         field_definition_position: FieldDefinitionPosition,
-        // Whether this field is part of an @provides.
+        /// Whether this field is part of an @provides.
         is_part_of_provides: bool,
     },
-    // A downcast edge, going from a composite type (object, interface, or union) to another
-    // composite type that intersects that type (i.e. has at least one possible runtime object type
-    // in common with it).
+    /// A downcast edge, going from a composite type (object, interface, or union) to another
+    /// composite type that intersects that type (i.e. has at least one possible runtime object type
+    /// in common with it).
     Downcast {
-        // The name of the schema containing the from/to types.
+        /// The name of the schema containing the from/to types.
         source: NodeStr,
-        // The parent type of the type condition, i.e. the type of the selection set containing
-        // the type condition.
+        /// The parent type of the type condition, i.e. the type of the selection set containing
+        /// the type condition.
         from_type_position: CompositeTypeDefinitionPosition,
-        // The type of the type condition, i.e. the type coming after "... on".
+        /// The type of the type condition, i.e. the type coming after "... on".
         to_type_position: CompositeTypeDefinitionPosition,
     },
-    // A key edge (only found in federated query graphs) going from an entity type in a particular
-    // subgraph to the same entity type but in another subgraph. Key transition edges _must_ have
-    // `conditions` corresponding to the key fields.
+    /// A key edge (only found in federated query graphs) going from an entity type in a particular
+    /// subgraph to the same entity type but in another subgraph. Key transition edges _must_ have
+    /// `conditions` corresponding to the key fields.
     KeyResolution,
-    // A root type edge (only found in federated query graphs) going from a root type (query,
-    // mutation or subscription) of a subgraph to the (same) root type of another subgraph. It
-    // encodes the fact that if a subgraph field returns a root type, any subgraph can be queried
-    // from there.
+    /// A root type edge (only found in federated query graphs) going from a root type (query,
+    /// mutation or subscription) of a subgraph to the (same) root type of another subgraph. It
+    /// encodes the fact that if a subgraph field returns a root type, any subgraph can be queried
+    /// from there.
     RootTypeResolution {
-        // The kind of schema root resolved.
+        /// The kind of schema root resolved.
         root_kind: SchemaRootDefinitionKind,
     },
-    // A subgraph-entering edge, which is a special case only used for edges coming out of the root
-    // nodes of "federated" query graphs. It does not correspond to any physical GraphQL elements
-    // but can be understood as the fact that the router is always free to start querying any of the
-    // subgraph services as needed.
+    /// A subgraph-entering edge, which is a special case only used for edges coming out of the root
+    /// nodes of "federated" query graphs. It does not correspond to any physical GraphQL elements
+    /// but can be understood as the fact that the router is always free to start querying any of
+    /// the subgraph services as needed.
     SubgraphEnteringTransition,
-    // A "fake" downcast edge (only found in federated query graphs) going from an @interfaceObject
-    // type to an implementation. This encodes the fact that an @interfaceObject type "stands-in"
-    // for any possible implementations (in the supergraph) of the corresponding interface. It is
-    // "fake" because the corresponding edge stays on the @interfaceObject type (this is also why
-    // the "to type" is only a name: that to/casted type does not actually exist in the subgraph
-    // in which the corresponding edge will be found).
+    /// A "fake" downcast edge (only found in federated query graphs) going from an @interfaceObject
+    /// type to an implementation. This encodes the fact that an @interfaceObject type "stands-in"
+    /// for any possible implementations (in the supergraph) of the corresponding interface. It is
+    /// "fake" because the corresponding edge stays on the @interfaceObject type (this is also why
+    /// the "to type" is only a name: that to/casted type does not actually exist in the subgraph
+    /// in which the corresponding edge will be found).
     InterfaceObjectFakeDownCast {
-        // The name of the schema containing the from type.
+        /// The name of the schema containing the from type.
         source: NodeStr,
-        // The parent type of the type condition, i.e. the type of the selection set containing
-        // the type condition.
+        /// The parent type of the type condition, i.e. the type of the selection set containing
+        /// the type condition.
         from_type_position: CompositeTypeDefinitionPosition,
-        // The type of the type condition, i.e. the type coming after "... on".
+        /// The type of the type condition, i.e. the type coming after "... on".
         to_type_name: Name,
     },
 }
@@ -225,46 +225,46 @@ impl Display for QueryGraphEdgeTransition {
 }
 
 pub struct QueryGraph {
-    // The "current" source of the query graph. For query graphs representing a single source graph,
-    // this will only ever be one value, but it will change for "federated" query graphs while
-    // they're being built (and after construction, will become FEDERATED_GRAPH_ROOT_SOURCE, which
-    // is a reserved placeholder value).
+    /// The "current" source of the query graph. For query graphs representing a single source
+    /// graph, this will only ever be one value, but it will change for "federated" query graphs
+    /// while they're being built (and after construction, will become FEDERATED_GRAPH_ROOT_SOURCE,
+    /// which is a reserved placeholder value).
     current_source: NodeStr,
-    // The nodes/edges of the query graph. Note that nodes/edges should never be removed, so indexes
-    // are immutable when a node/edge is created.
+    /// The nodes/edges of the query graph. Note that nodes/edges should never be removed, so
+    /// indexes are immutable when a node/edge is created.
     graph: DiGraph<QueryGraphNode, QueryGraphEdge>,
-    // The sources on which the query graph was built, which is a set (potentially of size 1) of
-    // GraphQL schema keyed by the name identifying them. Note that the `source` strings in the
-    // nodes/edges of a query graph are guaranteed to be valid key in this map.
+    /// The sources on which the query graph was built, which is a set (potentially of size 1) of
+    /// GraphQL schema keyed by the name identifying them. Note that the `source` strings in the
+    /// nodes/edges of a query graph are guaranteed to be valid key in this map.
     sources: IndexMap<NodeStr, FederationSchema>,
-    // A map (keyed by source) that associates type names of the underlying schema on which this
-    // query graph was built to each of the nodes that points to a type of that name. Note that for
-    // a "federated" query graph source, each type name will only map to a single node.
+    /// A map (keyed by source) that associates type names of the underlying schema on which this
+    /// query graph was built to each of the nodes that points to a type of that name. Note that for
+    /// a "federated" query graph source, each type name will only map to a single node.
     types_to_nodes_by_source: IndexMap<NodeStr, IndexMap<NamedType, IndexSet<NodeIndex>>>,
-    // A map (keyed by source) that associates schema root kinds to root nodes.
+    /// A map (keyed by source) that associates schema root kinds to root nodes.
     root_kinds_to_nodes_by_source: IndexMap<NodeStr, IndexMap<SchemaRootDefinitionKind, NodeIndex>>,
-    // Maps an edge to the possible edges that can follow it "productively", that is without
-    // creating a trivially inefficient path.
-    //
-    // More precisely, this map is equivalent to looking at the out edges of a given edge's tail
-    // node and filtering those edges that "never make sense" after the given edge, which mainly
-    // amounts to avoiding chaining @key edges when we know there is guaranteed to be a better
-    // option. As an example, suppose we have 3 subgraphs A, B and C which all defined an
-    // `@key(fields: "id")` on some entity type `T`. Then it is never interesting to take that @key
-    // edge from B -> C after A -> B because if we're in A and want to get to C, we can always do
-    // A -> C (of course, this is only true because it's the "same" key).
-    //
-    // See `precompute_non_trivial_followup_edges` for more details on which exact edges are
-    // filtered.
-    //
-    // Lastly, note that the main reason for having this field is that its result is pre-computed.
-    // Which in turn is done for performance reasons: having the same key defined in multiple
-    // subgraphs is _the_ most common pattern, and while our later algorithms (composition
-    // validation and query planning) would know to not select those trivially inefficient
-    // "detours", they might have to redo those checks many times and pre-computing once it is
-    // significantly faster (and pretty easy). FWIW, when originally introduced, this optimization
-    // lowered composition validation on a big composition (100+ subgraphs) from ~4 minutes to
-    // ~10 seconds.
+    /// Maps an edge to the possible edges that can follow it "productively", that is without
+    /// creating a trivially inefficient path.
+    ///
+    /// More precisely, this map is equivalent to looking at the out edges of a given edge's tail
+    /// node and filtering those edges that "never make sense" after the given edge, which mainly
+    /// amounts to avoiding chaining @key edges when we know there is guaranteed to be a better
+    /// option. As an example, suppose we have 3 subgraphs A, B and C which all defined an
+    /// `@key(fields: "id")` on some entity type `T`. Then it is never interesting to take that @key
+    /// edge from B -> C after A -> B because if we're in A and want to get to C, we can always do
+    /// A -> C (of course, this is only true because it's the "same" key).
+    ///
+    /// See `precompute_non_trivial_followup_edges` for more details on which exact edges are
+    /// filtered.
+    ///
+    /// Lastly, note that the main reason for having this field is that its result is pre-computed.
+    /// Which in turn is done for performance reasons: having the same key defined in multiple
+    /// subgraphs is _the_ most common pattern, and while our later algorithms (composition
+    /// validation and query planning) would know to not select those trivially inefficient
+    /// "detours", they might have to redo those checks many times and pre-computing once it is
+    /// significantly faster (and pretty easy). FWIW, when originally introduced, this optimization
+    /// lowered composition validation on a big composition (100+ subgraphs) from ~4 minutes to
+    /// ~10 seconds.
     non_trivial_followup_edges: IndexMap<EdgeIndex, IndexSet<EdgeIndex>>,
 }
 

--- a/src/schema/position.rs
+++ b/src/schema/position.rs
@@ -20,7 +20,7 @@ use std::hash::Hash;
 use std::ops::Deref;
 use strum::IntoEnumIterator;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, derive_more::From, derive_more::Display)]
 pub(crate) enum TypeDefinitionPosition {
     Scalar(ScalarTypeDefinitionPosition),
     Object(ObjectTypeDefinitionPosition),
@@ -79,56 +79,7 @@ impl TypeDefinitionPosition {
     }
 }
 
-impl Display for TypeDefinitionPosition {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            TypeDefinitionPosition::Scalar(type_) => type_.fmt(f),
-            TypeDefinitionPosition::Object(type_) => type_.fmt(f),
-            TypeDefinitionPosition::Interface(type_) => type_.fmt(f),
-            TypeDefinitionPosition::Union(type_) => type_.fmt(f),
-            TypeDefinitionPosition::Enum(type_) => type_.fmt(f),
-            TypeDefinitionPosition::InputObject(type_) => type_.fmt(f),
-        }
-    }
-}
-
-impl From<ScalarTypeDefinitionPosition> for TypeDefinitionPosition {
-    fn from(value: ScalarTypeDefinitionPosition) -> Self {
-        TypeDefinitionPosition::Scalar(value)
-    }
-}
-
-impl From<ObjectTypeDefinitionPosition> for TypeDefinitionPosition {
-    fn from(value: ObjectTypeDefinitionPosition) -> Self {
-        TypeDefinitionPosition::Object(value)
-    }
-}
-
-impl From<InterfaceTypeDefinitionPosition> for TypeDefinitionPosition {
-    fn from(value: InterfaceTypeDefinitionPosition) -> Self {
-        TypeDefinitionPosition::Interface(value)
-    }
-}
-
-impl From<UnionTypeDefinitionPosition> for TypeDefinitionPosition {
-    fn from(value: UnionTypeDefinitionPosition) -> Self {
-        TypeDefinitionPosition::Union(value)
-    }
-}
-
-impl From<EnumTypeDefinitionPosition> for TypeDefinitionPosition {
-    fn from(value: EnumTypeDefinitionPosition) -> Self {
-        TypeDefinitionPosition::Enum(value)
-    }
-}
-
-impl From<InputObjectTypeDefinitionPosition> for TypeDefinitionPosition {
-    fn from(value: InputObjectTypeDefinitionPosition) -> Self {
-        TypeDefinitionPosition::InputObject(value)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, derive_more::From, derive_more::Display)]
 pub(crate) enum OutputTypeDefinitionPosition {
     Scalar(ScalarTypeDefinitionPosition),
     Object(ObjectTypeDefinitionPosition),
@@ -146,48 +97,6 @@ impl OutputTypeDefinitionPosition {
             OutputTypeDefinitionPosition::Union(type_) => &type_.type_name,
             OutputTypeDefinitionPosition::Enum(type_) => &type_.type_name,
         }
-    }
-}
-
-impl Display for OutputTypeDefinitionPosition {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            OutputTypeDefinitionPosition::Scalar(type_) => type_.fmt(f),
-            OutputTypeDefinitionPosition::Object(type_) => type_.fmt(f),
-            OutputTypeDefinitionPosition::Interface(type_) => type_.fmt(f),
-            OutputTypeDefinitionPosition::Union(type_) => type_.fmt(f),
-            OutputTypeDefinitionPosition::Enum(type_) => type_.fmt(f),
-        }
-    }
-}
-
-impl From<ScalarTypeDefinitionPosition> for OutputTypeDefinitionPosition {
-    fn from(value: ScalarTypeDefinitionPosition) -> Self {
-        OutputTypeDefinitionPosition::Scalar(value)
-    }
-}
-
-impl From<ObjectTypeDefinitionPosition> for OutputTypeDefinitionPosition {
-    fn from(value: ObjectTypeDefinitionPosition) -> Self {
-        OutputTypeDefinitionPosition::Object(value)
-    }
-}
-
-impl From<InterfaceTypeDefinitionPosition> for OutputTypeDefinitionPosition {
-    fn from(value: InterfaceTypeDefinitionPosition) -> Self {
-        OutputTypeDefinitionPosition::Interface(value)
-    }
-}
-
-impl From<UnionTypeDefinitionPosition> for OutputTypeDefinitionPosition {
-    fn from(value: UnionTypeDefinitionPosition) -> Self {
-        OutputTypeDefinitionPosition::Union(value)
-    }
-}
-
-impl From<EnumTypeDefinitionPosition> for OutputTypeDefinitionPosition {
-    fn from(value: EnumTypeDefinitionPosition) -> Self {
-        OutputTypeDefinitionPosition::Enum(value)
     }
 }
 
@@ -228,7 +137,7 @@ impl From<AbstractTypeDefinitionPosition> for OutputTypeDefinitionPosition {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, derive_more::From, derive_more::Display)]
 pub(crate) enum CompositeTypeDefinitionPosition {
     Object(ObjectTypeDefinitionPosition),
     Interface(InterfaceTypeDefinitionPosition),
@@ -267,24 +176,6 @@ impl CompositeTypeDefinitionPosition {
                 }
             }
         }
-    }
-}
-
-impl From<ObjectTypeDefinitionPosition> for CompositeTypeDefinitionPosition {
-    fn from(value: ObjectTypeDefinitionPosition) -> Self {
-        CompositeTypeDefinitionPosition::Object(value)
-    }
-}
-
-impl From<InterfaceTypeDefinitionPosition> for CompositeTypeDefinitionPosition {
-    fn from(value: InterfaceTypeDefinitionPosition) -> Self {
-        CompositeTypeDefinitionPosition::Interface(value)
-    }
-}
-
-impl From<UnionTypeDefinitionPosition> for CompositeTypeDefinitionPosition {
-    fn from(value: UnionTypeDefinitionPosition) -> Self {
-        CompositeTypeDefinitionPosition::Union(value)
     }
 }
 
@@ -350,7 +241,7 @@ impl From<ObjectOrInterfaceTypeDefinitionPosition> for CompositeTypeDefinitionPo
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, derive_more::From, derive_more::Display)]
 pub(crate) enum AbstractTypeDefinitionPosition {
     Interface(InterfaceTypeDefinitionPosition),
     Union(UnionTypeDefinitionPosition),
@@ -365,19 +256,7 @@ impl AbstractTypeDefinitionPosition {
     }
 }
 
-impl From<InterfaceTypeDefinitionPosition> for AbstractTypeDefinitionPosition {
-    fn from(value: InterfaceTypeDefinitionPosition) -> Self {
-        AbstractTypeDefinitionPosition::Interface(value)
-    }
-}
-
-impl From<UnionTypeDefinitionPosition> for AbstractTypeDefinitionPosition {
-    fn from(value: UnionTypeDefinitionPosition) -> Self {
-        AbstractTypeDefinitionPosition::Union(value)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, derive_more::From, derive_more::Display)]
 pub(crate) enum ObjectOrInterfaceTypeDefinitionPosition {
     Object(ObjectTypeDefinitionPosition),
     Interface(InterfaceTypeDefinitionPosition),
@@ -400,27 +279,6 @@ impl ObjectOrInterfaceTypeDefinitionPosition {
                 type_.field(field_name).into()
             }
         }
-    }
-}
-
-impl Display for ObjectOrInterfaceTypeDefinitionPosition {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ObjectOrInterfaceTypeDefinitionPosition::Object(type_) => type_.fmt(f),
-            ObjectOrInterfaceTypeDefinitionPosition::Interface(type_) => type_.fmt(f),
-        }
-    }
-}
-
-impl From<ObjectTypeDefinitionPosition> for ObjectOrInterfaceTypeDefinitionPosition {
-    fn from(value: ObjectTypeDefinitionPosition) -> Self {
-        ObjectOrInterfaceTypeDefinitionPosition::Object(value)
-    }
-}
-
-impl From<InterfaceTypeDefinitionPosition> for ObjectOrInterfaceTypeDefinitionPosition {
-    fn from(value: InterfaceTypeDefinitionPosition) -> Self {
-        ObjectOrInterfaceTypeDefinitionPosition::Interface(value)
     }
 }
 
@@ -468,7 +326,7 @@ impl TryFrom<OutputTypeDefinitionPosition> for ObjectOrInterfaceTypeDefinitionPo
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, derive_more::From, derive_more::Display)]
 pub(crate) enum FieldDefinitionPosition {
     Object(ObjectFieldDefinitionPosition),
     Interface(InterfaceFieldDefinitionPosition),
@@ -512,35 +370,7 @@ impl FieldDefinitionPosition {
     }
 }
 
-impl Display for FieldDefinitionPosition {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            FieldDefinitionPosition::Object(field) => field.fmt(f),
-            FieldDefinitionPosition::Interface(field) => field.fmt(f),
-            FieldDefinitionPosition::Union(field) => field.fmt(f),
-        }
-    }
-}
-
-impl From<ObjectFieldDefinitionPosition> for FieldDefinitionPosition {
-    fn from(value: ObjectFieldDefinitionPosition) -> Self {
-        FieldDefinitionPosition::Object(value)
-    }
-}
-
-impl From<InterfaceFieldDefinitionPosition> for FieldDefinitionPosition {
-    fn from(value: InterfaceFieldDefinitionPosition) -> Self {
-        FieldDefinitionPosition::Interface(value)
-    }
-}
-
-impl From<UnionTypenameFieldDefinitionPosition> for FieldDefinitionPosition {
-    fn from(value: UnionTypenameFieldDefinitionPosition) -> Self {
-        FieldDefinitionPosition::Union(value)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, derive_more::From, derive_more::Display)]
 pub(crate) enum ObjectOrInterfaceFieldDefinitionPosition {
     Object(ObjectFieldDefinitionPosition),
     Interface(InterfaceFieldDefinitionPosition),
@@ -606,18 +436,6 @@ impl ObjectOrInterfaceFieldDefinitionPosition {
                 field.remove_directive(schema, directive)
             }
         }
-    }
-}
-
-impl From<ObjectFieldDefinitionPosition> for ObjectOrInterfaceFieldDefinitionPosition {
-    fn from(value: ObjectFieldDefinitionPosition) -> Self {
-        ObjectOrInterfaceFieldDefinitionPosition::Object(value)
-    }
-}
-
-impl From<InterfaceFieldDefinitionPosition> for ObjectOrInterfaceFieldDefinitionPosition {
-    fn from(value: InterfaceFieldDefinitionPosition) -> Self {
-        ObjectOrInterfaceFieldDefinitionPosition::Interface(value)
     }
 }
 


### PR DESCRIPTION
This PR implements the inter-subgraph logic of federated query graph creation. That is, it implements the business logic for adding federated root nodes and cross-subgraph edges when creating a federated query graph. Note that this PR needs to use some functionality around operation processing eventually, but until that's ready, there are TODOs where the logic will be called. Tests will be added in follow-up PRs.