### PR TITLE
fix: @link compatibility with JS federation

### DIFF
--- a/src/link/database.rs
+++ b/src/link/database.rs
@@ -192,6 +192,45 @@ mod tests {
     }
 
     #[test]
+    fn url_syntax() -> Result<(), LinkError> {
+        let schema = r#"
+            extend schema
+              @link(url: "https://specs.apollo.dev/link/v1.0")
+              @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+              @link(url: "https://example.com/my-directive/v1.0", import: ["@myDirective"])
+
+          type Query { x: Int }
+
+            directive @myDirective on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+
+            directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+            directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+            directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+            directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+            directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+            directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+            directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+        "#;
+
+        let schema = Schema::parse(schema, "url_dash.graphqls").unwrap();
+
+        let meta = links_metadata(&schema)?;
+        let meta = meta.expect("should have metadata");
+
+        assert!(meta
+            .source_link_of_directive(&name!("myDirective"))
+            .is_some());
+
+        Ok(())
+    }
+
+    #[test]
     fn computes_link_metadata() {
         let schema = r#"
           extend schema

--- a/src/link/spec.rs
+++ b/src/link/spec.rs
@@ -205,13 +205,12 @@ impl str::FromStr for Url {
                     .ok_or(SpecError::ParseError(
                         "invalid `@link` specification url: missing specification name".to_string(),
                     ))
-                    .and_then(|segment| {
-                        Name::new(segment).map_err(|err| {
-                            SpecError::ParseError(format!(
-                                "invalid `@link` specification url: {err}"
-                            ))
-                        })
-                    })?;
+                    // Note this is SUPER wrong, but the JS federation implementation didn't check
+                    // if the name was valid, and customers are actively using URLs with for example dashes.
+                    // So we pretend that it's fine. You can't reference an imported element by the
+                    // namespaced name because it's not valid GraphQL to do so--but you can
+                    // explicitly import elements from a spec with an invalid name.
+                    .map(|segment| Name::new_unchecked(segment.into()))?;
                 let scheme = url.scheme();
                 if !scheme.starts_with("http") {
                     return Err(SpecError::ParseError("invalid `@link` specification url: only http(s) urls are supported currently".to_string()));


### PR DESCRIPTION
Fixes two compatibility issues with our `@link` parsing found in customer schemas:
* explicit import of a root directive `@link(url: "https://example.com/myDirective", import: ["@myDirective"])` was treated as a conflict between the explicit and implicit import of `@myDirective`, changing it to only be a conflict if the explicit and implicit import came from *different* `@link`s
* linking a spec with an invalid GraphQL name, `@link(url: "https://example.com/spec-name", import: ["@directive"])`. According to the `@link` spec names must be valid GraphQL but the federation JS code does not check this and schemas exist in the wild that do this. namespacing doesn’t work with invalid names, but explicitly importing elements does, so I’m changing the Rust code to accept invalid names as well (currently with `Name::new_unchecked`, the more correct solution would be to make `name` optional, but then we have to handle this edge case everywhere… another possibility is to transform the name and make it valid somehow)