### PR TITLE
feat: support legacy `@core` link syntax

### DIFF
--- a/src/link/database.rs
+++ b/src/link/database.rs
@@ -15,7 +15,7 @@ pub fn links_metadata(schema: &Schema) -> Result<Option<LinksMetadata>, LinkErro
         .schema_definition
         .directives
         .iter()
-        .filter(|d| parse_link_if_bootstrap_directive(schema, d));
+        .filter(|d| is_bootstrap_directive(schema, d));
     let Some(bootstrap_directive) = bootstrap_directives.next() else {
         return Ok(None);
     };
@@ -163,9 +163,9 @@ fn is_core_directive_definition(definition: &DirectiveDefinition) -> bool {
             .map_or(true, |argument| *argument.ty == ty!(String))
 }
 
-// Note: currently only recognizing @link, not @core. Doesn't feel worth bothering with @core at
-// this point, but the latter uses the "feature" arg instead of "url".
-fn parse_link_if_bootstrap_directive(schema: &Schema, directive: &Directive) -> bool {
+/// Returns whether a given directive is the @link or @core directive that imports the @link or
+/// @core spec.
+fn is_bootstrap_directive(schema: &Schema, directive: &Directive) -> bool {
     let Some(definition) = schema.directive_definitions.get(&directive.name) else {
         return false;
     };

--- a/src/link/database.rs
+++ b/src/link/database.rs
@@ -11,6 +11,9 @@ use crate::link::{
 
 /// Extract @link metadata from a schema.
 pub fn links_metadata(schema: &Schema) -> Result<Option<LinksMetadata>, LinkError> {
+    // This finds "bootstrap" uses of @link / @core regardless of order. By spec,
+    // the bootstrap directive application must be the first application of @link / @core, but
+    // this was not enforced by the JS implementation, so we match it for backward compatibility.
     let mut bootstrap_directives = schema
         .schema_definition
         .directives
@@ -25,8 +28,8 @@ pub fn links_metadata(schema: &Schema) -> Result<Option<LinksMetadata>, LinkErro
             "the @link specification itself (\"{}\") is applied multiple times",
             extraneous_directive
                 .argument_by_name("url")
-                // XXX(@goto-bus-stop): @core compatibility is primarily to support old tests--should be
-                // removed when those are updated.
+                // XXX(@goto-bus-stop): @core compatibility is primarily to support old tests in other projects,
+                // and should be removed when those are updated.
                 .or(extraneous_directive.argument_by_name("feature"))
                 .and_then(|value| value.as_str().map(Cow::Borrowed))
                 .unwrap_or_else(|| Cow::Owned(Identity::link_identity().to_string()))

--- a/src/link/database.rs
+++ b/src/link/database.rs
@@ -1,33 +1,39 @@
+use apollo_compiler::ast::{Directive, DirectiveLocation};
+use apollo_compiler::schema::DirectiveDefinition;
+use apollo_compiler::{ty, Schema};
+use std::borrow::Cow;
 use std::{collections::HashMap, sync::Arc};
-
-use apollo_compiler::ast::{Directive, DirectiveLocation, Type};
-use apollo_compiler::Schema;
 
 use crate::link::{
     spec::{Identity, Url},
     {Link, LinkError, LinksMetadata, DEFAULT_LINK_NAME},
 };
 
+/// Extract @link metadata from a schema.
 pub fn links_metadata(schema: &Schema) -> Result<Option<LinksMetadata>, LinkError> {
     let mut bootstrap_directives = schema
         .schema_definition
         .directives
         .iter()
         .filter(|d| parse_link_if_bootstrap_directive(schema, d));
-    let bootstrap_directive = bootstrap_directives.next();
-    if bootstrap_directive.is_none() {
+    let Some(bootstrap_directive) = bootstrap_directives.next() else {
         return Ok(None);
-    }
-    // We have _a_ bootstrap directives, but 2 is more than we bargained for.
-    if bootstrap_directives.next().is_some() {
+    };
+    // There must be exactly one bootstrap directive.
+    if let Some(extraneous_directive) = bootstrap_directives.next() {
         return Err(LinkError::BootstrapError(format!(
             "the @link specification itself (\"{}\") is applied multiple times",
-            Identity::link_identity()
+            extraneous_directive
+                .argument_by_name("url")
+                .or(extraneous_directive.argument_by_name("feature"))
+                .and_then(|value| value.as_str().map(Cow::Borrowed))
+                .unwrap_or_else(|| Cow::Owned(Identity::link_identity().to_string()))
         )));
     }
+
     // At this point, we know this schema uses "our" @link. So we now "just" want to validate
     // all of the @link usages (starting with the bootstrapping one) and extract their metadata.
-    let link_name_in_schema = &bootstrap_directive.unwrap().name;
+    let link_name_in_schema = &bootstrap_directive.name;
     let mut links = Vec::new();
     let mut by_identity = HashMap::new();
     let mut by_name_in_schema = HashMap::new();
@@ -106,31 +112,64 @@ pub fn links_metadata(schema: &Schema) -> Result<Option<LinksMetadata>, LinkErro
     }))
 }
 
-// Note: currently only recognizing @link, not @core. Doesn't feel worth bothering with @core at
-// this point, but the latter uses the "feature" arg instead of "url".
-fn parse_link_if_bootstrap_directive(schema: &Schema, directive: &Directive) -> bool {
-    if let Some(definition) = schema.directive_definitions.get(&directive.name) {
-        let locations = &definition.locations;
-        let is_correct_def = definition.repeatable
-            && locations.len() == 1
-            && locations[0] == DirectiveLocation::Schema;
-        let is_correct_def = is_correct_def
-            && definition.arguments.iter().any(|arg| {
-                arg.name == "as" && matches!(&*arg.ty, Type::Named(name) if name == "String")
-            });
-        let is_correct_def = is_correct_def && definition.arguments.iter().any(|arg| {
-            arg.name == "url" && {
-                // The "true" type of `url` in the @link spec is actually `String` (nullable), and this
+/// Returns true if the given definition matches the @link definition.
+///
+/// Either of these definitions are accepted:
+/// ```graphql
+/// directive @_ANY_NAME_(url: String!, as: String) repeatable on SCHEMA
+/// directive @_ANY_NAME_(url: String, as: String) repeatable on SCHEMA
+/// ```
+fn is_link_directive_definition(definition: &DirectiveDefinition) -> bool {
+    definition.repeatable
+        && definition.locations == [DirectiveLocation::Schema]
+        && definition.argument_by_name("url").is_some_and(|argument| {
+            // The "true" type of `url` in the @link spec is actually `String` (nullable), and this
+            // for future-proofing reasons (the idea was that we may introduce later other
+            // ways to identify specs that are not urls). But we allow the definition to
+            // have a non-nullable type both for convenience and because some early
+            // federation previews actually generated that.
+            *argument.ty == ty!(String!) || *argument.ty == ty!(String)
+        })
+        && definition
+            .argument_by_name("as")
+            .is_some_and(|argument| *argument.ty == ty!(String))
+}
+
+/// Returns true if the given definition matches the @core definition.
+///
+/// Either of these definitions are accepted:
+/// ```graphql
+/// directive @_ANY_NAME_(feature: String!, as: String) repeatable on SCHEMA
+/// directive @_ANY_NAME_(feature: String, as: String) repeatable on SCHEMA
+/// directive @_ANY_NAME_(feature: String!) repeatable on SCHEMA
+/// directive @_ANY_NAME_(feature: String) repeatable on SCHEMA
+/// ```
+fn is_core_directive_definition(definition: &DirectiveDefinition) -> bool {
+    definition.repeatable
+        && definition.locations == [DirectiveLocation::Schema]
+        && definition
+            .argument_by_name("feature")
+            .is_some_and(|argument| {
+                // The "true" type of `url` in the @core spec is actually `String` (nullable), and this
                 // for future-proofing reasons (the idea was that we may introduce later other
                 // ways to identify specs that are not urls). But we allow the definition to
                 // have a non-nullable type both for convenience and because some early
                 // federation previews actually generated that.
-                matches!(&*arg.ty, Type::Named(name) | Type::NonNullNamed(name) if name == "String")
-            }
-        });
-        if !is_correct_def {
-            return false;
-        }
+                *argument.ty == ty!(String!) || *argument.ty == ty!(String)
+            })
+        && definition
+            .argument_by_name("as")
+            // Definition may be omitted in old graphs
+            .map_or(true, |argument| *argument.ty == ty!(String))
+}
+
+// Note: currently only recognizing @link, not @core. Doesn't feel worth bothering with @core at
+// this point, but the latter uses the "feature" arg instead of "url".
+fn parse_link_if_bootstrap_directive(schema: &Schema, directive: &Directive) -> bool {
+    let Some(definition) = schema.directive_definitions.get(&directive.name) else {
+        return false;
+    };
+    if is_link_directive_definition(definition) {
         if let Some(url) = directive
             .argument_by_name("url")
             .and_then(|value| value.as_str())
@@ -145,7 +184,21 @@ fn parse_link_if_bootstrap_directive(schema: &Schema, directive: &Directive) -> 
                 url.identity == Identity::link_identity() && directive.name == expected_name
             });
         }
-    }
+    } else if is_core_directive_definition(definition) {
+        if let Some(url) = directive
+            .argument_by_name("feature")
+            .and_then(|value| value.as_str())
+        {
+            let url = url.parse::<Url>();
+            let expected_name = directive
+                .argument_by_name("as")
+                .and_then(|value| value.as_str())
+                .unwrap_or("core");
+            return url.map_or(false, |url| {
+                url.identity == Identity::core_identity() && directive.name == expected_name
+            });
+        }
+    };
     false
 }
 
@@ -186,6 +239,74 @@ mod tests {
 
         assert!(meta
             .source_link_of_directive(&name!("inaccessible"))
+            .is_some());
+
+        Ok(())
+    }
+
+    #[test]
+    fn renamed_link_directive() -> Result<(), LinkError> {
+        let schema = r#"
+          extend schema
+            @lonk(url: "https://specs.apollo.dev/link/v1.0", as: "lonk")
+            @lonk(url: "https://specs.apollo.dev/inaccessible/v0.2")
+
+          type Query { x: Int }
+
+          enum lonk__Purpose {
+            SECURITY
+            EXECUTION
+          }
+
+          scalar lonk__Import
+
+          directive @lonk(url: String!, as: String, import: [lonk__Import], for: lonk__Purpose) repeatable on SCHEMA
+        "#;
+
+        let schema = Schema::parse(schema, "lonk.graphqls").unwrap();
+
+        let meta = links_metadata(&schema)?.expect("should have metadata");
+        assert!(meta
+            .source_link_of_directive(&name!("inaccessible"))
+            .is_some());
+
+        Ok(())
+    }
+
+    #[test]
+    fn renamed_core_directive() -> Result<(), LinkError> {
+        let schema = r#"
+          extend schema
+            @care(feature: "https://specs.apollo.dev/core/v0.2", as: "care")
+            @care(feature: "https://specs.apollo.dev/join/v0.2", for: EXECUTION)
+
+          directive @care(feature: String!, as: String, for: core__Purpose) repeatable on SCHEMA
+          directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+          directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+          directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+          directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+          type Query { x: Int }
+
+          enum care__Purpose {
+            SECURITY
+            EXECUTION
+          }
+
+          scalar care__Import
+
+          scalar join__FieldSet
+
+          enum join__Graph {
+            USERS @join__graph(name: "users", url: "http://localhost:4001")
+          }
+        "#;
+
+        let schema = Schema::parse(schema, "care.graphqls").unwrap();
+
+        let meta = links_metadata(&schema)?.expect("should have metadata");
+        assert!(meta
+            .source_link_of_directive(&name!("join__graph"))
             .is_some());
 
         Ok(())

--- a/src/link/database.rs
+++ b/src/link/database.rs
@@ -25,6 +25,8 @@ pub fn links_metadata(schema: &Schema) -> Result<Option<LinksMetadata>, LinkErro
             "the @link specification itself (\"{}\") is applied multiple times",
             extraneous_directive
                 .argument_by_name("url")
+                // XXX(@goto-bus-stop): @core compatibility is primarily to support old tests--should be
+                // removed when those are updated.
                 .or(extraneous_directive.argument_by_name("feature"))
                 .and_then(|value| value.as_str().map(Cow::Borrowed))
                 .unwrap_or_else(|| Cow::Owned(Identity::link_identity().to_string()))
@@ -145,6 +147,8 @@ fn is_link_directive_definition(definition: &DirectiveDefinition) -> bool {
 /// directive @_ANY_NAME_(feature: String) repeatable on SCHEMA
 /// ```
 fn is_core_directive_definition(definition: &DirectiveDefinition) -> bool {
+    // XXX(@goto-bus-stop): @core compatibility is primarily to support old tests--should be
+    // removed when those are updated.
     definition.repeatable
         && definition.locations == [DirectiveLocation::Schema]
         && definition
@@ -185,6 +189,8 @@ fn is_bootstrap_directive(schema: &Schema, directive: &Directive) -> bool {
             });
         }
     } else if is_core_directive_definition(definition) {
+        // XXX(@goto-bus-stop): @core compatibility is primarily to support old tests--should be
+        // removed when those are updated.
         if let Some(url) = directive
             .argument_by_name("feature")
             .and_then(|value| value.as_str())

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -51,7 +51,7 @@ pub enum Purpose {
 }
 
 impl Purpose {
-    pub fn from_ast_value(value: &Value) -> Result<Purpose, LinkError> {
+    pub fn from_value(value: &Value) -> Result<Purpose, LinkError> {
         if let Value::Enum(value) = value {
             Ok(value.parse::<Purpose>()?)
         } else {
@@ -111,7 +111,7 @@ pub struct Import {
 }
 
 impl Import {
-    pub fn from_hir_value(value: &Value) -> Result<Import, LinkError> {
+    pub fn from_value(value: &Value) -> Result<Import, LinkError> {
         // TODO: it could be nice to include the broken value in the error messages of this method
         // (especially since @link(import:) is a list), but `Value` does not implement `Display`
         // currently, so a bit annoying.
@@ -263,34 +263,54 @@ impl Link {
     }
 
     pub fn from_directive_application(directive: &Node<Directive>) -> Result<Link, LinkError> {
-        let url = directive
-            .argument_by_name("url")
-            .and_then(|arg| arg.as_str())
-            .ok_or(LinkError::BootstrapError(
+        let (url, is_link) = if let Some(value) = directive.argument_by_name("url") {
+            (value, true)
+        } else if let Some(value) = directive.argument_by_name("feature") {
+            (value, false)
+        } else {
+            return Err(LinkError::BootstrapError(
                 "the `url` argument for @link is mandatory".to_string(),
-            ))?;
-        let url: Url = url.parse::<Url>().map_err(|e| {
-            LinkError::BootstrapError(format!("invalid `url` argument (reason: {})", e))
+            ));
+        };
+
+        let (directive_name, arg_name) = if is_link {
+            ("link", "url")
+        } else {
+            ("core", "feature")
+        };
+
+        let url = url.as_str().ok_or_else(|| {
+            LinkError::BootstrapError(format!(
+                "the `{arg_name}` argument for @{directive_name} must be a String"
+            ))
         })?;
+        let url: Url = url.parse::<Url>().map_err(|e| {
+            LinkError::BootstrapError(format!("invalid `{arg_name}` argument (reason: {e})"))
+        })?;
+
         let spec_alias = directive
             .argument_by_name("as")
             .and_then(|arg| arg.as_node_str())
             .map(Name::new)
             .transpose()?;
         let purpose = if let Some(value) = directive.argument_by_name("for") {
-            Some(Purpose::from_ast_value(value)?)
+            Some(Purpose::from_value(value)?)
         } else {
             None
         };
-        let mut imports = Vec::new();
-        if let Some(values) = directive
-            .argument_by_name("import")
-            .and_then(|arg| arg.as_list())
-        {
-            for v in values {
-                imports.push(Arc::new(Import::from_hir_value(v)?));
-            }
+
+        let imports = if is_link {
+            directive
+                .argument_by_name("import")
+                .and_then(|arg| arg.as_list())
+                .unwrap_or(&[])
+                .iter()
+                .map(|value| Ok(Arc::new(Import::from_value(value)?)))
+                .collect::<Result<Vec<Arc<Import>>, LinkError>>()?
+        } else {
+            Default::default()
         };
+
         Ok(Link {
             url,
             spec_alias,

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -266,6 +266,8 @@ impl Link {
         let (url, is_link) = if let Some(value) = directive.argument_by_name("url") {
             (value, true)
         } else if let Some(value) = directive.argument_by_name("feature") {
+            // XXX(@goto-bus-stop): @core compatibility is primarily to support old tests--should be
+            // removed when those are updated.
             (value, false)
         } else {
             return Err(LinkError::BootstrapError(

--- a/tests/api_schema.rs
+++ b/tests/api_schema.rs
@@ -2449,7 +2449,7 @@ type Query {
 }
     "#;
 
-    let graph = Supergraph::new(&sdl).expect("should succeed");
+    let graph = Supergraph::new(sdl).expect("should succeed");
     let api_schema = graph
         .to_api_schema(Default::default())
         .expect("should succeed");

--- a/tests/api_schema.rs
+++ b/tests/api_schema.rs
@@ -2454,7 +2454,7 @@ type Query {
         .to_api_schema(Default::default())
         .expect("should succeed");
 
-    insta::assert_display_snapshot!(api_schema, @r###"
+    insta::assert_snapshot!(api_schema, @r###"
     type Query {
       me: String
     }

--- a/tests/api_schema.rs
+++ b/tests/api_schema.rs
@@ -2410,3 +2410,53 @@ fn include_supergraph_directives() -> Result<(), FederationError> {
 
     Ok(())
 }
+
+#[test]
+fn supports_core_directive_supergraph() {
+    let sdl = r#"
+schema
+  @core(feature: "https://specs.apollo.dev/core/v0.2")
+  @core(feature: "https://specs.apollo.dev/join/v0.2")
+{
+  query: Query
+}
+
+directive @core(feature: String!, as: String) repeatable on SCHEMA
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+) on FIELD_DEFINITION
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+) repeatable on OBJECT | INTERFACE
+
+directive @join__owner(graph: join__Graph!) on OBJECT | INTERFACE
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+scalar join__FieldSet
+
+enum join__Graph {
+  ACCOUNTS @join__graph(name: "accounts", url: "http://localhost:4001/graphql")
+}
+
+type Query {
+  me: String
+}
+    "#;
+
+    let graph = Supergraph::new(&sdl).expect("should succeed");
+    let api_schema = graph
+        .to_api_schema(Default::default())
+        .expect("should succeed");
+
+    insta::assert_display_snapshot!(api_schema, @r###"
+    type Query {
+      me: String
+    }
+    "###);
+}


### PR DESCRIPTION
This is for backward compatibility with existing supergraphs, bolting `@core` support onto the `@link` reading. It does not do anything to support fed v1 supergraphs.

While `@core` is not used in new graphs today, it is supported by the JS code, and we have a lot of tests throughout our systems that rely on using `@core` with fed v2.

Additionally, because the implementation of API schema generation is the same between fed v1 and fed v2, supporting `@core` will let us land it in the router *without* a fallback to JS for fed v1 supergraphs.

All new code that supports `@core` mentions `@core` literally in a comment so we can rip it out easily when we migrate over customers and our tests in the router.