### PR TITLE
fix: more compatible definitions added by `include_{defer,stream}`

### DIFF
--- a/src/api_schema.rs
+++ b/src/api_schema.rs
@@ -165,19 +165,7 @@ pub fn to_api_schema(
 
 fn defer_definition() -> Node<DirectiveDefinition> {
     Node::new(DirectiveDefinition {
-        description: Some(
-            r#"
-The `@defer` directive may be provided for fragment spreads and inline fragments
-to inform the executor to delay the execution of the current fragment to
-indicate deprioritization of the current fragment. A query with `@defer`
-directive will cause the request to potentially return multiple responses, where
-non-deferred data is delivered in the initial response and data deferred is
-delivered in a subsequent response. `@include` and `@skip` take precedence over
-`@defer`.
-        "#
-            .trim()
-            .into(),
-        ),
+        description: None,
         name: name!("defer"),
         arguments: vec![
             Node::new(InputValueDefinition {
@@ -196,22 +184,16 @@ delivered in a subsequent response. `@include` and `@skip` take precedence over
             }),
         ],
         repeatable: false,
-        locations: vec![DirectiveLocation::Field],
+        locations: vec![
+            DirectiveLocation::FragmentSpread,
+            DirectiveLocation::InlineFragment,
+        ],
     })
 }
 
 fn stream_definition() -> Node<DirectiveDefinition> {
     Node::new(DirectiveDefinition {
-        description: Some(
-            r#"
-The `@stream` directive may be provided for a field of `List` type so that the
-backend can leverage technology such as asynchronous iterators to provide a
-partial list in the initial response, and additional list items in subsequent
-responses. `@include` and `@skip` take precedence over `@stream`.
-        "#
-            .trim()
-            .into(),
-        ),
+        description: None,
         name: name!("stream"),
         arguments: vec![
             Node::new(InputValueDefinition {

--- a/tests/api_schema.rs
+++ b/tests/api_schema.rs
@@ -2399,23 +2399,8 @@ fn include_supergraph_directives() -> Result<(), FederationError> {
     })?;
 
     insta::assert_display_snapshot!(api_schema, @r###"
-    """
-    The `@defer` directive may be provided for fragment spreads and inline fragments
-    to inform the executor to delay the execution of the current fragment to
-    indicate deprioritization of the current fragment. A query with `@defer`
-    directive will cause the request to potentially return multiple responses, where
-    non-deferred data is delivered in the initial response and data deferred is
-    delivered in a subsequent response. `@include` and `@skip` take precedence over
-    `@defer`.
-    """
-    directive @defer(label: String, if: Boolean! = true) on FIELD
+    directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-    """
-    The `@stream` directive may be provided for a field of `List` type so that the
-    backend can leverage technology such as asynchronous iterators to provide a
-    partial list in the initial response, and additional list items in subsequent
-    responses. `@include` and `@skip` take precedence over `@stream`.
-    """
     directive @stream(label: String, if: Boolean! = true, initialCount: Int = 0) on FIELD
 
     type Query {


### PR DESCRIPTION
There was a rather silly mistake in the `@defer` definition: it applies to fragment spreads, but I copy-pasted wrong and made it apply to fields instead. That's fixed now.

I also removed the doc comments from the definitions. The JS code did not add them and having them messes up the comparison between JS and Rust results in the router. If it's any use to have it, we can re-add it later when the JS implementation is gone.
