### PR TITLE
Tests for removing items and their references

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ derive_more = "0.99.17"
 indexmap = "2.1.0"
 lazy_static = "1.4.0"
 linked-hash-map = "0.5.6"
+log = "0.4.20"
 petgraph = "0.6.4"
 salsa = "0.16.1"
 serde_json = "1.0.108"
@@ -24,6 +25,7 @@ thiserror = "1.0"
 url = "2"
 
 [dev-dependencies]
+env_logger = "0.10.1"
 insta = { version = "1.34.0", features = ["yaml"] }
 
 [[test]]

--- a/src/schema/position.rs
+++ b/src/schema/position.rs
@@ -767,6 +767,7 @@ impl SchemaRootDefinitionPosition {
     }
 
     pub(crate) fn remove(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
+        log::debug!("remove root definition {self}");
         let Some(root_type) = self.try_get(&schema.schema) else {
             return Ok(());
         };
@@ -984,6 +985,7 @@ impl ScalarTypeDefinitionPosition {
         &self,
         schema: &mut FederationSchema,
     ) -> Result<Option<ScalarTypeReferencers>, FederationError> {
+        log::debug!("remove scalar {self}");
         let Some(referencers) = self.remove_internal(schema)? else {
             return Ok(None);
         };
@@ -1332,6 +1334,7 @@ impl ObjectTypeDefinitionPosition {
         &self,
         schema: &mut FederationSchema,
     ) -> Result<Option<ObjectTypeReferencers>, FederationError> {
+        log::debug!("remove object {self}");
         let Some(referencers) = self.remove_internal(schema)? else {
             return Ok(None);
         };
@@ -1784,6 +1787,7 @@ impl ObjectFieldDefinitionPosition {
     }
 
     pub(crate) fn remove(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
+        log::debug!("remove field {self}");
         let Some(field) = self.try_get(&schema.schema) else {
             return Ok(());
         };
@@ -1796,6 +1800,7 @@ impl ObjectFieldDefinitionPosition {
         Ok(())
     }
 
+    /// Removes this field and also the whole object type if it has no fields left.
     pub(crate) fn remove_recursive(
         &self,
         schema: &mut FederationSchema,
@@ -2223,6 +2228,7 @@ impl ObjectFieldArgumentDefinitionPosition {
     }
 
     pub(crate) fn remove(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
+        log::debug!("remove field argument {self}");
         let Some(argument) = self.try_get(&schema.schema) else {
             return Ok(());
         };
@@ -2638,6 +2644,7 @@ impl InterfaceTypeDefinitionPosition {
         &self,
         schema: &mut FederationSchema,
     ) -> Result<Option<InterfaceTypeReferencers>, FederationError> {
+        log::debug!("remove interface {self}");
         let Some(referencers) = self.remove_internal(schema)? else {
             return Ok(None);
         };
@@ -3024,6 +3031,7 @@ impl InterfaceFieldDefinitionPosition {
     }
 
     pub(crate) fn remove(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
+        log::debug!("remove interface field {self}");
         let Some(field) = self.try_get(&schema.schema) else {
             return Ok(());
         };
@@ -3036,6 +3044,7 @@ impl InterfaceFieldDefinitionPosition {
         Ok(())
     }
 
+    /// Removes this field and also the whole interface if it has no fields left.
     pub(crate) fn remove_recursive(
         &self,
         schema: &mut FederationSchema,
@@ -3467,6 +3476,7 @@ impl InterfaceFieldArgumentDefinitionPosition {
     }
 
     pub(crate) fn remove(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
+        log::debug!("remove interface field argument {self}");
         let Some(argument) = self.try_get(&schema.schema) else {
             return Ok(());
         };
@@ -4010,6 +4020,7 @@ impl UnionTypeDefinitionPosition {
             .retain(|other_type| !name.equivalent(other_type.deref()));
     }
 
+    /// Removes a member and also this whole union type if it has no members left.
     pub(crate) fn remove_member_recursive<Q: Hash + Equivalent<Name>>(
         &self,
         schema: &mut FederationSchema,
@@ -4639,6 +4650,7 @@ impl EnumValueDefinitionPosition {
     }
 
     pub(crate) fn remove(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
+        log::debug!("remove enum value {self}");
         let Some(value) = self.try_get(&schema.schema) else {
             return Ok(());
         };
@@ -4651,6 +4663,7 @@ impl EnumValueDefinitionPosition {
         Ok(())
     }
 
+    /// Removes this value and also the whole enum if it has no values left.
     pub(crate) fn remove_recursive(
         &self,
         schema: &mut FederationSchema,
@@ -5232,6 +5245,7 @@ impl InputObjectFieldDefinitionPosition {
     }
 
     pub(crate) fn remove(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
+        log::debug!("remove input object field {self}");
         let Some(field) = self.try_get(&schema.schema) else {
             return Ok(());
         };
@@ -5641,6 +5655,7 @@ impl DirectiveDefinitionPosition {
         &self,
         schema: &mut FederationSchema,
     ) -> Result<Option<DirectiveReferencers>, FederationError> {
+        log::debug!("remove directive {self}");
         let Some(referencers) = self.remove_internal(schema)? else {
             return Ok(None);
         };
@@ -5860,6 +5875,7 @@ impl DirectiveArgumentDefinitionPosition {
     }
 
     pub(crate) fn remove(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
+        log::debug!("remove directive argument {self}");
         let Some(argument) = self.try_get(&schema.schema) else {
             return Ok(());
         };

--- a/src/schema/snapshots/apollo_federation__schema__position__tests__remove_directive_from_field.snap
+++ b/src/schema/snapshots/apollo_federation__schema__position__tests__remove_directive_from_field.snap
@@ -1,0 +1,30 @@
+---
+source: src/schema/position.rs
+expression: schema.schema
+---
+directive @applied on SCALAR | ENUM
+
+type Query {
+  object: ObjectType
+  enum: EnumType
+  scalar: ScalarType
+  arguments(enum: EnumType, scalar: ScalarType): ObjectType
+}
+
+enum EnumType @applied {
+  VALUE1
+  VALUE2
+}
+
+scalar ScalarType @applied
+
+type ObjectType {
+  returnEnum(inputScalar: ScalarType): EnumType
+  returnScalar(inputEnum: EnumType): ScalarType
+}
+
+input InputObjectType {
+  enum: EnumType
+  scalar: ScalarType
+}
+

--- a/src/schema/snapshots/apollo_federation__schema__position__tests__remove_directive_from_type.snap
+++ b/src/schema/snapshots/apollo_federation__schema__position__tests__remove_directive_from_type.snap
@@ -1,0 +1,30 @@
+---
+source: src/schema/position.rs
+expression: schema.schema
+---
+directive @directiveName(enum: EnumType, scalar: ScalarType) on FIELD_DEFINITION
+
+type Query {
+  object: ObjectType @directiveName(enum: VALUE1)
+  enum: EnumType @directiveName(scalar: 1)
+  scalar: ScalarType
+  arguments(enum: EnumType, scalar: ScalarType): ObjectType
+}
+
+enum EnumType {
+  VALUE1
+  VALUE2
+}
+
+scalar ScalarType
+
+type ObjectType {
+  returnEnum(inputScalar: ScalarType): EnumType
+  returnScalar(inputEnum: EnumType): ScalarType
+}
+
+input InputObjectType {
+  enum: EnumType
+  scalar: ScalarType
+}
+

--- a/src/schema/snapshots/apollo_federation__schema__position__tests__remove_enums.snap
+++ b/src/schema/snapshots/apollo_federation__schema__position__tests__remove_enums.snap
@@ -1,0 +1,24 @@
+---
+source: src/schema/position.rs
+expression: schema.schema
+---
+directive @directiveName(scalar: ScalarType) on FIELD_DEFINITION
+
+directive @applied on SCALAR | ENUM
+
+type Query {
+  object: ObjectType
+  arguments(scalar: ScalarType): ObjectType
+  scalar: ScalarType
+}
+
+input InputObjectType {
+  scalar: ScalarType
+}
+
+scalar ScalarType @applied
+
+type ObjectType {
+  returnScalar: ScalarType
+}
+

--- a/src/schema/snapshots/apollo_federation__schema__position__tests__remove_types.snap
+++ b/src/schema/snapshots/apollo_federation__schema__position__tests__remove_types.snap
@@ -1,0 +1,25 @@
+---
+source: src/schema/position.rs
+expression: schema.schema
+---
+directive @directiveName(enum: EnumType, scalar: ScalarType) on FIELD_DEFINITION
+
+directive @applied on SCALAR | ENUM
+
+type Query {
+  scalar: ScalarType
+  enum: EnumType @directiveName(scalar: 1)
+}
+
+enum EnumType @applied {
+  VALUE1
+  VALUE2
+}
+
+scalar ScalarType @applied
+
+input InputObjectType {
+  enum: EnumType
+  scalar: ScalarType
+}
+


### PR DESCRIPTION
This is a draft as it needs some thought about `remove()` vs. `remove_recursive()` and what they should really do.

The key change here is that references to an item are removed *before* any item is removed. That's necessary because while removing references, sometimes the item is looked up.

There may be an alternative way to do this, where reference removal doesn't require ever looking up the original item, so that ordering wouldn't matter. I'll look at that as well. It would probably be less brittle than this solution.