### PR TITLE
deps: update apollo-compiler to 1.0.0-beta.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Elastic-2.0"
 autotests = false                                               # Integration tests are modules of tests/main.rs
 
 [dependencies]
-apollo-compiler = "=1.0.0-beta.11"
+apollo-compiler = "=1.0.0-beta.12"
 derive_more = "0.99.17"
 indexmap = "2.1.0"
 lazy_static = "1.4.0"

--- a/src/link/argument.rs
+++ b/src/link/argument.rs
@@ -8,8 +8,8 @@ pub(crate) fn directive_optional_enum_argument(
     application: &Node<Directive>,
     name: &Name,
 ) -> Result<Option<Name>, FederationError> {
-    match application.arguments.iter().find(|a| a.name == *name) {
-        Some(a) => match a.value.deref() {
+    match application.argument_by_name(name) {
+        Some(value) => match value.deref() {
             Value::Enum(name) => Ok(Some(name.clone())),
             Value::Null => Ok(None),
             _ => Err(SingleFederationError::Internal {
@@ -43,8 +43,8 @@ pub(crate) fn directive_optional_string_argument(
     application: &Node<Directive>,
     name: &Name,
 ) -> Result<Option<NodeStr>, FederationError> {
-    match application.arguments.iter().find(|a| a.name == *name) {
-        Some(a) => match a.value.deref() {
+    match application.argument_by_name(name) {
+        Some(value) => match value.deref() {
             Value::String(name) => Ok(Some(name.clone())),
             Value::Null => Ok(None),
             _ => Err(SingleFederationError::Internal {
@@ -78,9 +78,8 @@ pub(crate) fn directive_optional_fieldset_argument(
     application: &Node<Directive>,
     name: &Name,
 ) -> Result<Option<NodeStr>, FederationError> {
-    let argument = application.arguments.iter().find(|a| a.name == *name);
-    match argument {
-        Some(argument) => match argument.value.deref() {
+    match application.argument_by_name(name) {
+        Some(value) => match value.deref() {
             Value::String(name) => Ok(Some(name.clone())),
             Value::Null => Ok(None),
             _ => Err(SingleFederationError::Internal {
@@ -111,8 +110,8 @@ pub(crate) fn directive_optional_boolean_argument(
     application: &Node<Directive>,
     name: &Name,
 ) -> Result<Option<bool>, FederationError> {
-    match application.arguments.iter().find(|a| a.name == *name) {
-        Some(a) => match a.value.deref() {
+    match application.argument_by_name(name) {
+        Some(value) => match value.deref() {
             Value::Boolean(value) => Ok(Some(*value)),
             Value::Null => Ok(None),
             _ => Err(SingleFederationError::Internal {

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -383,9 +383,8 @@ impl Merger {
                     &mut supergraph_field.make_mut().description,
                     &field.description,
                 );
-                let mut existing_args = supergraph_field.arguments.iter();
                 for arg in field.arguments.iter() {
-                    if let Some(_existing_arg) = &existing_args.find(|a| a.name == arg.name) {
+                    if let Some(_existing_arg) = supergraph_field.argument_by_name(&arg.name) {
                     } else {
                         // TODO mismatch no args
                     }


### PR DESCRIPTION
Just some papercut fixes and a way to lookup schema coordinates, which is mostly intended for tests:
```rust
assert!(coord!(Type.field).lookup_field(&schema).is_ok());
```