### PR TITLE
chore(deps): remove `env_logger`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ strum = "0.25.0"
 strum_macros = "0.25.2"
 
 [dev-dependencies]
-env_logger = "0.7"
 insta = { version = "1.34.0", features = ["yaml"] }
 
 [[test]]


### PR DESCRIPTION
It's not currently used anywhere. alternative to #20 :)

Or **should** we be using it somewhere?
