### PR TITLE
Update to apollo-compiler 1.0.0-beta.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Elastic-2.0"
 autotests = false                                               # Integration tests are modules of tests/main.rs
 
 [dependencies]
-apollo-compiler = "1.0.0-beta.10"
+apollo-compiler = "=1.0.0-beta.10"
 derive_more = "0.99.17"
 salsa = "0.16.1"
 indexmap = "2.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Elastic-2.0"
 autotests = false                                               # Integration tests are modules of tests/main.rs
 
 [dependencies]
-apollo-compiler = { git = "https://github.com/apollographql/apollo-rs", branch = "valid-ref" }
+apollo-compiler = "1.0.0-beta.10"
 derive_more = "0.99.17"
 salsa = "0.16.1"
 indexmap = "2.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,10 @@ description = "Apollo Federation"
 documentation = "https://docs.rs/apollo-federation"
 repository = "https://github.com/apollographql/federation-next"
 license = "Elastic-2.0"
-autotests = false # Integration tests are modules of tests/main.rs
+autotests = false                                               # Integration tests are modules of tests/main.rs
 
 [dependencies]
-apollo-compiler = "=1.0.0-beta.7"
+apollo-compiler = { git = "https://github.com/apollographql/apollo-rs", branch = "valid-ref" }
 derive_more = "0.99.17"
 salsa = "0.16.1"
 indexmap = "2.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-federation"
-version = "0.0.4"
+version = "0.0.5"
 authors = ["The Apollo GraphQL Contributors"]
 edition = "2021"
 description = "Apollo Federation"

--- a/src/database.rs
+++ b/src/database.rs
@@ -2,13 +2,12 @@ use std::sync::Arc;
 
 use apollo_compiler::Schema;
 
-use crate::link::{
-    database::links_metadata,
-    spec::{Identity, APOLLO_SPEC_DOMAIN},
-    Link,
-};
+use crate::error::FederationError;
+use crate::link::database::links_metadata;
+use crate::link::spec::{Identity, APOLLO_SPEC_DOMAIN};
+use crate::link::Link;
 use crate::subgraph::Subgraphs;
-use crate::{Supergraph, SupergraphError};
+use crate::Supergraph;
 
 // TODO: we should define this as part as some more generic "JoinSpec" definition, but need
 // to define the ground work for that in `apollo-at-link` first.
@@ -28,7 +27,7 @@ pub fn join_link(schema: &Schema) -> Arc<Link> {
         .expect("The presence of the join link should have been validated on construction")
 }
 
-pub fn extract_subgraphs(_supergraph: &Supergraph) -> Result<Subgraphs, SupergraphError> {
+pub fn extract_subgraphs(_supergraph: &Supergraph) -> Result<Subgraphs, FederationError> {
     // TODO
     Ok(Subgraphs::new())
 }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1,5 +1,6 @@
-use apollo_compiler::ast::InvalidNameError;
-use apollo_compiler::DiagnosticList;
+use crate::subgraph::spec::FederationSpecError;
+use apollo_compiler::validation::DiagnosticList;
+use apollo_compiler::{ast::InvalidNameError, validation::WithErrors};
 use lazy_static::lazy_static;
 use std::fmt::{Display, Formatter, Write};
 
@@ -367,6 +368,12 @@ impl From<InvalidNameError> for FederationError {
     }
 }
 
+impl From<FederationSpecError> for FederationError {
+    fn from(err: FederationSpecError) -> Self {
+        todo!()
+    }
+}
+
 #[derive(Debug, Clone, thiserror::Error)]
 pub struct MultipleFederationErrors {
     pub errors: Vec<SingleFederationError>,
@@ -460,6 +467,12 @@ impl From<DiagnosticList> for FederationError {
     fn from(value: DiagnosticList) -> Self {
         let value: MultipleFederationErrors = value.into();
         value.into()
+    }
+}
+
+impl<T> From<WithErrors<T>> for FederationError {
+    fn from(value: WithErrors<T>) -> Self {
+        value.errors.into()
     }
 }
 

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -369,7 +369,9 @@ impl From<InvalidNameError> for FederationError {
 }
 
 impl From<FederationSpecError> for FederationError {
-    fn from(err: FederationSpecError) -> Self {
+    fn from(_err: FederationSpecError) -> Self {
+        // TODO: When we get around to finishing the composition port, we should really switch it to
+        // using FederationError instead of FederationSpecError.
         todo!()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use apollo_compiler::Schema;
 use crate::error::FederationError;
 use crate::merge::merge_subgraphs;
 use crate::merge::MergeFailure;
-use crate::subgraph::Subgraph;
+use crate::subgraph::ValidSubgraph;
 use apollo_compiler::validation::Valid;
 
 pub mod database;
@@ -28,7 +28,7 @@ impl Supergraph {
         Ok(Self { schema })
     }
 
-    pub fn compose(subgraphs: Vec<&Subgraph>) -> Result<Self, MergeFailure> {
+    pub fn compose(subgraphs: Vec<&ValidSubgraph>) -> Result<Self, MergeFailure> {
         let schema = merge_subgraphs(subgraphs)?.schema;
         Ok(Self { schema })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,11 @@ use apollo_compiler::ast::DirectiveList;
 use apollo_compiler::schema::ExtendedType;
 use apollo_compiler::Schema;
 
+use crate::error::FederationError;
 use crate::merge::merge_subgraphs;
+use crate::merge::MergeFailure;
 use crate::subgraph::Subgraph;
+use apollo_compiler::validation::Valid;
 
 pub mod database;
 pub mod error;
@@ -14,42 +17,25 @@ pub mod query_graph;
 pub mod schema;
 pub mod subgraph;
 
-type MergeError = &'static str;
-
-// TODO: Same remark as in other crates: we need to define this more cleanly, and probably need
-// some "federation errors" crate.
-#[derive(Debug)]
-pub struct SupergraphError {
-    pub msg: String,
-}
-
 pub struct Supergraph {
-    pub schema: Schema,
+    pub schema: Valid<Schema>,
 }
 
 impl Supergraph {
-    pub fn new(schema_str: &str) -> Self {
-        let schema = Schema::parse(schema_str, "schema.graphql");
-
-        // TODO: like for subgraphs, it would nice if `Supergraph` was always representing
-        // a valid supergraph (which is simpler than for subgraph, but still at least means
-        // that it's valid graphQL in the first place, and that it has the `join` spec).
-
-        Self { schema }
+    pub fn new(schema_str: &str) -> Result<Self, FederationError> {
+        let schema = Schema::parse_and_validate(schema_str, "schema.graphql")?;
+        // TODO: federation-specific validation
+        Ok(Self { schema })
     }
 
-    pub fn compose(subgraphs: Vec<&Subgraph>) -> Result<Self, MergeError> {
-        let merge_result = match merge_subgraphs(subgraphs) {
-            Ok(success) => Ok(Self::new(success.schema.to_string().as_str())),
-            // TODO handle errors
-            Err(_) => Err("failed to compose"),
-        };
-        merge_result
+    pub fn compose(subgraphs: Vec<&Subgraph>) -> Result<Self, MergeFailure> {
+        let schema = merge_subgraphs(subgraphs)?.schema;
+        Ok(Self { schema })
     }
 
     /// Generates API schema from the supergraph schema.
     pub fn to_api_schema(&self) -> Schema {
-        let mut api_schema = self.schema.clone();
+        let mut api_schema = self.schema.clone().into_inner();
 
         // remove schema directives
         api_schema.schema_definition.make_mut().directives.clear();
@@ -130,8 +116,8 @@ impl Supergraph {
     }
 }
 
-impl From<Schema> for Supergraph {
-    fn from(schema: Schema) -> Self {
+impl From<Valid<Schema>> for Supergraph {
+    fn from(schema: Valid<Schema>) -> Self {
         Self { schema }
     }
 }
@@ -236,7 +222,7 @@ mod tests {
            = S | T
         "#;
 
-        let supergraph = Supergraph::new(schema);
+        let supergraph = Supergraph::new(schema).unwrap();
         let _subgraphs = database::extract_subgraphs(&supergraph)
             .expect("Should have been able to extract subgraphs");
         // TODO: actual assertions on the subgraph once it's actually implemented.

--- a/src/link/database.rs
+++ b/src/link/database.rs
@@ -179,7 +179,7 @@ mod tests {
           directive @link(url: String, as: String, import: [Import], for: link__Purpose) repeatable on SCHEMA
         "#;
 
-        let schema = Schema::parse(schema, "testSchema");
+        let schema = Schema::parse(schema, "testSchema").unwrap();
 
         let meta = links_metadata(&schema)
             // TODO: error handling?

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -11,6 +11,7 @@ use apollo_compiler::schema::{
     ObjectType, ScalarType, UnionType,
 };
 use apollo_compiler::ty;
+use apollo_compiler::validation::Valid;
 use apollo_compiler::{name, Node, NodeStr, Schema};
 use indexmap::map::Entry::{Occupied, Vacant};
 use indexmap::map::Iter;
@@ -27,7 +28,7 @@ struct Merger {
 }
 
 pub struct MergeSuccess {
-    pub schema: Schema,
+    pub schema: Valid<Schema>,
     pub composition_hints: Vec<MergeWarning>,
 }
 
@@ -136,6 +137,8 @@ impl Merger {
         }
 
         if self.errors.is_empty() {
+            // TODO: validate here and extend `MergeFailure` to propagate validation errors
+            let supergraph = Valid::assume_valid(supergraph);
             Ok(MergeSuccess {
                 schema: supergraph,
                 composition_hints: self.composition_hints.to_owned(),

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::fmt::{Debug, Formatter};
 use std::iter;
 
 use apollo_compiler::ast::DirectiveList;
@@ -17,7 +18,7 @@ use indexmap::map::Entry::{Occupied, Vacant};
 use indexmap::map::Iter;
 use indexmap::{IndexMap, IndexSet};
 
-use crate::subgraph::Subgraph;
+use crate::subgraph::ValidSubgraph;
 
 type MergeWarning = &'static str;
 type MergeError = &'static str;
@@ -38,7 +39,23 @@ pub struct MergeFailure {
     pub composition_hints: Vec<MergeWarning>,
 }
 
-pub fn merge_subgraphs(subgraphs: Vec<&Subgraph>) -> Result<MergeSuccess, MergeFailure> {
+impl Debug for MergeFailure {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        MergeFailureDebug {
+            errors: &self.errors,
+            composition_hints: &self.composition_hints,
+        }
+        .fmt(f)
+    }
+}
+
+#[derive(Debug)]
+pub struct MergeFailureDebug<'source> {
+    pub errors: &'source Vec<MergeError>,
+    pub composition_hints: &'source Vec<MergeWarning>,
+}
+
+pub fn merge_subgraphs(subgraphs: Vec<&ValidSubgraph>) -> Result<MergeSuccess, MergeFailure> {
     let mut merger = Merger::new();
     merger.merge(subgraphs)
 }
@@ -50,10 +67,10 @@ impl Merger {
             errors: Vec::new(),
         }
     }
-    fn merge(&mut self, subgraphs: Vec<&Subgraph>) -> Result<MergeSuccess, MergeFailure> {
+    fn merge(&mut self, subgraphs: Vec<&ValidSubgraph>) -> Result<MergeSuccess, MergeFailure> {
         let mut subgraphs = subgraphs.clone();
         subgraphs.sort_by(|s1, s2| s1.name.cmp(&s2.name));
-        let mut subgraphs_and_enum_values: Vec<(&Subgraph, Name)> = Vec::new();
+        let mut subgraphs_and_enum_values: Vec<(&ValidSubgraph, Name)> = Vec::new();
         for subgraph in &subgraphs {
             // TODO: Implement JS codebase's name transform (which always generates a valid GraphQL
             // name and avoids collisions).
@@ -165,7 +182,7 @@ impl Merger {
         }
     }
 
-    fn merge_schema(&mut self, supergraph_schema: &mut Schema, subgraph: &Subgraph) {
+    fn merge_schema(&mut self, supergraph_schema: &mut Schema, subgraph: &ValidSubgraph) {
         let supergraph_def = &mut supergraph_schema.schema_definition.make_mut();
         let subgraph_def = &subgraph.schema.schema_definition;
         self.merge_descriptions(&mut supergraph_def.description, &subgraph_def.description);
@@ -815,7 +832,7 @@ fn link_purpose_enum_type() -> (Name, EnumType) {
 // TODO join spec
 fn add_core_feature_join(
     supergraph: &mut Schema,
-    subgraphs_and_enum_values: &Vec<(&Subgraph, Name)>,
+    subgraphs_and_enum_values: &Vec<(&ValidSubgraph, Name)>,
 ) {
     // @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
     supergraph
@@ -1154,7 +1171,9 @@ fn join_union_member_directive_definition() -> DirectiveDefinition {
 }
 
 /// enum Graph
-fn join_graph_enum_type(subgraphs_and_enum_values: &Vec<(&Subgraph, Name)>) -> (Name, EnumType) {
+fn join_graph_enum_type(
+    subgraphs_and_enum_values: &Vec<(&ValidSubgraph, Name)>,
+) -> (Name, EnumType) {
     let join_graph_enum_name = name!("join__Graph");
     let mut join_graph_enum_type = EnumType {
         description: None,

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -41,18 +41,11 @@ pub struct MergeFailure {
 
 impl Debug for MergeFailure {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        MergeFailureDebug {
-            errors: &self.errors,
-            composition_hints: &self.composition_hints,
-        }
-        .fmt(f)
+        f.debug_struct("MergeFailure")
+            .field("errors", &self.errors)
+            .field("composition_hints", &self.composition_hints)
+            .finish()
     }
-}
-
-#[derive(Debug)]
-pub struct MergeFailureDebug<'source> {
-    pub errors: &'source Vec<MergeError>,
-    pub composition_hints: &'source Vec<MergeWarning>,
 }
 
 pub fn merge_subgraphs(subgraphs: Vec<&ValidSubgraph>) -> Result<MergeSuccess, MergeFailure> {

--- a/src/query_graph/build_query_graph.rs
+++ b/src/query_graph/build_query_graph.rs
@@ -951,7 +951,7 @@ impl FederatedQueryGraphBuilder {
         let base = BaseQueryGraphBuilder::new(
             query_graph,
             NodeStr::new(FEDERATED_GRAPH_ROOT_SOURCE),
-            FederationSchema::new(Schema::new())?,
+            FederationSchema::new(Schema::new().validate().unwrap())?,
         );
         let subgraphs = FederatedQueryGraphBuilderSubgraphs::new(&base)?;
         Ok(FederatedQueryGraphBuilder {
@@ -1124,7 +1124,7 @@ impl FederatedQueryGraphBuilder {
                         }.into());
                 };
                 let conditions = Node::new(parse_field_set(
-                    schema.schema(),
+                    FederationSchema::valid_schema(schema),
                     type_pos.type_name().clone(),
                     application.fields.clone(),
                 )?);
@@ -1247,7 +1247,7 @@ impl FederatedQueryGraphBuilder {
                             let implementation_type_in_other_subgraph_pos: CompositeTypeDefinitionPosition =
                                 other_schema.get_type(implementation_type_in_supergraph_pos.type_name.clone())?.try_into()?;
                             let Ok(implementation_conditions) = parse_field_set(
-                                other_schema.schema(),
+                                FederationSchema::valid_schema(schema),
                                 implementation_type_in_other_subgraph_pos
                                     .type_name()
                                     .clone(),
@@ -1314,7 +1314,7 @@ impl FederatedQueryGraphBuilder {
                     .federation_spec_definition
                     .requires_directive_arguments(directive)?;
                 let conditions = parse_field_set(
-                    schema.schema(),
+                    FederationSchema::valid_schema(schema),
                     field_definition_position.parent().type_name().clone(),
                     application.fields,
                 )?;
@@ -1379,7 +1379,7 @@ impl FederatedQueryGraphBuilder {
                 let field_type_pos: CompositeTypeDefinitionPosition =
                     field_type_pos.clone().try_into()?;
                 let conditions = parse_field_set(
-                    schema.schema(),
+                    FederationSchema::valid_schema(schema),
                     field_type_pos.type_name().clone(),
                     application.fields,
                 )?;
@@ -1807,7 +1807,7 @@ impl FederatedQueryGraphBuilder {
                         }.into());
                 };
                 let conditions = Node::new(parse_field_set(
-                    schema.schema(),
+                    FederationSchema::valid_schema(schema),
                     type_in_supergraph_pos.type_name.clone(),
                     NodeStr::from_static(&"__typename"),
                 )?);
@@ -2045,7 +2045,7 @@ mod tests {
     const SCHEMA_NAME: NodeStr = NodeStr::from_static(&"test");
 
     fn test_query_graph_from_schema_sdl(sdl: &str) -> Result<QueryGraph, FederationError> {
-        let schema = FederationSchema::new(Schema::parse(sdl, "schema.graphql"))?;
+        let schema = FederationSchema::new(Schema::parse_and_validate(sdl, "schema.graphql")?)?;
         build_query_graph(SCHEMA_NAME, schema)
     }
 

--- a/src/query_graph/build_query_graph.rs
+++ b/src/query_graph/build_query_graph.rs
@@ -14,9 +14,10 @@ use crate::schema::position::{
     OutputTypeDefinitionPosition, SchemaRootDefinitionKind, SchemaRootDefinitionPosition,
     TypeDefinitionPosition, UnionTypeDefinitionPosition,
 };
-use crate::schema::FederationSchema;
+use crate::schema::ValidFederationSchema;
 use apollo_compiler::executable::{Selection, SelectionSet};
 use apollo_compiler::schema::{DirectiveList as ComponentDirectiveList, ExtendedType, Name};
+use apollo_compiler::validation::Valid;
 use apollo_compiler::{Node, NodeStr, Schema};
 use indexmap::{IndexMap, IndexSet};
 use petgraph::graph::{EdgeIndex, NodeIndex};
@@ -32,8 +33,8 @@ use strum::IntoEnumIterator;
 ///
 /// Assumes the given schemas have been validated.
 pub fn build_federated_query_graph(
-    supergraph_schema: Arc<FederationSchema>,
-    api_schema: Arc<FederationSchema>,
+    supergraph_schema: Arc<ValidFederationSchema>,
+    api_schema: Arc<ValidFederationSchema>,
     validate_extracted_subgraphs: Option<bool>,
     for_query_planning: Option<bool>,
 ) -> Result<QueryGraph, FederationError> {
@@ -69,7 +70,7 @@ pub fn build_federated_query_graph(
 /// Assumes the given schemas have been validated.
 pub fn build_query_graph(
     name: NodeStr,
-    schema: FederationSchema,
+    schema: ValidFederationSchema,
 ) -> Result<QueryGraph, FederationError> {
     let mut query_graph = QueryGraph {
         // Note this name is a dummy initial name that gets overridden as we build the query graph.
@@ -90,7 +91,7 @@ struct BaseQueryGraphBuilder {
 }
 
 impl BaseQueryGraphBuilder {
-    fn new(mut query_graph: QueryGraph, source: NodeStr, schema: FederationSchema) -> Self {
+    fn new(mut query_graph: QueryGraph, source: NodeStr, schema: ValidFederationSchema) -> Self {
         query_graph.current_source = source.clone();
         query_graph.sources.insert(source.clone(), schema);
         query_graph
@@ -212,7 +213,7 @@ struct SchemaQueryGraphBuilder {
 
 struct SchemaQueryGraphBuilderSubgraphData {
     federation_spec_definition: &'static FederationSpecDefinition,
-    api_schema: Arc<FederationSchema>,
+    api_schema: Arc<ValidFederationSchema>,
 }
 
 impl SchemaQueryGraphBuilder {
@@ -221,8 +222,8 @@ impl SchemaQueryGraphBuilder {
     fn new(
         query_graph: QueryGraph,
         source: NodeStr,
-        schema: FederationSchema,
-        api_schema: Option<Arc<FederationSchema>>,
+        schema: ValidFederationSchema,
+        api_schema: Option<Arc<ValidFederationSchema>>,
         for_query_planning: bool,
     ) -> Result<Self, FederationError> {
         let subgraph = if let Some(api_schema) = api_schema {
@@ -939,19 +940,21 @@ struct AbstractTypeWithRuntimeTypes {
 
 struct FederatedQueryGraphBuilder {
     base: BaseQueryGraphBuilder,
-    supergraph_schema: Arc<FederationSchema>,
+    supergraph_schema: Arc<ValidFederationSchema>,
     subgraphs: FederatedQueryGraphBuilderSubgraphs,
 }
 
 impl FederatedQueryGraphBuilder {
     fn new(
         query_graph: QueryGraph,
-        supergraph_schema: Arc<FederationSchema>,
+        supergraph_schema: Arc<ValidFederationSchema>,
     ) -> Result<Self, FederationError> {
         let base = BaseQueryGraphBuilder::new(
             query_graph,
             NodeStr::new(FEDERATED_GRAPH_ROOT_SOURCE),
-            FederationSchema::new(Schema::new().validate().unwrap())?,
+            // This is a dummy schema that should never be used, so it's fine if we assume validity
+            // here (note that empty schemas have no Query type, making them invalid GraphQL).
+            ValidFederationSchema::new(Valid::assume_valid(Schema::new()))?,
         );
         let subgraphs = FederatedQueryGraphBuilderSubgraphs::new(&base)?;
         Ok(FederatedQueryGraphBuilder {
@@ -1124,7 +1127,7 @@ impl FederatedQueryGraphBuilder {
                         }.into());
                 };
                 let conditions = Node::new(parse_field_set(
-                    FederationSchema::valid_schema(schema),
+                    schema.schema(),
                     type_pos.type_name().clone(),
                     application.fields.clone(),
                 )?);
@@ -1247,7 +1250,7 @@ impl FederatedQueryGraphBuilder {
                             let implementation_type_in_other_subgraph_pos: CompositeTypeDefinitionPosition =
                                 other_schema.get_type(implementation_type_in_supergraph_pos.type_name.clone())?.try_into()?;
                             let Ok(implementation_conditions) = parse_field_set(
-                                FederationSchema::valid_schema(schema),
+                                other_schema.schema(),
                                 implementation_type_in_other_subgraph_pos
                                     .type_name()
                                     .clone(),
@@ -1314,7 +1317,7 @@ impl FederatedQueryGraphBuilder {
                     .federation_spec_definition
                     .requires_directive_arguments(directive)?;
                 let conditions = parse_field_set(
-                    FederationSchema::valid_schema(schema),
+                    schema.schema(),
                     field_definition_position.parent().type_name().clone(),
                     application.fields,
                 )?;
@@ -1379,7 +1382,7 @@ impl FederatedQueryGraphBuilder {
                 let field_type_pos: CompositeTypeDefinitionPosition =
                     field_type_pos.clone().try_into()?;
                 let conditions = parse_field_set(
-                    FederationSchema::valid_schema(schema),
+                    schema.schema(),
                     field_type_pos.type_name().clone(),
                     application.fields,
                 )?;
@@ -1807,7 +1810,7 @@ impl FederatedQueryGraphBuilder {
                         }.into());
                 };
                 let conditions = Node::new(parse_field_set(
-                    FederationSchema::valid_schema(schema),
+                    schema.schema(),
                     type_in_supergraph_pos.type_name.clone(),
                     NodeStr::from_static(&"__typename"),
                 )?);
@@ -2034,7 +2037,7 @@ mod tests {
         ObjectOrInterfaceTypeDefinitionPosition, ObjectTypeDefinitionPosition,
         OutputTypeDefinitionPosition, ScalarTypeDefinitionPosition, SchemaRootDefinitionKind,
     };
-    use crate::schema::FederationSchema;
+    use crate::schema::ValidFederationSchema;
     use apollo_compiler::schema::Name;
     use apollo_compiler::{name, NodeStr, Schema};
     use indexmap::{IndexMap, IndexSet};
@@ -2045,7 +2048,8 @@ mod tests {
     const SCHEMA_NAME: NodeStr = NodeStr::from_static(&"test");
 
     fn test_query_graph_from_schema_sdl(sdl: &str) -> Result<QueryGraph, FederationError> {
-        let schema = FederationSchema::new(Schema::parse_and_validate(sdl, "schema.graphql")?)?;
+        let schema =
+            ValidFederationSchema::new(Schema::parse_and_validate(sdl, "schema.graphql")?)?;
         build_query_graph(SCHEMA_NAME, schema)
     }
 

--- a/src/query_graph/extract_subgraphs_from_supergraph.rs
+++ b/src/query_graph/extract_subgraphs_from_supergraph.rs
@@ -18,7 +18,7 @@ use crate::schema::position::{
     ScalarTypeDefinitionPosition, SchemaRootDefinitionKind, SchemaRootDefinitionPosition,
     TypeDefinitionPosition, UnionTypeDefinitionPosition,
 };
-use crate::schema::FederationSchema;
+use crate::schema::{FederationSchema, ValidFederationSchema};
 use apollo_compiler::ast::FieldDefinition;
 use apollo_compiler::executable::{Field, Selection, SelectionSet};
 use apollo_compiler::schema::{
@@ -26,7 +26,7 @@ use apollo_compiler::schema::{
     DirectiveLocation, EnumType, EnumValueDefinition, ExtendedType, ExtensionId, InputObjectType,
     InputValueDefinition, InterfaceType, Name, NamedType, ObjectType, ScalarType, Type, UnionType,
 };
-use apollo_compiler::validation::{Valid, WithErrors};
+use apollo_compiler::validation::Valid;
 use apollo_compiler::{name, Node, NodeStr, Schema};
 use indexmap::{IndexMap, IndexSet};
 use lazy_static::lazy_static;
@@ -40,7 +40,7 @@ use std::ops::Deref;
 pub(super) fn extract_subgraphs_from_supergraph(
     supergraph_schema: &FederationSchema,
     validate_extracted_subgraphs: Option<bool>,
-) -> Result<FederationSubgraphs, FederationError> {
+) -> Result<ValidFederationSubgraphs, FederationError> {
     let validate_extracted_subgraphs = validate_extracted_subgraphs.unwrap_or(true);
     let (link_spec_definition, join_spec_definition) = validate_supergraph(supergraph_schema)?;
     let is_fed_1 = *join_spec_definition.version() == Version { major: 0, minor: 1 };
@@ -83,29 +83,42 @@ pub(super) fn extract_subgraphs_from_supergraph(
                 message: "Subgraph unexpectedly does not use federation spec".to_owned(),
             })?;
         add_federation_operations(subgraph, federation_spec_definition)?;
-        if validate_extracted_subgraphs {
-            let Err(WithErrors { errors, .. }) = subgraph.schema.schema().validate() else {
-                continue;
-            };
-            // TODO: Implement maybeDumpSubgraphSchema() for better error messaging
-            if is_fed_1 {
-                // See message above about Fed 1 supergraphs
-                todo!()
-            } else {
-                return Err(
-                    SingleFederationError::InvalidFederationSupergraph {
-                        message: format!(
-                            "Unexpected error extracting {} from the supergraph: this is either a bug, or the supergraph has been corrupted.\n\nDetails:\n{}",
-                            subgraph.name,
-                            errors.to_string_no_color()
-                        ),
-                    }.into()
-                );
-            }
-        }
     }
 
-    Ok(subgraphs)
+    let mut valid_subgraphs = ValidFederationSubgraphs::new();
+    for (_, subgraph) in subgraphs {
+        let valid_subgraph_schema = if validate_extracted_subgraphs {
+            match subgraph.schema.validate() {
+                Ok(schema) => schema,
+                Err(error) => {
+                    // TODO: Implement maybeDumpSubgraphSchema() for better error messaging
+                    if is_fed_1 {
+                        // See message above about Fed 1 supergraphs
+                        todo!()
+                    } else {
+                        return Err(
+                            SingleFederationError::InvalidFederationSupergraph {
+                                message: format!(
+                                    "Unexpected error extracting {} from the supergraph: this is either a bug, or the supergraph has been corrupted.\n\nDetails:\n{}",
+                                    subgraph.name,
+                                    error,
+                                ),
+                            }.into()
+                        );
+                    }
+                }
+            }
+        } else {
+            ValidFederationSchema(Valid::assume_valid(subgraph.schema))
+        };
+        valid_subgraphs.add(ValidFederationSubgraph {
+            name: subgraph.name,
+            url: subgraph.url,
+            schema: valid_subgraph_schema,
+        })?;
+    }
+
+    Ok(valid_subgraphs)
 }
 
 type ValidateSupergraphOk = (&'static LinkSpecDefinition, &'static JoinSpecDefinition);
@@ -199,7 +212,7 @@ fn collect_empty_subgraphs(
 
 /// TODO: Use the JS/programmatic approach instead of hard-coding definitions.
 pub(crate) fn new_empty_fed_2_subgraph_schema() -> Result<FederationSchema, FederationError> {
-    FederationSchema::new(Schema::parse_and_validate(
+    FederationSchema::new(Schema::parse(
         r#"
     extend schema
         @link(url: "https://specs.apollo.dev/link/v1.0")
@@ -1415,24 +1428,24 @@ fn get_subgraph<'subgraph>(
     })
 }
 
-pub(crate) struct FederationSubgraph {
-    pub(crate) name: String,
-    pub(crate) url: String,
-    pub(crate) schema: FederationSchema,
+struct FederationSubgraph {
+    name: String,
+    url: String,
+    schema: FederationSchema,
 }
 
-pub(crate) struct FederationSubgraphs {
+struct FederationSubgraphs {
     subgraphs: BTreeMap<String, FederationSubgraph>,
 }
 
 impl FederationSubgraphs {
-    pub(crate) fn new() -> Self {
+    fn new() -> Self {
         FederationSubgraphs {
             subgraphs: BTreeMap::new(),
         }
     }
 
-    pub(crate) fn add(&mut self, subgraph: FederationSubgraph) -> Result<(), FederationError> {
+    fn add(&mut self, subgraph: FederationSubgraph) -> Result<(), FederationError> {
         if self.subgraphs.contains_key(&subgraph.name) {
             return Err(SingleFederationError::InvalidFederationSupergraph {
                 message: format!("A subgraph named \"{}\" already exists", subgraph.name),
@@ -1443,11 +1456,11 @@ impl FederationSubgraphs {
         Ok(())
     }
 
-    pub(crate) fn get(&self, name: &str) -> Option<&FederationSubgraph> {
+    fn get(&self, name: &str) -> Option<&FederationSubgraph> {
         self.subgraphs.get(name)
     }
 
-    pub(crate) fn get_mut(&mut self, name: &str) -> Option<&mut FederationSubgraph> {
+    fn get_mut(&mut self, name: &str) -> Option<&mut FederationSubgraph> {
         self.subgraphs.get_mut(name)
     }
 }
@@ -1455,6 +1468,48 @@ impl FederationSubgraphs {
 impl IntoIterator for FederationSubgraphs {
     type Item = <BTreeMap<String, FederationSubgraph> as IntoIterator>::Item;
     type IntoIter = <BTreeMap<String, FederationSubgraph> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.subgraphs.into_iter()
+    }
+}
+
+pub(crate) struct ValidFederationSubgraph {
+    pub(crate) name: String,
+    pub(crate) url: String,
+    pub(crate) schema: ValidFederationSchema,
+}
+
+pub(crate) struct ValidFederationSubgraphs {
+    subgraphs: BTreeMap<String, ValidFederationSubgraph>,
+}
+
+impl ValidFederationSubgraphs {
+    pub(crate) fn new() -> Self {
+        ValidFederationSubgraphs {
+            subgraphs: BTreeMap::new(),
+        }
+    }
+
+    pub(crate) fn add(&mut self, subgraph: ValidFederationSubgraph) -> Result<(), FederationError> {
+        if self.subgraphs.contains_key(&subgraph.name) {
+            return Err(SingleFederationError::InvalidFederationSupergraph {
+                message: format!("A subgraph named \"{}\" already exists", subgraph.name),
+            }
+            .into());
+        }
+        self.subgraphs.insert(subgraph.name.clone(), subgraph);
+        Ok(())
+    }
+
+    pub(crate) fn get(&self, name: &str) -> Option<&ValidFederationSubgraph> {
+        self.subgraphs.get(name)
+    }
+}
+
+impl IntoIterator for ValidFederationSubgraphs {
+    type Item = <BTreeMap<String, ValidFederationSubgraph> as IntoIterator>::Item;
+    type IntoIter = <BTreeMap<String, ValidFederationSubgraph> as IntoIterator>::IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
         self.subgraphs.into_iter()
@@ -1821,14 +1876,19 @@ fn remove_inactive_applications(
                 (fields, parent_type_pos)
             }
         };
+        // TODO: The assume_valid_ref() here is non-ideal, in the sense that the error messages we
+        // get back during field set parsing may not be user-friendly. We can't really validate the
+        // schema here since the schema may not be fully valid when this function is called within
+        // extract_subgraphs_from_supergraph() (it would also incur significant performance loss).
+        // At best, we could try to shift this computation to after the subgraph schema validation
+        // step, but its unclear at this time whether performing this shift affects correctness (and
+        // it takes time to determine that). So for now, we keep this here.
+        let valid_schema = Valid::assume_valid_ref(schema.schema());
         // TODO: In the JS codebase, this function ends up getting additionally used in the schema
         // upgrader, where parsing the field set may error. In such cases, we end up skipping those
         // directives instead of returning error here, as it pollutes the list of error messages
         // during composition (another site in composition will properly check for field set
         // validity and give better error messaging).
-
-        // TODO: is this correct?
-        let valid_schema = Valid::assume_valid_ref(schema.schema());
         let mut fields =
             parse_field_set(valid_schema, parent_type_pos.type_name().clone(), fields)?;
         let is_modified = remove_non_external_leaf_fields(schema, &mut fields)?;

--- a/src/query_graph/field_set.rs
+++ b/src/query_graph/field_set.rs
@@ -1,24 +1,24 @@
 use crate::error::FederationError;
 use apollo_compiler::executable::{FieldSet, SelectionSet};
 use apollo_compiler::schema::NamedType;
+use apollo_compiler::validation::Valid;
 use apollo_compiler::{NodeStr, Schema};
 
 // TODO: In the JS codebase, this optionally runs an additional validation to forbid aliases, and
 // has some error-rewriting to help give the user better hints around non-existent fields.
 pub(super) fn parse_field_set(
-    schema: &Schema,
+    schema: &Valid<Schema>,
     parent_type_name: NamedType,
     value: NodeStr,
 ) -> Result<SelectionSet, FederationError> {
     // Note this parsing takes care of adding curly braces ("{" and "}") if they aren't in the
     // string.
-    let field_set = FieldSet::parse(
+    let field_set = FieldSet::parse_and_validate(
         schema,
         parent_type_name,
         value.as_str(),
         "field_set.graphql",
-    );
-    field_set.validate(schema)?;
+    )?;
     merge_selection_sets(&[&field_set.selection_set])
 }
 

--- a/src/query_graph/mod.rs
+++ b/src/query_graph/mod.rs
@@ -3,10 +3,9 @@ use crate::schema::position::{
     CompositeTypeDefinitionPosition, FieldDefinitionPosition, OutputTypeDefinitionPosition,
     SchemaRootDefinitionKind,
 };
-use crate::schema::FederationSchema;
+use crate::schema::ValidFederationSchema;
 use apollo_compiler::executable::SelectionSet;
 use apollo_compiler::schema::{Name, NamedType};
-use apollo_compiler::validation::Valid;
 use apollo_compiler::{Node, NodeStr};
 use indexmap::{IndexMap, IndexSet};
 use petgraph::graph::{DiGraph, EdgeIndex, NodeIndex};
@@ -225,7 +224,7 @@ pub struct QueryGraph {
     /// The sources on which the query graph was built, which is a set (potentially of size 1) of
     /// GraphQL schema keyed by the name identifying them. Note that the `source` strings in the
     /// nodes/edges of a query graph are guaranteed to be valid key in this map.
-    sources: IndexMap<NodeStr, Valid<FederationSchema>>,
+    sources: IndexMap<NodeStr, ValidFederationSchema>,
     /// A map (keyed by source) that associates type names of the underlying schema on which this
     /// query graph was built to each of the nodes that points to a type of that name. Note that for
     /// a "federated" query graph source, each type name will only map to a single node.
@@ -311,11 +310,11 @@ impl QueryGraph {
         })
     }
 
-    pub(crate) fn schema(&self) -> Result<&Valid<FederationSchema>, FederationError> {
+    pub(crate) fn schema(&self) -> Result<&ValidFederationSchema, FederationError> {
         self.schema_by_source(&self.current_source)
     }
 
-    fn schema_by_source(&self, source: &str) -> Result<&Valid<FederationSchema>, FederationError> {
+    fn schema_by_source(&self, source: &str) -> Result<&ValidFederationSchema, FederationError> {
         self.sources.get(source).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: "Schema unexpectedly missing".to_owned(),

--- a/src/query_graph/mod.rs
+++ b/src/query_graph/mod.rs
@@ -6,6 +6,7 @@ use crate::schema::position::{
 use crate::schema::FederationSchema;
 use apollo_compiler::executable::SelectionSet;
 use apollo_compiler::schema::{Name, NamedType};
+use apollo_compiler::validation::Valid;
 use apollo_compiler::{Node, NodeStr};
 use indexmap::{IndexMap, IndexSet};
 use petgraph::graph::{DiGraph, EdgeIndex, NodeIndex};
@@ -224,7 +225,7 @@ pub struct QueryGraph {
     /// The sources on which the query graph was built, which is a set (potentially of size 1) of
     /// GraphQL schema keyed by the name identifying them. Note that the `source` strings in the
     /// nodes/edges of a query graph are guaranteed to be valid key in this map.
-    sources: IndexMap<NodeStr, FederationSchema>,
+    sources: IndexMap<NodeStr, Valid<FederationSchema>>,
     /// A map (keyed by source) that associates type names of the underlying schema on which this
     /// query graph was built to each of the nodes that points to a type of that name. Note that for
     /// a "federated" query graph source, each type name will only map to a single node.
@@ -310,11 +311,11 @@ impl QueryGraph {
         })
     }
 
-    pub(crate) fn schema(&self) -> Result<&FederationSchema, FederationError> {
+    pub(crate) fn schema(&self) -> Result<&Valid<FederationSchema>, FederationError> {
         self.schema_by_source(&self.current_source)
     }
 
-    fn schema_by_source(&self, source: &str) -> Result<&FederationSchema, FederationError> {
+    fn schema_by_source(&self, source: &str) -> Result<&Valid<FederationSchema>, FederationError> {
         self.sources.get(source).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: "Schema unexpectedly missing".to_owned(),

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -6,6 +6,7 @@ use crate::schema::position::{
     TypeDefinitionPosition, UnionTypeDefinitionPosition,
 };
 use apollo_compiler::schema::{ExtendedType, Name};
+use apollo_compiler::validation::Valid;
 use apollo_compiler::Schema;
 use indexmap::IndexSet;
 use referencer::Referencers;
@@ -22,6 +23,10 @@ pub struct FederationSchema {
 impl FederationSchema {
     pub(crate) fn schema(&self) -> &Schema {
         &self.schema
+    }
+
+    pub(crate) fn valid_schema(federation_schema: &Valid<Self>) -> &Valid<Schema> {
+        Valid::assume_valid_ref(&federation_schema.schema)
     }
 
     pub(crate) fn metadata(&self) -> &Option<LinksMetadata> {

--- a/src/schema/position.rs
+++ b/src/schema/position.rs
@@ -12,6 +12,7 @@ use apollo_compiler::schema::{
     ExtendedType, FieldDefinition, InputObjectType, InputValueDefinition, InterfaceType, Name,
     ObjectType, ScalarType, SchemaDefinition, UnionType,
 };
+use apollo_compiler::validation::Valid;
 use apollo_compiler::{name, Node, Schema};
 use indexmap::{Equivalent, IndexSet};
 use lazy_static::lazy_static;
@@ -6173,7 +6174,7 @@ fn validate_arguments(arguments: &[Node<InputValueDefinition>]) -> Result<(), Fe
 }
 
 impl FederationSchema {
-    pub fn new(schema: Schema) -> Result<FederationSchema, FederationError> {
+    pub fn new(schema: Valid<Schema>) -> Result<FederationSchema, FederationError> {
         let metadata = links_metadata(&schema)?;
         let mut referencers: Referencers = Default::default();
 
@@ -6271,6 +6272,7 @@ impl FederationSchema {
             .insert_references(directive, &schema, &mut referencers)?;
         }
 
+        let schema = schema.into_inner();
         Ok(FederationSchema {
             schema,
             metadata,

--- a/src/subgraph/mod.rs
+++ b/src/subgraph/mod.rs
@@ -2,99 +2,52 @@ use std::collections::BTreeMap;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use apollo_compiler::ast::{InvalidNameError, Name};
+use apollo_compiler::ast::Name;
 use apollo_compiler::schema::{ComponentName, ExtendedType, ObjectType};
 use apollo_compiler::{name, Node, Schema};
 use indexmap::map::Entry;
 use indexmap::{IndexMap, IndexSet};
 
+use crate::error::FederationError;
 use crate::link::spec::Identity;
 use crate::link::LinkError;
 use crate::link::{Link, DEFAULT_LINK_NAME};
 use crate::subgraph::spec::{
-    AppliedFederationLink, FederationSpecDefinitions, FederationSpecError, LinkSpecDefinitions,
-    ANY_SCALAR_NAME, ENTITIES_QUERY, ENTITY_UNION_NAME, FEDERATION_V2_DIRECTIVE_NAMES,
-    KEY_DIRECTIVE_NAME, SERVICE_SDL_QUERY, SERVICE_TYPE,
+    AppliedFederationLink, FederationSpecDefinitions, LinkSpecDefinitions, ANY_SCALAR_NAME,
+    ENTITIES_QUERY, ENTITY_UNION_NAME, FEDERATION_V2_DIRECTIVE_NAMES, KEY_DIRECTIVE_NAME,
+    SERVICE_SDL_QUERY, SERVICE_TYPE,
 };
+use apollo_compiler::validation::Valid;
 
 mod database;
-mod spec;
-
-// TODO: we need a strategy for errors. All (or almost all) federation errors have a code in
-// particular (and the way we deal with this in typescript, having all errors declared in one place
-// with descriptions that allow to autogenerate doc is kind of useful (if not perfect)), so we
-// probably want some additional crate specific for errors and use that here.
-#[derive(Debug)]
-pub struct SubgraphError {
-    pub msg: String,
-}
-
-impl From<apollo_compiler::DiagnosticList> for SubgraphError {
-    fn from(value: apollo_compiler::DiagnosticList) -> Self {
-        SubgraphError {
-            msg: value.to_string_no_color(),
-        }
-    }
-}
-
-impl From<LinkError> for SubgraphError {
-    fn from(value: LinkError) -> Self {
-        SubgraphError {
-            msg: value.to_string(),
-        }
-    }
-}
-
-impl From<FederationSpecError> for SubgraphError {
-    fn from(value: FederationSpecError) -> Self {
-        SubgraphError {
-            msg: value.to_string(),
-        }
-    }
-}
-
-impl From<InvalidNameError> for SubgraphError {
-    fn from(err: InvalidNameError) -> Self {
-        SubgraphError {
-            msg: format!("Invalid GraphQL name \"{}\"", err.0),
-        }
-    }
-}
+pub mod spec;
 
 pub struct Subgraph {
     pub name: String,
     pub url: String,
-    pub schema: Schema,
+    pub schema: Valid<Schema>,
 }
 
 impl Subgraph {
-    pub fn new(name: &str, url: &str, schema_str: &str) -> Self {
-        let schema = Schema::parse(schema_str, name);
-
-        // TODO: ideally, we'd want Subgraph to always represent a valid subgraph: we don't want
-        // every possible method that receive a subgraph to have to worry if the underlying schema
-        // is actually not a subgraph at all: we want the type-system to help carry known
-        // guarantees. This imply we should run validation here (both graphQL ones, but also
-        // subgraph specific ones).
-        // This also mean we would ideally want `schema` to not export any mutable methods
-        // but not sure what that entail/how doable that is currently.
-
-        Self {
+    pub fn new(name: &str, url: &str, schema_str: &str) -> Result<Self, FederationError> {
+        let schema = Schema::parse_and_validate(schema_str, name)?;
+        // TODO: federation-specific validation
+        Ok(Self {
             name: name.to_string(),
             url: url.to_string(),
             schema,
-        }
+        })
     }
 
     pub fn parse_and_expand(
         name: &str,
         url: &str,
         schema_str: &str,
-    ) -> Result<Self, SubgraphError> {
+    ) -> Result<Self, FederationError> {
         let mut schema = Schema::builder()
             .adopt_orphan_extensions()
             .parse(schema_str, name)
-            .build();
+            .build()?;
 
         let mut imported_federation_definitions: Option<FederationSpecDefinitions> = None;
         let mut imported_link_definitions: Option<LinkSpecDefinitions> = None;
@@ -108,7 +61,8 @@ impl Subgraph {
             let link_directive = Link::from_directive_application(directive)?;
             if link_directive.url.identity == Identity::federation_identity() {
                 if imported_federation_definitions.is_some() {
-                    return Err(SubgraphError { msg: "invalid graphql schema - multiple @link imports for the federation specification are not supported".to_owned() });
+                    let msg = "invalid graphql schema - multiple @link imports for the federation specification are not supported";
+                    return Err(LinkError::BootstrapError(msg.to_owned()).into());
                 }
 
                 imported_federation_definitions =
@@ -116,7 +70,8 @@ impl Subgraph {
             } else if link_directive.url.identity == Identity::link_identity() {
                 // user manually imported @link specification
                 if imported_link_definitions.is_some() {
-                    return Err(SubgraphError { msg: "invalid graphql schema - multiple @link imports for the link specification are not supported".to_owned() });
+                    let msg = "invalid graphql schema - multiple @link imports for the link specification are not supported";
+                    return Err(LinkError::BootstrapError(msg.to_owned()).into());
                 }
 
                 imported_link_definitions = Some(LinkSpecDefinitions::new(link_directive));
@@ -129,7 +84,7 @@ impl Subgraph {
             imported_federation_definitions,
             imported_link_definitions,
         )?;
-        schema.validate()?;
+        let schema = schema.validate()?;
         Ok(Self {
             name: name.to_owned(),
             url: url.to_owned(),
@@ -141,7 +96,7 @@ impl Subgraph {
         schema: &mut Schema,
         imported_federation_definitions: Option<FederationSpecDefinitions>,
         imported_link_definitions: Option<LinkSpecDefinitions>,
-    ) -> Result<(), SubgraphError> {
+    ) -> Result<(), FederationError> {
         // populate @link spec definitions
         let link_spec_definitions = match imported_link_definitions {
             Some(definitions) => definitions,
@@ -180,7 +135,7 @@ impl Subgraph {
     fn populate_missing_link_definitions(
         schema: &mut Schema,
         link_spec_definitions: LinkSpecDefinitions,
-    ) -> Result<(), SubgraphError> {
+    ) -> Result<(), FederationError> {
         let purpose_enum_name = Name::new(&link_spec_definitions.purpose_enum_name)?;
         schema
             .types
@@ -208,7 +163,7 @@ impl Subgraph {
     fn populate_missing_federation_directive_definitions(
         schema: &mut Schema,
         fed_definitions: &FederationSpecDefinitions,
-    ) -> Result<(), SubgraphError> {
+    ) -> Result<(), FederationError> {
         let fieldset_scalar_name = Name::new(&fed_definitions.fieldset_scalar_name)?;
         schema
             .types
@@ -239,7 +194,7 @@ impl Subgraph {
     fn populate_missing_federation_types(
         schema: &mut Schema,
         fed_definitions: &FederationSpecDefinitions,
-    ) -> Result<(), SubgraphError> {
+    ) -> Result<(), FederationError> {
         schema
             .types
             .entry(SERVICE_TYPE)
@@ -336,11 +291,9 @@ impl Subgraphs {
         }
     }
 
-    pub fn add(&mut self, subgraph: Subgraph) -> Result<(), SubgraphError> {
+    pub fn add(&mut self, subgraph: Subgraph) -> Result<(), String> {
         if self.subgraphs.contains_key(&subgraph.name) {
-            return Err(SubgraphError {
-                msg: format!("A subgraph named {} already exists", subgraph.name),
-            });
+            return Err(format!("A subgraph named {} already exists", subgraph.name));
         }
         self.subgraphs
             .insert(subgraph.name.clone(), Arc::new(subgraph));
@@ -390,7 +343,7 @@ mod tests {
           directive @link(url: String, as: String, import: [Import], for: link__Purpose) repeatable on SCHEMA
         "#;
 
-        let subgraph = Subgraph::new("S1", "http://s1", schema);
+        let subgraph = Subgraph::new("S1", "http://s1", schema).unwrap();
         let keys = keys(&subgraph.schema, "T");
         assert_eq!(keys.len(), 1);
         assert_eq!(keys.get(0).unwrap().type_name, "T");

--- a/src/subgraph/mod.rs
+++ b/src/subgraph/mod.rs
@@ -25,12 +25,12 @@ pub mod spec;
 pub struct Subgraph {
     pub name: String,
     pub url: String,
-    pub schema: Valid<Schema>,
+    pub schema: Schema,
 }
 
 impl Subgraph {
     pub fn new(name: &str, url: &str, schema_str: &str) -> Result<Self, FederationError> {
-        let schema = Schema::parse_and_validate(schema_str, name)?;
+        let schema = Schema::parse(schema_str, name)?;
         // TODO: federation-specific validation
         Ok(Self {
             name: name.to_string(),
@@ -43,7 +43,7 @@ impl Subgraph {
         name: &str,
         url: &str,
         schema_str: &str,
-    ) -> Result<Self, FederationError> {
+    ) -> Result<ValidSubgraph, FederationError> {
         let mut schema = Schema::builder()
             .adopt_orphan_extensions()
             .parse(schema_str, name)
@@ -85,7 +85,7 @@ impl Subgraph {
             imported_link_definitions,
         )?;
         let schema = schema.validate()?;
-        Ok(Self {
+        Ok(ValidSubgraph {
             name: name.to_owned(),
             url: url.to_owned(),
             schema,
@@ -302,6 +302,18 @@ impl Subgraphs {
 
     pub fn get(&self, name: &str) -> Option<Arc<Subgraph>> {
         self.subgraphs.get(name).cloned()
+    }
+}
+
+pub struct ValidSubgraph {
+    pub name: String,
+    pub url: String,
+    pub schema: Valid<Schema>,
+}
+
+impl std::fmt::Debug for ValidSubgraph {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, r#"name: {}, urL: {}"#, self.name, self.url)
     }
 }
 

--- a/src/subgraph/spec.rs
+++ b/src/subgraph/spec.rs
@@ -219,6 +219,8 @@ impl FederationSpecDefinitions {
         }
     }
 
+    // The Default trait doesn't allow for returning Results, so we ignore the clippy warning here.
+    #[allow(clippy::should_implement_trait)]
     pub fn default() -> Result<Self, FederationSpecError> {
         Self::from_link(Link {
             url: Url {
@@ -591,23 +593,6 @@ impl LinkSpecDefinitions {
         }
     }
 
-    pub fn default() -> Self {
-        let link = Link {
-            url: Url {
-                identity: Identity::link_identity(),
-                version: Version { major: 1, minor: 0 },
-            },
-            imports: vec![Arc::new(Import {
-                element: "Import".to_owned(),
-                is_directive: false,
-                alias: None,
-            })],
-            purpose: None,
-            spec_alias: None,
-        };
-        Self::new(link)
-    }
-
     ///   scalar Import
     pub fn import_scalar_definition(&self, name: Name) -> ScalarType {
         ScalarType {
@@ -695,6 +680,25 @@ impl LinkSpecDefinitions {
             repeatable: true,
             locations: vec![DirectiveLocation::Schema],
         })
+    }
+}
+
+impl Default for LinkSpecDefinitions {
+    fn default() -> Self {
+        let link = Link {
+            url: Url {
+                identity: Identity::link_identity(),
+                version: Version { major: 1, minor: 0 },
+            },
+            imports: vec![Arc::new(Import {
+                element: "Import".to_owned(),
+                is_directive: false,
+                alias: None,
+            })],
+            purpose: None,
+            spec_alias: None,
+        };
+        Self::new(link)
     }
 }
 

--- a/tests/snapshots/main__composition_tests__can_compose_supergraph.snap
+++ b/tests/snapshots/main__composition_tests__can_compose_supergraph.snap
@@ -1,5 +1,5 @@
 ---
-source: apollo-federation/tests/composition_tests.rs
+source: tests/composition_tests.rs
 expression: print_sdl(&supergraph.schema)
 ---
 schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
@@ -51,9 +51,11 @@ enum join__Graph {
 scalar link__Import
 
 enum link__Purpose {
-  "SECURITY features provide metadata necessary to securely resolve fields."
+  """
+  SECURITY features provide metadata necessary to securely resolve fields.
+  """
   SECURITY
-  "EXECUTION features provide metadata necessary for operation execution."
+  """EXECUTION features provide metadata necessary for operation execution."""
   EXECUTION
 }
 

--- a/tests/snapshots/main__composition_tests__can_compose_types_from_different_subgraphs.snap
+++ b/tests/snapshots/main__composition_tests__can_compose_types_from_different_subgraphs.snap
@@ -1,5 +1,5 @@
 ---
-source: apollo-federation/tests/composition_tests.rs
+source: tests/composition_tests.rs
 expression: print_sdl(&supergraph.schema)
 ---
 schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
@@ -44,9 +44,11 @@ enum join__Graph {
 scalar link__Import
 
 enum link__Purpose {
-  "SECURITY features provide metadata necessary to securely resolve fields."
+  """
+  SECURITY features provide metadata necessary to securely resolve fields.
+  """
   SECURITY
-  "EXECUTION features provide metadata necessary for operation execution."
+  """EXECUTION features provide metadata necessary for operation execution."""
   EXECUTION
 }
 

--- a/tests/snapshots/main__composition_tests__can_compose_with_descriptions-2.snap
+++ b/tests/snapshots/main__composition_tests__can_compose_with_descriptions-2.snap
@@ -1,25 +1,28 @@
 ---
-source: apollo-federation/tests/composition_tests.rs
+source: tests/composition_tests.rs
 expression: print_sdl(&supergraph.to_api_schema())
 ---
-"A cool schema"
+"""A cool schema"""
 schema {
   query: Query
 }
 
-"An enum"
+"""An enum"""
 enum E {
-  "The A value"
+  """The A value"""
   A
-  "The B value"
+  """The B value"""
   B
 }
 
-"Available queries\nNot much yet"
+"""
+Available queries
+Not much yet
+"""
 type Query {
-  "Returns tea"
+  """Returns tea"""
   t(
-    "An argument that is very important"
+    """An argument that is very important"""
     x: String!,
   ): String
 }

--- a/tests/snapshots/main__composition_tests__can_compose_with_descriptions.snap
+++ b/tests/snapshots/main__composition_tests__can_compose_with_descriptions.snap
@@ -1,13 +1,13 @@
 ---
-source: apollo-federation/tests/composition_tests.rs
+source: tests/composition_tests.rs
 expression: print_sdl(&supergraph.schema)
 ---
-"A cool schema"
+"""A cool schema"""
 schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
   query: Query
 }
 
-"The foo directive description"
+"""The foo directive description"""
 directive @foo(url: String) on FIELD
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
@@ -24,19 +24,22 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
-"An enum"
+"""An enum"""
 enum E @join__type(graph: SUBGRAPH2) {
-  "The A value"
+  """The A value"""
   A @join__enumValue(graph: SUBGRAPH2)
-  "The B value"
+  """The B value"""
   B @join__enumValue(graph: SUBGRAPH2)
 }
 
-"Available queries\nNot much yet"
+"""
+Available queries
+Not much yet
+"""
 type Query @join__type(graph: SUBGRAPH1) @join__type(graph: SUBGRAPH2) {
-  "Returns tea"
+  """Returns tea"""
   t(
-    "An argument that is very important"
+    """An argument that is very important"""
     x: String!,
   ): String @join__field(graph: SUBGRAPH1)
 }
@@ -51,9 +54,11 @@ enum join__Graph {
 scalar link__Import
 
 enum link__Purpose {
-  "SECURITY features provide metadata necessary to securely resolve fields."
+  """
+  SECURITY features provide metadata necessary to securely resolve fields.
+  """
   SECURITY
-  "EXECUTION features provide metadata necessary for operation execution."
+  """EXECUTION features provide metadata necessary for operation execution."""
   EXECUTION
 }
 

--- a/tests/snapshots/main__composition_tests__compose_removes_federation_directives.snap
+++ b/tests/snapshots/main__composition_tests__compose_removes_federation_directives.snap
@@ -1,5 +1,5 @@
 ---
-source: apollo-federation/tests/composition_tests.rs
+source: tests/composition_tests.rs
 expression: print_sdl(&supergraph.schema)
 ---
 schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
@@ -39,9 +39,11 @@ enum join__Graph {
 scalar link__Import
 
 enum link__Purpose {
-  "SECURITY features provide metadata necessary to securely resolve fields."
+  """
+  SECURITY features provide metadata necessary to securely resolve fields.
+  """
   SECURITY
-  "EXECUTION features provide metadata necessary for operation execution."
+  """EXECUTION features provide metadata necessary for operation execution."""
   EXECUTION
 }
 

--- a/tests/subgraph/parse_expand_tests.rs
+++ b/tests/subgraph/parse_expand_tests.rs
@@ -17,7 +17,7 @@ fn can_parse_and_expand() -> Result<(), String> {
         "#;
 
     let subgraph = Subgraph::parse_and_expand("S1", "http://s1", schema).map_err(|e| {
-        println!("{}", e.msg);
+        println!("{}", e);
         String::from("failed to parse and expand the subgraph, see errors above for details")
     })?;
     assert!(subgraph.schema.types.contains_key("T"));
@@ -46,7 +46,7 @@ fn can_parse_and_expand_with_renames() -> Result<(), String> {
         "#;
 
     let subgraph = Subgraph::parse_and_expand("S1", "http://s1", schema).map_err(|e| {
-        println!("{}", e.msg);
+        println!("{}", e);
         String::from("failed to parse and expand the subgraph, see errors above for details")
     })?;
     assert!(subgraph.schema.directive_definitions.contains_key("myKey"));
@@ -74,7 +74,7 @@ fn can_parse_and_expand_with_namespace() -> Result<(), String> {
         "#;
 
     let subgraph = Subgraph::parse_and_expand("S1", "http://s1", schema).map_err(|e| {
-        println!("{}", e.msg);
+        println!("{}", e);
         String::from("failed to parse and expand the subgraph, see errors above for details")
     })?;
     assert!(subgraph.schema.directive_definitions.contains_key("key"));
@@ -112,7 +112,7 @@ fn can_parse_and_expand_preserves_user_definitions() -> Result<(), String> {
         "#;
 
     let subgraph = Subgraph::parse_and_expand("S1", "http://s1", schema).map_err(|e| {
-        println!("{}", e.msg);
+        println!("{}", e);
         String::from("failed to parse and expand the subgraph, see errors above for details")
     })?;
     assert!(subgraph.schema.types.contains_key("Purpose"));
@@ -133,7 +133,7 @@ fn can_parse_and_expand_works_with_fed_v1() -> Result<(), String> {
         "#;
 
     let subgraph = Subgraph::parse_and_expand("S1", "http://s1", schema).map_err(|e| {
-        println!("{}", e.msg);
+        println!("{}", e);
         String::from("failed to parse and expand the subgraph, see errors above for details")
     })?;
     assert!(subgraph.schema.types.contains_key("T"));
@@ -160,5 +160,5 @@ fn can_parse_and_expand_will_fail_when_importing_same_spec_twice() {
 
     let result = Subgraph::parse_and_expand("S1", "http://s1", schema)
         .expect_err("importing same specification twice should fail");
-    assert_eq!("invalid graphql schema - multiple @link imports for the federation specification are not supported", result.msg);
+    assert_eq!("Invalid use of @link in schema: invalid graphql schema - multiple @link imports for the federation specification are not supported", result.to_string());
 }


### PR DESCRIPTION
This PR (started by @SimonSapin and updated by me) updates `federation-next` to use `apollo-compiler@1.0.0-beta.10`.