### PR TITLE
@link(as: String) argument is nullable

### DIFF
--- a/src/subgraph/spec.rs
+++ b/src/subgraph/spec.rs
@@ -643,8 +643,7 @@ impl LinkSpecDefinitions {
                 InputValueDefinition {
                     description: None,
                     name: name!("url"),
-                    // TODO: doc-comment disagrees with non-null here
-                    ty: ty!(String!).into(),
+                    ty: ty!(String).into(),
                     default_value: None,
                     directives: Default::default(),
                 }


### PR DESCRIPTION
Per spec: https://specs.apollo.dev/link/v1.0/#@link.as