### PR TITLE
Prepare 0.0.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 ## Documentation-->
 
+# [0.0.7](https://crates.io/crates/apollo-federation/0.0.7) - 2024-02-22
+
+## Features
+- Continued work on core query planning implementation, by [SimonSapin] in [pull/121]
+
+## Fixes
+- Fix `@defer` directive definition in API schema generation, by [goto-bus-stop] in [pull/221]
+
+[SimonSapin]: https://github.com/SimonSapin
+[goto-bus-stop]: https://github.com/goto-bus-stop
+[pull/121]: https://github.com/apollographql/federation-next/pull/121
+[pull/221]: https://github.com/apollographql/federation-next/pull/221
+
 # [0.0.3](https://crates.io/crates/apollo-federation/0.0.3) - 2023-11-08
 
 ## Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-federation"
-version = "0.0.6"
+version = "0.0.7"
 authors = ["The Apollo GraphQL Contributors"]
 edition = "2021"
 description = "Apollo Federation"


### PR DESCRIPTION
The fix to API schema directives supports the `experimental_api_schema_generation_mode: both` setting in the router.