### PR TITLE
chore: Apply Clippy suggestions from Rust 1.75

### DIFF
--- a/src/link/database.rs
+++ b/src/link/database.rs
@@ -200,7 +200,7 @@ mod tests {
 
         let link_spec = meta.for_identity(&Identity::link_identity()).unwrap();
         assert_eq!(
-            link_spec.imports.get(0).unwrap().as_ref(),
+            link_spec.imports.first().unwrap().as_ref(),
             &Import {
                 element: name!("Import"),
                 is_directive: false,
@@ -220,7 +220,7 @@ mod tests {
         let imports = &fed_spec.imports;
         assert_eq!(imports.len(), 2);
         assert_eq!(
-            imports.get(0).unwrap().as_ref(),
+            imports.first().unwrap().as_ref(),
             &Import {
                 element: name!("key"),
                 is_directive: true,

--- a/src/subgraph/mod.rs
+++ b/src/subgraph/mod.rs
@@ -357,7 +357,7 @@ mod tests {
         let subgraph = Subgraph::new("S1", "http://s1", schema).unwrap();
         let keys = keys(&subgraph.schema, &name!("T"));
         assert_eq!(keys.len(), 1);
-        assert_eq!(keys.get(0).unwrap().type_name, name!("T"));
+        assert_eq!(keys.first().unwrap().type_name, name!("T"));
 
         // TODO: no accessible selection yet.
     }


### PR DESCRIPTION
Clippy wants you to use `.first()` over `.get(0)`. I don't like this rule to be honest, in the places where we use it the first-ness of 0 is not meaningful. We could disable it but its not that important. This gets CI passing again