### PR TITLE
feat: add options to insert `@defer`, `@stream` in API schema

### DIFF
--- a/examples/api_schema.rs
+++ b/examples/api_schema.rs
@@ -13,7 +13,7 @@ fn main() -> ExitCode {
     let schema = Schema::parse_and_validate(source, name).unwrap();
     let supergraph = Supergraph::from(schema);
 
-    match supergraph.to_api_schema() {
+    match supergraph.to_api_schema(Default::default()) {
         Ok(result) => println!("{result}"),
         Err(error) => {
             eprintln!("{error}");

--- a/src/api_schema.rs
+++ b/src/api_schema.rs
@@ -5,7 +5,12 @@ use crate::link::inaccessible_spec_definition::validate_inaccessible;
 use crate::schema::position;
 use crate::schema::FederationSchema;
 use apollo_compiler::name;
+use apollo_compiler::schema::DirectiveDefinition;
+use apollo_compiler::schema::DirectiveLocation;
+use apollo_compiler::schema::InputValueDefinition;
+use apollo_compiler::ty;
 use apollo_compiler::validation::Valid;
+use apollo_compiler::Node;
 use apollo_compiler::Schema;
 
 /// Remove types and directives imported by `@link`.
@@ -112,7 +117,16 @@ fn remove_core_feature_elements(schema: &mut FederationSchema) -> Result<(), Fed
     Ok(())
 }
 
-pub fn to_api_schema(schema: FederationSchema) -> Result<Valid<Schema>, FederationError> {
+#[derive(Debug, Default, Clone)]
+pub struct ApiSchemaOptions {
+    pub include_defer: bool,
+    pub include_stream: bool,
+}
+
+pub fn to_api_schema(
+    schema: FederationSchema,
+    options: ApiSchemaOptions,
+) -> Result<Valid<Schema>, FederationError> {
     let mut api_schema = schema;
 
     // As we compute the API schema of a supergraph, we want to ignore explicit definitions of `@defer` and `@stream` because
@@ -131,7 +145,98 @@ pub fn to_api_schema(schema: FederationSchema) -> Result<Valid<Schema>, Federati
     remove_core_feature_elements(&mut api_schema)?;
 
     let mut api_schema = api_schema.into_inner();
+
+    if options.include_defer {
+        api_schema
+            .directive_definitions
+            .insert(name!("defer"), defer_definition());
+    }
+
+    if options.include_stream {
+        api_schema
+            .directive_definitions
+            .insert(name!("stream"), stream_definition());
+    }
+
     crate::compat::make_print_schema_compatible(&mut api_schema);
 
     Ok(api_schema.validate()?)
+}
+
+fn defer_definition() -> Node<DirectiveDefinition> {
+    Node::new(DirectiveDefinition {
+        description: Some(
+            r#"
+The `@defer` directive may be provided for fragment spreads and inline fragments
+to inform the executor to delay the execution of the current fragment to
+indicate deprioritization of the current fragment. A query with `@defer`
+directive will cause the request to potentially return multiple responses, where
+non-deferred data is delivered in the initial response and data deferred is
+delivered in a subsequent response. `@include` and `@skip` take precedence over
+`@defer`.
+        "#
+            .trim()
+            .into(),
+        ),
+        name: name!("defer"),
+        arguments: vec![
+            Node::new(InputValueDefinition {
+                description: None,
+                name: name!("label"),
+                ty: ty!(String).into(),
+                default_value: None,
+                directives: Default::default(),
+            }),
+            Node::new(InputValueDefinition {
+                description: None,
+                name: name!("if"),
+                ty: ty!(Boolean!).into(),
+                default_value: Some(true.into()),
+                directives: Default::default(),
+            }),
+        ],
+        repeatable: false,
+        locations: vec![DirectiveLocation::Field],
+    })
+}
+
+fn stream_definition() -> Node<DirectiveDefinition> {
+    Node::new(DirectiveDefinition {
+        description: Some(
+            r#"
+The `@stream` directive may be provided for a field of `List` type so that the
+backend can leverage technology such as asynchronous iterators to provide a
+partial list in the initial response, and additional list items in subsequent
+responses. `@include` and `@skip` take precedence over `@stream`.
+        "#
+            .trim()
+            .into(),
+        ),
+        name: name!("stream"),
+        arguments: vec![
+            Node::new(InputValueDefinition {
+                description: None,
+                name: name!("label"),
+                ty: ty!(String).into(),
+                default_value: None,
+                directives: Default::default(),
+            }),
+            Node::new(InputValueDefinition {
+                description: None,
+                name: name!("if"),
+                ty: ty!(Boolean!).into(),
+                default_value: Some(true.into()),
+                directives: Default::default(),
+            }),
+            Node::new(InputValueDefinition {
+                description: None,
+                name: name!("initialCount"),
+                ty: ty!(Int).into(),
+                default_value: Some(0.into()),
+                directives: Default::default(),
+            }),
+        ],
+        repeatable: false,
+        locations: vec![DirectiveLocation::Field],
+    })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ pub mod query_plan;
 pub mod schema;
 pub mod subgraph;
 
+pub use api_schema::ApiSchemaOptions;
+
 pub struct Supergraph {
     pub schema: Valid<Schema>,
 }
@@ -37,9 +39,12 @@ impl Supergraph {
 
     /// Generates an API Schema from this supergraph schema. The API Schema represents the combined
     /// API of the supergraph that's visible to end users.
-    pub fn to_api_schema(&self) -> Result<Valid<Schema>, FederationError> {
+    pub fn to_api_schema(
+        &self,
+        options: ApiSchemaOptions,
+    ) -> Result<Valid<Schema>, FederationError> {
         let api_schema = FederationSchema::new(self.schema.clone().into_inner())?;
-        api_schema::to_api_schema(api_schema)
+        api_schema::to_api_schema(api_schema, options)
     }
 }
 

--- a/tests/composition_tests.rs
+++ b/tests/composition_tests.rs
@@ -51,7 +51,9 @@ fn can_compose_supergraph() {
 
     let supergraph = Supergraph::compose(vec![&s1, &s2]).unwrap();
     insta::assert_snapshot!(print_sdl(&supergraph.schema));
-    insta::assert_snapshot!(print_sdl(&supergraph.to_api_schema().unwrap()));
+    insta::assert_snapshot!(print_sdl(
+        &supergraph.to_api_schema(Default::default()).unwrap()
+    ));
 }
 
 #[test]
@@ -103,7 +105,9 @@ fn can_compose_with_descriptions() {
 
     let supergraph = Supergraph::compose(vec![&s1, &s2]).unwrap();
     insta::assert_snapshot!(print_sdl(&supergraph.schema));
-    insta::assert_snapshot!(print_sdl(&supergraph.to_api_schema().unwrap()));
+    insta::assert_snapshot!(print_sdl(
+        &supergraph.to_api_schema(Default::default()).unwrap()
+    ));
 }
 
 #[test]
@@ -137,7 +141,9 @@ fn can_compose_types_from_different_subgraphs() {
     .unwrap();
     let supergraph = Supergraph::compose(vec![&s1, &s2]).unwrap();
     insta::assert_snapshot!(print_sdl(&supergraph.schema));
-    insta::assert_snapshot!(print_sdl(&supergraph.to_api_schema().unwrap()));
+    insta::assert_snapshot!(print_sdl(
+        &supergraph.to_api_schema(Default::default()).unwrap()
+    ));
 }
 
 #[test]
@@ -176,5 +182,7 @@ fn compose_removes_federation_directives() {
 
     let supergraph = Supergraph::compose(vec![&s1, &s2]).unwrap();
     insta::assert_snapshot!(print_sdl(&supergraph.schema));
-    insta::assert_snapshot!(print_sdl(&supergraph.to_api_schema().unwrap()));
+    insta::assert_snapshot!(print_sdl(
+        &supergraph.to_api_schema(Default::default()).unwrap()
+    ));
 }


### PR DESCRIPTION
Whether `@defer` or `@stream` should be exposed depends on the capabilities and configuration of the supergraph router. This option adds the definitions to the API schema if requested.