### PR TITLE
Prep 0.0.6 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-federation"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["The Apollo GraphQL Contributors"]
 edition = "2021"
 description = "Apollo Federation"


### PR DESCRIPTION
When we push a vX.Y.Z tag, it automatically gets published, right? 😇 

This is to release the apollo-compiler upgrade and the API schema implementation.