### PR TITLE
Port tests for query graph creation

### DIFF
--- a/src/query_graph/mod.rs
+++ b/src/query_graph/mod.rs
@@ -12,11 +12,11 @@ use petgraph::graph::{DiGraph, EdgeIndex, NodeIndex};
 use std::fmt::{Display, Formatter};
 use std::hash::Hash;
 
-pub(crate) mod build_query_graph;
+pub mod build_query_graph;
 pub(crate) mod extract_subgraphs_from_supergraph;
 mod field_set;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct QueryGraphNode {
     /// The GraphQL type this node points to.
     pub(crate) type_: QueryGraphNodeType,
@@ -112,7 +112,7 @@ impl Display for QueryGraphEdge {
 /// The type of query graph edge "transition".
 ///
 /// An edge transition encodes what the edge corresponds to, in the underlying GraphQL schema.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) enum QueryGraphEdgeTransition {
     /// A field edge, going from (a node for) the field parent type to the field's (base) type.
     FieldCollection {

--- a/src/schema/position.rs
+++ b/src/schema/position.rs
@@ -370,6 +370,15 @@ impl FieldDefinitionPosition {
     }
 }
 
+impl From<ObjectOrInterfaceFieldDefinitionPosition> for FieldDefinitionPosition {
+    fn from(value: ObjectOrInterfaceFieldDefinitionPosition) -> Self {
+        match value {
+            ObjectOrInterfaceFieldDefinitionPosition::Object(value) => value.into(),
+            ObjectOrInterfaceFieldDefinitionPosition::Interface(value) => value.into(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, derive_more::From, derive_more::Display)]
 pub(crate) enum ObjectOrInterfaceFieldDefinitionPosition {
     Object(ObjectFieldDefinitionPosition),
@@ -6164,7 +6173,7 @@ fn validate_arguments(arguments: &[Node<InputValueDefinition>]) -> Result<(), Fe
 }
 
 impl FederationSchema {
-    pub(crate) fn new(schema: Schema) -> Result<FederationSchema, FederationError> {
+    pub fn new(schema: Schema) -> Result<FederationSchema, FederationError> {
         let metadata = links_metadata(&schema)?;
         let mut referencers: Referencers = Default::default();
 


### PR DESCRIPTION
This PR ports the singular test in the JS codebase for query graph creation (most query planning tests are integration tests).

Some notes:
- You'll notice we introduce a new function called `build_query_graph()`; this is specifically for non-federated query graphs (used for the API schema during composition). We don't appear to have logic that directly tests federated query graphs in the JS codebase, but there's shared logic between non-federated and federated query graph creation, so this PR tests that shared logic at least.
- This PR is stacked on top of https://github.com/apollographql/federation-next/pull/94