### PR TITLE
chore: a few minor fixes / improvements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,14 +43,10 @@ impl Supergraph {
 
         // remove known internal types
         api_schema.types.retain(|type_name, graphql_type| {
-            !is_join_type(type_name.as_str())
-                && !graphql_type
-                    .directives()
-                    .iter()
-                    .any(|d| d.name == "inaccessible")
+            !is_join_type(type_name.as_str()) && !graphql_type.directives().has("inaccessible")
         });
         // remove directive applications
-        for (_, graphql_type) in api_schema.types.iter_mut() {
+        for graphql_type in api_schema.types.values_mut() {
             match graphql_type {
                 ExtendedType::Scalar(scalar) => {
                     scalar.make_mut().directives.clear();
@@ -134,7 +130,7 @@ fn is_join_type(type_name: &str) -> bool {
 }
 
 fn is_inaccessible_applied(directives: &DirectiveList) -> bool {
-    directives.iter().any(|d| d.name == "inaccessible")
+    directives.has("inaccessible")
 }
 
 #[cfg(test)]

--- a/src/link/federation_spec_definition.rs
+++ b/src/link/federation_spec_definition.rs
@@ -3,7 +3,7 @@ use crate::link::argument::{
     directive_optional_boolean_argument, directive_required_fieldset_argument,
 };
 use crate::link::spec::{Identity, Url, Version};
-use crate::link::spec_definition::{spec_definitions, SpecDefinition, SpecDefinitions};
+use crate::link::spec_definition::{SpecDefinition, SpecDefinitions};
 use crate::schema::FederationSchema;
 use apollo_compiler::ast::Argument;
 use apollo_compiler::schema::{
@@ -11,7 +11,6 @@ use apollo_compiler::schema::{
 };
 use apollo_compiler::{name, Node, NodeStr};
 use lazy_static::lazy_static;
-use std::ops::Deref;
 
 pub(crate) const FEDERATION_ENTITY_TYPE_NAME_IN_SPEC: Name = name!("_Entity");
 pub(crate) const FEDERATION_KEY_DIRECTIVE_NAME_IN_SPEC: Name = name!("key");
@@ -354,33 +353,33 @@ impl SpecDefinition for FederationSpecDefinition {
 }
 
 lazy_static! {
-    pub(crate) static ref FEDERATION_VERSIONS: Result<SpecDefinitions<FederationSpecDefinition>, FederationError> = {
+    pub(crate) static ref FEDERATION_VERSIONS: SpecDefinitions<FederationSpecDefinition> = {
         let mut definitions = SpecDefinitions::new(Identity::federation_identity());
         definitions.add(FederationSpecDefinition::new(Version {
             major: 2,
             minor: 0,
-        }))?;
+        }));
         definitions.add(FederationSpecDefinition::new(Version {
             major: 2,
             minor: 1,
-        }))?;
+        }));
         definitions.add(FederationSpecDefinition::new(Version {
             major: 2,
             minor: 2,
-        }))?;
+        }));
         definitions.add(FederationSpecDefinition::new(Version {
             major: 2,
             minor: 3,
-        }))?;
+        }));
         definitions.add(FederationSpecDefinition::new(Version {
             major: 2,
             minor: 4,
-        }))?;
+        }));
         definitions.add(FederationSpecDefinition::new(Version {
             major: 2,
             minor: 5,
-        }))?;
-        Ok(definitions)
+        }));
+        definitions
     };
 }
 
@@ -394,7 +393,7 @@ pub(crate) fn get_federation_spec_definition_from_subgraph(
         .ok_or_else(|| SingleFederationError::Internal {
             message: "Subgraph unexpectedly does not use federation spec".to_owned(),
         })?;
-    Ok(spec_definitions(FEDERATION_VERSIONS.deref())?
+    Ok(FEDERATION_VERSIONS
         .find(&federation_link.url.version)
         .ok_or_else(|| SingleFederationError::Internal {
             message: "Subgraph unexpectedly does not use a supported federation spec version"

--- a/src/link/join_spec_definition.rs
+++ b/src/link/join_spec_definition.rs
@@ -309,24 +309,24 @@ impl SpecDefinition for JoinSpecDefinition {
 }
 
 lazy_static! {
-    pub(crate) static ref JOIN_VERSIONS: Result<SpecDefinitions<JoinSpecDefinition>, FederationError> = {
+    pub(crate) static ref JOIN_VERSIONS: SpecDefinitions<JoinSpecDefinition> = {
         let mut definitions = SpecDefinitions::new(Identity::join_identity());
         definitions.add(JoinSpecDefinition::new(
             Version { major: 0, minor: 1 },
             None,
-        ))?;
+        ));
         definitions.add(JoinSpecDefinition::new(
             Version { major: 0, minor: 2 },
             None,
-        ))?;
+        ));
         definitions.add(JoinSpecDefinition::new(
             Version { major: 0, minor: 3 },
             None,
-        ))?;
+        ));
         definitions.add(JoinSpecDefinition::new(
             Version { major: 0, minor: 1 },
             Some(Version { major: 2, minor: 0 }),
-        ))?;
-        Ok(definitions)
+        ));
+        definitions
     };
 }

--- a/src/link/link_spec_definition.rs
+++ b/src/link/link_spec_definition.rs
@@ -1,4 +1,3 @@
-use crate::error::FederationError;
 use crate::link::spec::{Identity, Url, Version};
 use crate::link::spec_definition::{SpecDefinition, SpecDefinitions};
 use lazy_static::lazy_static;
@@ -32,27 +31,27 @@ impl SpecDefinition for LinkSpecDefinition {
 }
 
 lazy_static! {
-    pub(crate) static ref CORE_VERSIONS: Result<SpecDefinitions<LinkSpecDefinition>, FederationError> = {
+    pub(crate) static ref CORE_VERSIONS: SpecDefinitions<LinkSpecDefinition> = {
         let mut definitions = SpecDefinitions::new(Identity::core_identity());
         definitions.add(LinkSpecDefinition::new(
             Version { major: 0, minor: 1 },
             None,
             Identity::core_identity(),
-        ))?;
+        ));
         definitions.add(LinkSpecDefinition::new(
             Version { major: 0, minor: 2 },
             Some(Version { major: 2, minor: 0 }),
             Identity::core_identity(),
-        ))?;
-        Ok(definitions)
+        ));
+        definitions
     };
-    pub(crate) static ref LINK_VERSIONS: Result<SpecDefinitions<LinkSpecDefinition>, FederationError> = {
+    pub(crate) static ref LINK_VERSIONS: SpecDefinitions<LinkSpecDefinition> = {
         let mut definitions = SpecDefinitions::new(Identity::link_identity());
         definitions.add(LinkSpecDefinition::new(
             Version { major: 1, minor: 0 },
             Some(Version { major: 2, minor: 0 }),
             Identity::link_identity(),
-        ))?;
-        Ok(definitions)
+        ));
+        definitions
     };
 }

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -2,12 +2,10 @@ use crate::error::{FederationError, SingleFederationError};
 use crate::link::link_spec_definition::{LinkSpecDefinition, CORE_VERSIONS, LINK_VERSIONS};
 use crate::link::spec::Identity;
 use crate::link::spec::Url;
-use crate::link::spec_definition::spec_definitions;
 use apollo_compiler::ast::{Directive, InvalidNameError, Value};
 use apollo_compiler::schema::Name;
 use apollo_compiler::{name, Node, NodeStr};
 use std::fmt;
-use std::ops::Deref;
 use std::str;
 use std::{collections::HashMap, sync::Arc};
 use thiserror::Error;
@@ -347,23 +345,19 @@ impl LinksMetadata {
         &self,
     ) -> Result<&'static LinkSpecDefinition, FederationError> {
         if let Some(link_link) = self.for_identity(&Identity::link_identity()) {
-            spec_definitions(LINK_VERSIONS.deref())?
-                .find(&link_link.url.version)
-                .ok_or_else(|| {
-                    SingleFederationError::Internal {
-                        message: format!("Unexpected link spec version {}", link_link.url.version),
-                    }
-                    .into()
-                })
+            LINK_VERSIONS.find(&link_link.url.version).ok_or_else(|| {
+                SingleFederationError::Internal {
+                    message: format!("Unexpected link spec version {}", link_link.url.version),
+                }
+                .into()
+            })
         } else if let Some(core_link) = self.for_identity(&Identity::core_identity()) {
-            spec_definitions(CORE_VERSIONS.deref())?
-                .find(&core_link.url.version)
-                .ok_or_else(|| {
-                    SingleFederationError::Internal {
-                        message: format!("Unexpected core spec version {}", core_link.url.version),
-                    }
-                    .into()
-                })
+            CORE_VERSIONS.find(&core_link.url.version).ok_or_else(|| {
+                SingleFederationError::Internal {
+                    message: format!("Unexpected core spec version {}", core_link.url.version),
+                }
+                .into()
+            })
         } else {
             Err(SingleFederationError::Internal {
                 message: "Unexpectedly could not find core/link spec".to_owned(),

--- a/src/link/spec_definition.rs
+++ b/src/link/spec_definition.rs
@@ -25,7 +25,7 @@ pub(crate) trait SpecDefinition {
         schema: &FederationSchema,
         name_in_schema: &Name,
     ) -> Result<bool, FederationError> {
-        let Some(ref metadata) = schema.metadata() else {
+        let Some(metadata) = schema.metadata() else {
             return Err(SingleFederationError::Internal {
                 message: "Schema is not a core schema (add @link first)".to_owned(),
             }
@@ -42,7 +42,7 @@ pub(crate) trait SpecDefinition {
         schema: &FederationSchema,
         name_in_schema: &Name,
     ) -> Result<bool, FederationError> {
-        let Some(ref metadata) = schema.metadata() else {
+        let Some(metadata) = schema.metadata() else {
             return Err(SingleFederationError::Internal {
                 message: "Schema is not a core schema (add @link first)".to_owned(),
             }
@@ -128,7 +128,7 @@ pub(crate) trait SpecDefinition {
         &self,
         schema: &FederationSchema,
     ) -> Result<Option<Arc<Link>>, FederationError> {
-        let Some(ref metadata) = schema.metadata() else {
+        let Some(metadata) = schema.metadata() else {
             return Err(SingleFederationError::Internal {
                 message: "Schema is not a core schema (add @link first)".to_owned(),
             }

--- a/src/link/spec_definition.rs
+++ b/src/link/spec_definition.rs
@@ -155,23 +155,19 @@ impl<T: SpecDefinition> SpecDefinitions<T> {
         }
     }
 
-    pub(crate) fn add(&mut self, definition: T) -> Result<(), FederationError> {
-        if *definition.identity() != self.identity {
-            return Err(SingleFederationError::Internal {
-                message: format!(
-                    "Cannot add definition for {} to the versions of definitions for {}",
-                    definition.to_string(),
-                    self.identity
-                ),
-            }
-            .into());
-        }
+    pub(crate) fn add(&mut self, definition: T) {
+        assert_eq!(
+            *definition.identity(),
+            self.identity,
+            "Cannot add definition for {} to the versions of definitions for {}",
+            definition.to_string(),
+            self.identity
+        );
         if self.definitions.contains_key(definition.version()) {
-            return Ok(());
+            return;
         }
         self.definitions
             .insert(definition.version().clone(), definition);
-        Ok(())
     }
 
     pub(crate) fn find(&self, requested: &Version) -> Option<&T> {
@@ -180,14 +176,5 @@ impl<T: SpecDefinition> SpecDefinitions<T> {
 
     pub(crate) fn versions(&self) -> Keys<Version, T> {
         self.definitions.keys()
-    }
-}
-
-pub(crate) fn spec_definitions<T: SpecDefinition>(
-    spec_definitions: &'static Result<SpecDefinitions<T>, FederationError>,
-) -> Result<&'static SpecDefinitions<T>, FederationError> {
-    match spec_definitions {
-        Ok(spec_definitions) => Ok(spec_definitions),
-        Err(error) => Err(error.clone()),
     }
 }

--- a/src/query_graph/extract_subgraphs_from_supergraph.rs
+++ b/src/query_graph/extract_subgraphs_from_supergraph.rs
@@ -7,7 +7,7 @@ use crate::link::join_spec_definition::{
 };
 use crate::link::link_spec_definition::LinkSpecDefinition;
 use crate::link::spec::{Identity, Version};
-use crate::link::spec_definition::{spec_definitions, SpecDefinition};
+use crate::link::spec_definition::SpecDefinition;
 use crate::query_graph::field_set::parse_field_set;
 use crate::schema::position::{
     is_graphql_reserved_name, CompositeTypeDefinitionPosition, DirectiveDefinitionPosition,
@@ -140,13 +140,11 @@ fn validate_supergraph(
         }
         .into());
     };
-    let Some(join_spec_definition) =
-        spec_definitions(JOIN_VERSIONS.deref())?.find(&join_link.url.version)
-    else {
+    let Some(join_spec_definition) = JOIN_VERSIONS.find(&join_link.url.version) else {
         return Err(SingleFederationError::InvalidFederationSupergraph {
             message: format!(
                 "Invalid supergraph: uses unsupported join spec version {} (supported versions: {})",
-                spec_definitions(JOIN_VERSIONS.deref())?.versions().map( | v| v.to_string()).collect:: < Vec<String> > ().join(", "),
+                JOIN_VERSIONS.versions().map(|v| v.to_string()).collect::<Vec<_>>().join(", "),
                 join_link.url.version,
             ),
         }.into());
@@ -193,7 +191,7 @@ fn collect_empty_subgraphs(
             .ok_or_else(|| SingleFederationError::InvalidFederationSupergraph {
                 message: "Subgraph unexpectedly does not use federation spec".to_owned(),
             })?;
-        let federation_spec_definition = spec_definitions(FEDERATION_VERSIONS.deref())?
+        let federation_spec_definition = FEDERATION_VERSIONS
             .find(&federation_link.url.version)
             .ok_or_else(|| SingleFederationError::InvalidFederationSupergraph {
                 message: "Subgraph unexpectedly does not use a supported federation spec version"

--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -1044,7 +1044,7 @@ fn directives_with_sorted_arguments(directives: &DirectiveList) -> DirectiveList
 }
 
 fn is_deferred_selection(directives: &DirectiveList) -> bool {
-    directives.iter().any(|d| d.name == "defer")
+    directives.has("defer")
 }
 
 /// Normalizes the selection set of the specified operation.

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -1,9 +1,10 @@
 use crate::error::{FederationError, SingleFederationError};
 use crate::link::LinksMetadata;
 use crate::schema::position::{
-    CompositeTypeDefinitionPosition, EnumTypeDefinitionPosition, InputObjectTypeDefinitionPosition,
-    InterfaceTypeDefinitionPosition, ObjectTypeDefinitionPosition, ScalarTypeDefinitionPosition,
-    TypeDefinitionPosition, UnionTypeDefinitionPosition,
+    CompositeTypeDefinitionPosition, DirectiveDefinitionPosition, EnumTypeDefinitionPosition,
+    InputObjectTypeDefinitionPosition, InterfaceTypeDefinitionPosition,
+    ObjectTypeDefinitionPosition, ScalarTypeDefinitionPosition, TypeDefinitionPosition,
+    UnionTypeDefinitionPosition,
 };
 use apollo_compiler::schema::{ExtendedType, Name};
 use apollo_compiler::validation::Valid;
@@ -37,26 +38,31 @@ impl FederationSchema {
         &self.referencers
     }
 
-    pub(crate) fn get_types(&self) -> Vec<TypeDefinitionPosition> {
-        self.schema
-            .types
-            .iter()
-            .map(|(type_name, type_)| {
-                let type_name = type_name.clone();
-                match type_ {
-                    ExtendedType::Scalar(_) => ScalarTypeDefinitionPosition { type_name }.into(),
-                    ExtendedType::Object(_) => ObjectTypeDefinitionPosition { type_name }.into(),
-                    ExtendedType::Interface(_) => {
-                        InterfaceTypeDefinitionPosition { type_name }.into()
-                    }
-                    ExtendedType::Union(_) => UnionTypeDefinitionPosition { type_name }.into(),
-                    ExtendedType::Enum(_) => EnumTypeDefinitionPosition { type_name }.into(),
-                    ExtendedType::InputObject(_) => {
-                        InputObjectTypeDefinitionPosition { type_name }.into()
-                    }
+    pub(crate) fn get_types(&self) -> impl Iterator<Item = TypeDefinitionPosition> + '_ {
+        self.schema.types.iter().map(|(type_name, type_)| {
+            let type_name = type_name.clone();
+            match type_ {
+                ExtendedType::Scalar(_) => ScalarTypeDefinitionPosition { type_name }.into(),
+                ExtendedType::Object(_) => ObjectTypeDefinitionPosition { type_name }.into(),
+                ExtendedType::Interface(_) => InterfaceTypeDefinitionPosition { type_name }.into(),
+                ExtendedType::Union(_) => UnionTypeDefinitionPosition { type_name }.into(),
+                ExtendedType::Enum(_) => EnumTypeDefinitionPosition { type_name }.into(),
+                ExtendedType::InputObject(_) => {
+                    InputObjectTypeDefinitionPosition { type_name }.into()
                 }
+            }
+        })
+    }
+
+    pub(crate) fn get_directive_definitions(
+        &self,
+    ) -> impl Iterator<Item = DirectiveDefinitionPosition> + '_ {
+        self.schema
+            .directive_definitions
+            .keys()
+            .map(|name| DirectiveDefinitionPosition {
+                directive_name: name.clone(),
             })
-            .collect()
     }
 
     pub(crate) fn get_type(

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -30,8 +30,8 @@ impl FederationSchema {
         &self.schema
     }
 
-    pub(crate) fn metadata(&self) -> &Option<LinksMetadata> {
-        &self.metadata
+    pub(crate) fn metadata(&self) -> Option<&LinksMetadata> {
+        self.metadata.as_ref()
     }
 
     pub(crate) fn referencers(&self) -> &Referencers {

--- a/src/subgraph/mod.rs
+++ b/src/subgraph/mod.rs
@@ -312,7 +312,7 @@ pub struct ValidSubgraph {
 
 impl std::fmt::Debug for ValidSubgraph {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, r#"name: {}, urL: {}"#, self.name, self.url)
+        write!(f, r#"name: {}, url: {}"#, self.name, self.url)
     }
 }
 


### PR DESCRIPTION
This PR is a grab-bag of a few things I ran into while getting into API schema validation. I won't be able to finish that before holiday break so posting the generic changes first.

- Change uses of `directives.iter().any()` to `directives.has()`, which is a little easier: [`DirectiveList::has`](https://docs.rs/apollo-compiler/1.0.0-beta.11/apollo_compiler/ast/struct.DirectiveList.html#method.has)
- Return an `Iterator` instead of a `Vec` from `get_types()`, the user can still decide to `collect()` it into a vec if needed. Also adds a parallel `get_directive_definitions()`.
- Return `Option<&LinksMetadata>` instead of `&Option<LinksMetadata>`-- an option containing a reference is a much more useful type than a reference to an option. You basically always want to prefer an `Option<&T>` if you can.
- c5193a39afa8ddf50e0ea60577cd3bf80f5c4d32 sets source files on supergraphs when merging subgraphs; this will let diagnostics point to source code in the future
- Remove the `Result<>` wrapper around `SpecDefinitions`. `SpecDefinitions::add` now panics if you try to add a wrong version, which is correct as it's a programmer error. And it's now much easier to use the `JOIN_VERSIONS` etc. throughout the code.