### PR TITLE
feat: Adjust operation types

### DIFF
--- a/src/query_graph/build_query_graph.rs
+++ b/src/query_graph/build_query_graph.rs
@@ -23,7 +23,6 @@ use indexmap::{IndexMap, IndexSet};
 use petgraph::graph::{EdgeIndex, NodeIndex};
 use petgraph::visit::EdgeRef;
 use petgraph::Direction;
-use std::sync::Arc;
 use strum::IntoEnumIterator;
 
 /// Builds a "federated" query graph based on the provided supergraph and API schema.
@@ -33,8 +32,8 @@ use strum::IntoEnumIterator;
 ///
 /// Assumes the given schemas have been validated.
 pub fn build_federated_query_graph(
-    supergraph_schema: Arc<ValidFederationSchema>,
-    api_schema: Arc<ValidFederationSchema>,
+    supergraph_schema: ValidFederationSchema,
+    api_schema: ValidFederationSchema,
     validate_extracted_subgraphs: Option<bool>,
     for_query_planning: Option<bool>,
 ) -> Result<QueryGraph, FederationError> {
@@ -213,7 +212,7 @@ struct SchemaQueryGraphBuilder {
 
 struct SchemaQueryGraphBuilderSubgraphData {
     federation_spec_definition: &'static FederationSpecDefinition,
-    api_schema: Arc<ValidFederationSchema>,
+    api_schema: ValidFederationSchema,
 }
 
 impl SchemaQueryGraphBuilder {
@@ -223,7 +222,7 @@ impl SchemaQueryGraphBuilder {
         query_graph: QueryGraph,
         source: NodeStr,
         schema: ValidFederationSchema,
-        api_schema: Option<Arc<ValidFederationSchema>>,
+        api_schema: Option<ValidFederationSchema>,
         for_query_planning: bool,
     ) -> Result<Self, FederationError> {
         let subgraph = if let Some(api_schema) = api_schema {
@@ -940,14 +939,14 @@ struct AbstractTypeWithRuntimeTypes {
 
 struct FederatedQueryGraphBuilder {
     base: BaseQueryGraphBuilder,
-    supergraph_schema: Arc<ValidFederationSchema>,
+    supergraph_schema: ValidFederationSchema,
     subgraphs: FederatedQueryGraphBuilderSubgraphs,
 }
 
 impl FederatedQueryGraphBuilder {
     fn new(
         query_graph: QueryGraph,
-        supergraph_schema: Arc<ValidFederationSchema>,
+        supergraph_schema: ValidFederationSchema,
     ) -> Result<Self, FederationError> {
         let base = BaseQueryGraphBuilder::new(
             query_graph,

--- a/src/query_graph/extract_subgraphs_from_supergraph.rs
+++ b/src/query_graph/extract_subgraphs_from_supergraph.rs
@@ -32,6 +32,7 @@ use indexmap::{IndexMap, IndexSet};
 use lazy_static::lazy_static;
 use std::collections::BTreeMap;
 use std::ops::Deref;
+use std::sync::Arc;
 
 /// Assumes the given schema has been validated.
 ///
@@ -109,7 +110,7 @@ pub(super) fn extract_subgraphs_from_supergraph(
                 }
             }
         } else {
-            ValidFederationSchema(Valid::assume_valid(subgraph.schema))
+            ValidFederationSchema(Arc::new(Valid::assume_valid(subgraph.schema)))
         };
         valid_subgraphs.add(ValidFederationSubgraph {
             name: subgraph.name,

--- a/src/query_plan/query_planner.rs
+++ b/src/query_plan/query_planner.rs
@@ -115,8 +115,8 @@ impl Default for QueryPlannerDebugConfig {
 pub struct QueryPlanner {
     config: Arc<QueryPlannerConfig>,
     federated_query_graph: Arc<QueryGraph>,
-    supergraph_schema: Arc<ValidFederationSchema>,
-    api_schema: Arc<ValidFederationSchema>,
+    supergraph_schema: ValidFederationSchema,
+    api_schema: ValidFederationSchema,
     subgraph_federation_spec_definitions: IndexMap<NodeStr, &'static FederationSpecDefinition>,
     /// A set of the names of interface types for which at least one subgraph use an
     /// @interfaceObject to abstract that interface.


### PR DESCRIPTION
This PR makes the following adjustments:
-  Changes`ValidFederationSchema` to use `Arc`, and specify equality via `Arc.ptr_eq()` (as the JS code defines schemas as equal if they reference the same object, and in our case post-validation the `FederationSchema` won't change). This should avoid having to custom-define equality in some places that previously used `Arc<ValidFederationSchema>`.
- Renames the selection types `NormalizedField`, `NormalizedFragmentSpread`, and `NormalizedInlineFragment` to additionally have the suffix `Selection` (e.g. `NormalizedFieldSelection`).
- Pulls the non-selection-set data out of `NormalizedFieldSelection` and `NormalizedInlineFragmentSelection` into `NormalizedField` and `NormalizedInlineFragment` (this mimics the JS's naming convention). These will be used in operation paths and graph paths.
- Updates the operation types to have `ValidFederationSchema`, as equality checks/validations will often want to know whether two operation types are based on the same schema.
- Updates the operation types to use `federation-next` positions instead of `apollo-compiler` types (since e.g. positions convey parent information and type kinds).
- Changes `NormalizedFieldSelection` to have an optional selection set, conditioned on whether the field's type is a composite type (currently `apollo-compiler` fields always have selection sets, but they're empty when the field's type is non-composite).
- Changes `Node` usages to `Arc`, since we're not actually setting/getting the location information in those `Node`s (and trying to do so feels dubious, since they wouldn't reflect the operation as it changes over time).
- Uses `Arc` to wrap some collection types, to reduce the expense of cloning.
- Splits the merging and normalization code to be methods on selections and selection sets.
- Changes the merging code to merge lists of items instead of two items at a time, which aligns with the JS code a bit more (we also merge into `self` now, and try to unwrap `Arc`s if they're the sole strong reference). The intention here is to reduce the amount we create and throw away temporary data structures.
- Updates the hoisting/collapsing logic to work for nested cases.
- Changes `From` implementations to use `&Foo` instead of `&Node<Foo>`, as the latter can always be `deref`ed into the former.
- Adjusts/Adds some doc strings.