### PR TITLE
Use Name instead of strings for names

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use apollo_compiler::name;
 use apollo_compiler::Schema;
 
 use crate::error::FederationError;
@@ -14,7 +15,7 @@ use crate::Supergraph;
 pub fn join_link_identity() -> Identity {
     Identity {
         domain: APOLLO_SPEC_DOMAIN.to_string(),
-        name: "join".to_string(),
+        name: name!("join"),
     }
 }
 

--- a/src/link/argument.rs
+++ b/src/link/argument.rs
@@ -83,7 +83,7 @@ pub(crate) fn directive_optional_fieldset_argument(
         Some(argument) => match argument.value.deref() {
             Value::String(name) => Ok(Some(name.clone())),
             Value::Null => Ok(None),
-            _ => Err(SingleFederationError::InvalidGraphQL {
+            _ => Err(SingleFederationError::Internal {
                 message: format!("Invalid value for argument \"{}\": must be a string.", name),
             }
             .into()),

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -3,9 +3,9 @@ use crate::link::link_spec_definition::{LinkSpecDefinition, CORE_VERSIONS, LINK_
 use crate::link::spec::Identity;
 use crate::link::spec::Url;
 use crate::link::spec_definition::spec_definitions;
-use apollo_compiler::ast::{Directive, Value};
-use apollo_compiler::name;
+use apollo_compiler::ast::{Directive, InvalidNameError, Value};
 use apollo_compiler::schema::Name;
+use apollo_compiler::{name, Node, NodeStr};
 use std::fmt;
 use std::ops::Deref;
 use std::str;
@@ -28,6 +28,8 @@ pub const DEFAULT_PURPOSE_ENUM_NAME: Name = name!("Purpose");
 // error and whatnot.
 #[derive(Error, Debug, PartialEq)]
 pub enum LinkError {
+    #[error(transparent)]
+    InvalidName(#[from] InvalidNameError),
     #[error("Invalid use of @link in schema: {0}")]
     BootstrapError(String),
 }
@@ -77,11 +79,10 @@ impl str::FromStr for Purpose {
 
 impl fmt::Display for Purpose {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let str = match self {
-            Purpose::SECURITY => "SECURITY",
-            Purpose::EXECUTION => "EXECUTION",
-        };
-        write!(f, "{}", str)
+        match self {
+            Purpose::SECURITY => f.write_str("SECURITY"),
+            Purpose::EXECUTION => f.write_str("EXECUTION"),
+        }
     }
 }
 
@@ -100,13 +101,13 @@ pub struct Import {
     ///
     /// Note that this will never start with '@': whether or not this is the name of a directive is
     /// entirely reflected by the value of `is_directive`.
-    pub element: String,
+    pub element: Name,
 
     /// Whether the imported element is a directive (if it is not, then it is an imported type).
     pub is_directive: bool,
 
     /// The optional alias under which the element is imported.
-    pub alias: Option<String>,
+    pub alias: Option<Name>,
 }
 
 impl Import {
@@ -116,50 +117,54 @@ impl Import {
         // currently, so a bit annoying.
         match value {
             Value::String(str) => {
-                let is_directive = str.starts_with('@');
-                let element = if is_directive {
-                    str.strip_prefix('@').unwrap().to_string()
+                if let Some(directive_name) = str.strip_prefix('@') {
+                    Ok(Import { element: Name::new(directive_name)?, is_directive: true, alias: None })
                 } else {
-                    str.to_string()
-                };
-                Ok(Import { element, is_directive, alias: None })
+                    Ok(Import { element: Name::new(str.clone())?, is_directive: false, alias: None })
+                }
             },
             Value::Object(fields) => {
-                let mut name: Option<String> = None;
-                let mut alias: Option<String> = None;
+                let mut name: Option<NodeStr> = None;
+                let mut alias: Option<NodeStr> = None;
                 for (k, v) in fields {
                     match k.as_str() {
                         "name" => {
-                            name = Some(v.as_str().ok_or_else(|| {
+                            name = Some(v.as_node_str().ok_or_else(|| {
                                 LinkError::BootstrapError("invalid value for `name` field in @link(import:) argument: must be a string".to_string())
-                            })?.to_owned())
+                            })?.clone())
                         },
                         "as" => {
-                            alias = Some(v.as_str().ok_or_else(|| {
+                            alias = Some(v.as_node_str().ok_or_else(|| {
                                 LinkError::BootstrapError("invalid value for `as` field in @link(import:) argument: must be a string".to_string())
-                            })?.to_owned())
+                            })?.clone())
                         },
                         _ => Err(LinkError::BootstrapError(format!("unknown field `{k}` in @link(import:) argument")))?
                     }
                 }
                 if let Some(element) = name {
-                    let is_directive = element.starts_with('@');
-                    if is_directive {
-                        let element = element.strip_prefix('@').unwrap().to_string();
-                        if let Some(alias_str) = alias {
-                            if !alias_str.starts_with('@') {
-                                Err(LinkError::BootstrapError(format!("invalid alias '{}' for import name '{}': should start with '@' since the imported name does", alias_str, element)))?
-                            }
-                            alias = Some(alias_str.strip_prefix('@').unwrap().to_string());
+                    if let Some(directive_name) = element.strip_prefix('@') {
+                        if let Some(alias_str) = alias.as_ref() {
+                            let Some(alias_str) = alias_str.strip_prefix('@') else {
+                                return Err(LinkError::BootstrapError(format!("invalid alias '{}' for import name '{}': should start with '@' since the imported name does", alias_str, element)));
+                            };
+                            alias = Some(alias_str.into());
                         }
-                        Ok(Import { element, is_directive, alias })
+                        Ok(Import {
+                            element: Name::new(directive_name)?,
+                            is_directive: true,
+                            alias: alias.map(Name::new).transpose()?,
+                        })
                     } else {
                         if let Some(alias) = &alias {
                             if alias.starts_with('@') {
-                                Err(LinkError::BootstrapError(format!("invalid alias '{}' for import name '{}': should not start with '@' (or, if {} is a directive, then the name should start with '@')", alias, element, element)))?
+                                return Err(LinkError::BootstrapError(format!("invalid alias '{}' for import name '{}': should not start with '@' (or, if {} is a directive, then the name should start with '@')", alias, element, element)));
                             }
                         }
-                        Ok(Import { element, is_directive, alias })
+                        Ok(Import {
+                            element: Name::new(element)?,
+                            is_directive: false,
+                            alias: alias.map(Name::new).transpose()?,
+                        })
                     }
                 } else {
                     Err(LinkError::BootstrapError("invalid entry in @link(import:) argument, missing mandatory `name` field".to_string()))
@@ -169,24 +174,37 @@ impl Import {
         }
     }
 
-    pub fn element_display_name(&self) -> String {
-        if self.is_directive {
-            format!("@{}", self.element)
-        } else {
-            self.element.clone()
+    pub fn element_display_name(&self) -> impl fmt::Display + '_ {
+        DisplayName {
+            name: &self.element,
+            is_directive: self.is_directive,
         }
     }
 
-    pub fn imported_name(&self) -> &String {
+    pub fn imported_name(&self) -> &Name {
         return self.alias.as_ref().unwrap_or(&self.element);
     }
 
-    pub fn imported_display_name(&self) -> String {
-        if self.is_directive {
-            format!("@{}", self.imported_name())
-        } else {
-            self.imported_name().clone()
+    pub fn imported_display_name(&self) -> impl fmt::Display + '_ {
+        DisplayName {
+            name: self.imported_name(),
+            is_directive: self.is_directive,
         }
+    }
+}
+
+/// A [`fmt::Display`]able wrapper for name strings that adds an `@` in front for directive names.
+struct DisplayName<'s> {
+    name: &'s str,
+    is_directive: bool,
+}
+
+impl<'s> fmt::Display for DisplayName<'s> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_directive {
+            f.write_str("@")?;
+        }
+        f.write_str(self.name)
     }
 }
 
@@ -196,11 +214,7 @@ impl fmt::Display for Import {
             write!(
                 f,
                 r#"{{ name: "{}", as: "{}" }}"#,
-                if self.is_directive {
-                    format!("@{}", self.element)
-                } else {
-                    self.element.clone()
-                },
+                self.element_display_name(),
                 self.imported_display_name()
             )
         } else {
@@ -212,41 +226,43 @@ impl fmt::Display for Import {
 #[derive(Debug, Eq, PartialEq)]
 pub struct Link {
     pub url: Url,
-    pub spec_alias: Option<String>,
+    pub spec_alias: Option<Name>,
     pub imports: Vec<Arc<Import>>,
     pub purpose: Option<Purpose>,
 }
 
 impl Link {
-    pub fn spec_name_in_schema(&self) -> &String {
+    pub fn spec_name_in_schema(&self) -> &Name {
         self.spec_alias.as_ref().unwrap_or(&self.url.identity.name)
     }
 
-    pub fn directive_name_in_schema(&self, name: &str) -> String {
+    pub fn directive_name_in_schema(&self, name: &Name) -> Name {
         // If the directive is imported, then it's name in schema is whatever name it is
         // imported under. Otherwise, it is usually fully qualified by the spec name (so,
         // something like 'federation__key'), but there is a special case for directives
         // whose name match the one of the spec: those don't get qualified.
-        if let Some(import) = self.imports.iter().find(|i| i.element == name) {
-            import.alias.clone().unwrap_or(name.to_string())
-        } else if name == self.url.identity.name {
+        if let Some(import) = self.imports.iter().find(|i| i.element == *name) {
+            import.alias.clone().unwrap_or_else(|| name.clone())
+        } else if name == self.url.identity.name.as_str() {
             self.spec_name_in_schema().clone()
         } else {
-            format!("{}__{}", self.spec_name_in_schema(), name)
+            // Both sides are `Name`s and we just add valid characters in between.
+            Name::new_unchecked(format!("{}__{}", self.spec_name_in_schema(), name).into())
         }
     }
 
-    pub fn type_name_in_schema(&self, name: &str) -> String {
+    pub fn type_name_in_schema(&self, name: &Name) -> Name {
         // Similar to directives, but the special case of a directive name matching the spec
         // name does not apply to types.
-        if let Some(import) = self.imports.iter().find(|i| i.element == name) {
-            import.alias.clone().unwrap_or(name.to_string())
+        if let Some(import) = self.imports.iter().find(|i| i.element == *name) {
+            import.alias.clone().unwrap_or_else(|| name.clone())
         } else {
-            format!("{}__{}", self.spec_name_in_schema(), name)
+            // Both sides are `Name`s and we just add valid characters in between.
+            Name::new_unchecked(format!("{}__{}", self.spec_name_in_schema(), name).into())
         }
     }
 
-    pub fn from_directive_application(directive: &Directive) -> Result<Link, LinkError> {
+    pub fn from_directive_application(directive: &Node<Directive>) -> Result<Link, LinkError> {
         let url = directive
             .argument_by_name("url")
             .and_then(|arg| arg.as_str())
@@ -258,8 +274,9 @@ impl Link {
         })?;
         let spec_alias = directive
             .argument_by_name("as")
-            .and_then(|arg| arg.as_str())
-            .map(|s| s.to_owned());
+            .and_then(|arg| arg.as_node_str())
+            .map(Name::new)
+            .transpose()?;
         let purpose = if let Some(value) = directive.argument_by_name("for") {
             Some(Purpose::from_ast_value(value)?)
         } else {
@@ -319,9 +336,9 @@ pub struct LinkedElement {
 pub struct LinksMetadata {
     pub(crate) links: Vec<Arc<Link>>,
     pub(crate) by_identity: HashMap<Identity, Arc<Link>>,
-    pub(crate) by_name_in_schema: HashMap<String, Arc<Link>>,
-    pub(crate) types_by_imported_name: HashMap<String, (Arc<Link>, Arc<Import>)>,
-    pub(crate) directives_by_imported_name: HashMap<String, (Arc<Link>, Arc<Import>)>,
+    pub(crate) by_name_in_schema: HashMap<Name, Arc<Link>>,
+    pub(crate) types_by_imported_name: HashMap<Name, (Arc<Link>, Arc<Import>)>,
+    pub(crate) directives_by_imported_name: HashMap<Name, (Arc<Link>, Arc<Import>)>,
 }
 
 impl LinksMetadata {
@@ -362,10 +379,10 @@ impl LinksMetadata {
         return self.by_identity.get(identity).cloned();
     }
 
-    pub fn source_link_of_type(&self, type_name: &str) -> Option<LinkedElement> {
+    pub fn source_link_of_type(&self, type_name: &Name) -> Option<LinkedElement> {
         // For types, it's either an imported name or it must be fully qualified
 
-        if let Some((link, import)) = self.types_by_imported_name.get(type_name) {
+        if let Some((link, import)) = self.types_by_imported_name.get(type_name.as_str()) {
             Some(LinkedElement {
                 link: Arc::clone(link),
                 import: Some(Arc::clone(import)),
@@ -382,20 +399,23 @@ impl LinksMetadata {
         }
     }
 
-    pub fn source_link_of_directive(&self, directive_name: &str) -> Option<LinkedElement> {
+    pub fn source_link_of_directive(&self, directive_name: &Name) -> Option<LinkedElement> {
         // For directives, it can be either:
         //   1. be an imported name,
         //   2. be the "imported" name of a linked spec (special case of a directive named like the
         //      spec),
         //   3. or it must be fully qualified.
-        if let Some((link, import)) = self.directives_by_imported_name.get(directive_name) {
+        if let Some((link, import)) = self
+            .directives_by_imported_name
+            .get(directive_name.as_str())
+        {
             return Some(LinkedElement {
                 link: Arc::clone(link),
                 import: Some(Arc::clone(import)),
             });
         }
 
-        if let Some(link) = self.by_name_in_schema.get(directive_name) {
+        if let Some(link) = self.by_name_in_schema.get(directive_name.as_str()) {
             return Some(LinkedElement {
                 link: Arc::clone(link),
                 import: None,

--- a/src/link/spec_definition.rs
+++ b/src/link/spec_definition.rs
@@ -23,7 +23,7 @@ pub(crate) trait SpecDefinition {
     fn is_spec_directive_name(
         &self,
         schema: &FederationSchema,
-        name_in_schema: &str,
+        name_in_schema: &Name,
     ) -> Result<bool, FederationError> {
         let Some(ref metadata) = schema.metadata() else {
             return Err(SingleFederationError::Internal {
@@ -40,7 +40,7 @@ pub(crate) trait SpecDefinition {
     fn is_spec_type_name(
         &self,
         schema: &FederationSchema,
-        name_in_schema: &str,
+        name_in_schema: &Name,
     ) -> Result<bool, FederationError> {
         let Some(ref metadata) = schema.metadata() else {
             return Err(SingleFederationError::Internal {
@@ -62,20 +62,18 @@ pub(crate) trait SpecDefinition {
         let Some(link) = self.link_in_schema(schema)? else {
             return Ok(None);
         };
-        Ok(Some(
-            link.directive_name_in_schema(name_in_spec).try_into()?,
-        ))
+        Ok(Some(link.directive_name_in_schema(name_in_spec)))
     }
 
     fn type_name_in_schema(
         &self,
         schema: &FederationSchema,
-        name_in_spec: &str,
+        name_in_spec: &Name,
     ) -> Result<Option<Name>, FederationError> {
         let Some(link) = self.link_in_schema(schema)? else {
             return Ok(None);
         };
-        Ok(Some(link.type_name_in_schema(name_in_spec).try_into()?))
+        Ok(Some(link.type_name_in_schema(name_in_spec)))
     }
 
     fn directive_definition<'schema>(

--- a/src/schema/position.rs
+++ b/src/schema/position.rs
@@ -599,10 +599,7 @@ impl SchemaDefinitionPosition {
             Some(metadata) => {
                 let link_spec_definition = metadata.link_spec_definition()?;
                 let link_name_in_schema = link_spec_definition
-                    .directive_name_in_schema(
-                        schema,
-                        &Name::new(&link_spec_definition.identity().name)?,
-                    )?
+                    .directive_name_in_schema(schema, &link_spec_definition.identity().name)?
                     .ok_or_else(|| SingleFederationError::Internal {
                         message: "Unexpectedly could not find core/link spec usage".to_owned(),
                     })?;

--- a/src/subgraph/mod.rs
+++ b/src/subgraph/mod.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeMap;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use apollo_compiler::ast::Name;
 use apollo_compiler::schema::{ComponentName, ExtendedType, ObjectType};
 use apollo_compiler::{name, Node, Schema};
 use indexmap::map::Entry;
@@ -136,22 +135,22 @@ impl Subgraph {
         schema: &mut Schema,
         link_spec_definitions: LinkSpecDefinitions,
     ) -> Result<(), FederationError> {
-        let purpose_enum_name = Name::new(&link_spec_definitions.purpose_enum_name)?;
+        let purpose_enum_name = &link_spec_definitions.purpose_enum_name;
         schema
             .types
             .entry(purpose_enum_name.clone())
             .or_insert_with(|| {
                 link_spec_definitions
-                    .link_purpose_enum_definition(purpose_enum_name)
+                    .link_purpose_enum_definition(purpose_enum_name.clone())
                     .into()
             });
-        let import_scalar_name = Name::new(&link_spec_definitions.import_scalar_name)?;
+        let import_scalar_name = &link_spec_definitions.import_scalar_name;
         schema
             .types
             .entry(import_scalar_name.clone())
             .or_insert_with(|| {
                 link_spec_definitions
-                    .import_scalar_definition(import_scalar_name)
+                    .import_scalar_definition(import_scalar_name.clone())
                     .into()
             });
         if let Entry::Vacant(entry) = schema.directive_definitions.entry(DEFAULT_LINK_NAME) {
@@ -164,19 +163,19 @@ impl Subgraph {
         schema: &mut Schema,
         fed_definitions: &FederationSpecDefinitions,
     ) -> Result<(), FederationError> {
-        let fieldset_scalar_name = Name::new(&fed_definitions.fieldset_scalar_name)?;
+        let fieldset_scalar_name = &fed_definitions.fieldset_scalar_name;
         schema
             .types
             .entry(fieldset_scalar_name.clone())
             .or_insert_with(|| {
                 fed_definitions
-                    .fieldset_scalar_definition(fieldset_scalar_name)
+                    .fieldset_scalar_definition(fieldset_scalar_name.clone())
                     .into()
             });
 
         for directive_name in &FEDERATION_V2_DIRECTIVE_NAMES {
             let namespaced_directive_name =
-                Name::new(&fed_definitions.namespaced_type_name(directive_name, true))?;
+                fed_definitions.namespaced_type_name(directive_name, true);
             if let Entry::Vacant(entry) = schema
                 .directive_definitions
                 .entry(namespaced_directive_name.clone())
@@ -356,9 +355,9 @@ mod tests {
         "#;
 
         let subgraph = Subgraph::new("S1", "http://s1", schema).unwrap();
-        let keys = keys(&subgraph.schema, "T");
+        let keys = keys(&subgraph.schema, &name!("T"));
         assert_eq!(keys.len(), 1);
-        assert_eq!(keys.get(0).unwrap().type_name, "T");
+        assert_eq!(keys.get(0).unwrap().type_name, name!("T"));
 
         // TODO: no accessible selection yet.
     }


### PR DESCRIPTION
while experimenting with diagnostics in the `link` module, I found it useful to have `Name` instances (with location information) to point to.

This also moves some errors earlier--if you for example have a spec URL where the name section is not a valid GraphQL name, it bails out immediately instead of at some later point when trying to use the name. 