### PR TITLE
[operation normalization] return NormalizedOperation and normalize Fragment

### DIFF
--- a/src/query_graph/field_set.rs
+++ b/src/query_graph/field_set.rs
@@ -26,6 +26,7 @@ pub(super) fn parse_field_set(
         &field_set.selection_set,
         &IndexMap::new(),
         schema,
+        true,
     )
 }
 

--- a/src/query_graph/field_set.rs
+++ b/src/query_graph/field_set.rs
@@ -1,5 +1,5 @@
 use crate::error::FederationError;
-use crate::query_plan::operation::NormalizedSelectionSet;
+use crate::query_plan::operation::{FragmentSpreadNormalizationOption, NormalizedSelectionSet};
 use crate::schema::ValidFederationSchema;
 use apollo_compiler::executable::{FieldSet, SelectionSet};
 use apollo_compiler::schema::NamedType;
@@ -26,7 +26,7 @@ pub(super) fn parse_field_set(
         &field_set.selection_set,
         &IndexMap::new(),
         schema,
-        true,
+        &FragmentSpreadNormalizationOption::InlineFragmentSpread,
     )
 }
 

--- a/src/query_graph/field_set.rs
+++ b/src/query_graph/field_set.rs
@@ -26,7 +26,7 @@ pub(super) fn parse_field_set(
         &field_set.selection_set,
         &IndexMap::new(),
         schema,
-        &FragmentSpreadNormalizationOption::InlineFragmentSpread,
+        FragmentSpreadNormalizationOption::InlineFragmentSpread,
     )
 }
 

--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -494,7 +494,7 @@ impl NormalizedFragment {
                 &fragment.selection_set,
                 &IndexMap::new(),
                 schema,
-                &FragmentSpreadNormalizationOption::PreserveFragmentSpread,
+                FragmentSpreadNormalizationOption::PreserveFragmentSpread,
             )?,
         })
     }
@@ -748,6 +748,7 @@ pub(crate) mod normalized_inline_fragment_selection {
 }
 
 /// Available fragment spread normalization options
+#[derive(Copy, Clone)]
 pub(crate) enum FragmentSpreadNormalizationOption {
     InlineFragmentSpread,
     PreserveFragmentSpread,
@@ -800,7 +801,7 @@ impl NormalizedSelectionSet {
         selection_set: &SelectionSet,
         fragments: &IndexMap<Name, Node<Fragment>>,
         schema: &ValidFederationSchema,
-        normalize_fragment_spread_option: &FragmentSpreadNormalizationOption,
+        normalize_fragment_spread_option: FragmentSpreadNormalizationOption,
     ) -> Result<NormalizedSelectionSet, FederationError> {
         let type_position: CompositeTypeDefinitionPosition =
             schema.get_type(selection_set.ty.clone())?.try_into()?;
@@ -829,7 +830,7 @@ impl NormalizedSelectionSet {
         destination: &mut Vec<NormalizedSelection>,
         fragments: &IndexMap<Name, Node<Fragment>>,
         schema: &ValidFederationSchema,
-        normalize_fragment_spread_option: &FragmentSpreadNormalizationOption,
+        normalize_fragment_spread_option: FragmentSpreadNormalizationOption,
     ) -> Result<(), FederationError> {
         for selection in selections {
             match selection {
@@ -1240,7 +1241,7 @@ impl NormalizedFieldSelection {
         parent_type_position: &CompositeTypeDefinitionPosition,
         fragments: &IndexMap<Name, Node<Fragment>>,
         schema: &ValidFederationSchema,
-        normalize_fragment_spread_option: &FragmentSpreadNormalizationOption,
+        normalize_fragment_spread_option: FragmentSpreadNormalizationOption,
     ) -> Result<Option<NormalizedFieldSelection>, FederationError> {
         // Skip __schema/__type introspection fields as router takes care of those, and they do not
         // need to be query planned.
@@ -1372,7 +1373,7 @@ impl NormalizedFragmentSpreadSelection {
         parent_type_position: &CompositeTypeDefinitionPosition,
         fragments: &IndexMap<Name, Node<Fragment>>,
         schema: &ValidFederationSchema,
-        normalize_fragment_spread_option: &FragmentSpreadNormalizationOption,
+        normalize_fragment_spread_option: FragmentSpreadNormalizationOption,
     ) -> Result<NormalizedInlineFragmentSelection, FederationError> {
         let Some(fragment) = fragments.get(&fragment_spread.fragment_name) else {
             return Err(Internal {
@@ -1458,7 +1459,7 @@ impl NormalizedInlineFragmentSelection {
         parent_type_position: &CompositeTypeDefinitionPosition,
         fragments: &IndexMap<Name, Node<Fragment>>,
         schema: &ValidFederationSchema,
-        normalize_fragment_spread_option: &FragmentSpreadNormalizationOption,
+        normalize_fragment_spread_option: FragmentSpreadNormalizationOption,
     ) -> Result<NormalizedInlineFragmentSelection, FederationError> {
         let type_condition_position: Option<CompositeTypeDefinitionPosition> =
             if let Some(type_condition) = &inline_fragment.type_condition {
@@ -1784,7 +1785,7 @@ pub(crate) fn normalize_operation(
         &operation.selection_set,
         fragments,
         schema,
-        &FragmentSpreadNormalizationOption::InlineFragmentSpread,
+        FragmentSpreadNormalizationOption::InlineFragmentSpread,
     )?;
     normalized_selection_set.optimize_sibling_typenames(interface_types_with_interface_objects)?;
 

--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -1554,11 +1554,7 @@ impl TryFrom<&NormalizedOperation> for Operation {
     type Error = FederationError;
 
     fn try_from(normalized_operation: &NormalizedOperation) -> Result<Self, Self::Error> {
-        let operation_type = match normalized_operation.root_kind {
-            SchemaRootDefinitionKind::Query => OperationType::Query,
-            SchemaRootDefinitionKind::Mutation => OperationType::Mutation,
-            SchemaRootDefinitionKind::Subscription => OperationType::Subscription,
-        };
+        let operation_type: OperationType = normalized_operation.root_kind.into();
         Ok(Self {
             operation_type,
             name: normalized_operation.name.clone(),


### PR DESCRIPTION
`normalize_operation` now returns `NormalizedOperation`.

By default, when normalizing selection sets, we auto expand and inline fragment spreads. In order to be able to rebase fragments we need to normalize their selection sets without inlining other fragments. Updated method to accept explicit `FragmentSpreadNormalizationOption` enum option to indicate whether to inline spreads or preserve them (it is the same logic except for handling fragment spreads).