### PR TITLE
[Query Planner] add stub implementation for QueryPlanner::build_query_plan

### DIFF
--- a/src/query_plan/mod.rs
+++ b/src/query_plan/mod.rs
@@ -15,10 +15,12 @@ pub(crate) mod query_planning_traversal;
 
 pub type QueryPlanCost = i64;
 
+#[derive(Debug, Default)]
 pub struct QueryPlan {
     node: Option<TopLevelPlanNode>,
 }
 
+#[derive(Debug, derive_more::From)]
 pub enum TopLevelPlanNode {
     Subscription(SubscriptionNode),
     Fetch(FetchNode),
@@ -29,12 +31,13 @@ pub enum TopLevelPlanNode {
     Condition(ConditionNode),
 }
 
+#[derive(Debug)]
 pub struct SubscriptionNode {
     primary: FetchNode,
     rest: Option<PlanNode>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum PlanNode {
     Fetch(Arc<FetchNode>),
     Sequence(Arc<SequenceNode>),
@@ -44,6 +47,7 @@ pub enum PlanNode {
     Condition(Arc<ConditionNode>),
 }
 
+#[derive(Debug)]
 pub struct FetchNode {
     subgraph_name: NodeStr,
     /// Optional identifier for the fetch for defer support. All fetches of a given plan will be
@@ -77,14 +81,17 @@ pub struct FetchNode {
     output_rewrites: Vec<FetchDataRewrite>,
 }
 
+#[derive(Debug)]
 pub struct SequenceNode {
     nodes: Vec<PlanNode>,
 }
 
+#[derive(Debug)]
 pub struct ParallelNode {
     nodes: Vec<PlanNode>,
 }
 
+#[derive(Debug)]
 pub struct FlattenNode {
     path: Vec<FetchDataPathElement>,
     node: PlanNode,
@@ -106,6 +113,7 @@ pub struct FlattenNode {
 /// we implement more advanced server-side heuristics to decide if deferring is judicious or not.
 /// This allows the executor of the plan to consistently send a defer-abiding multipart response to
 /// the client.
+#[derive(Debug)]
 pub struct DeferNode {
     /// The "primary" part of a defer, that is the non-deferred part (though could be deferred
     /// itself for a nested defer).
@@ -117,6 +125,7 @@ pub struct DeferNode {
 }
 
 /// The primary block of a `DeferNode`.
+#[derive(Debug)]
 pub struct PrimaryDeferBlock {
     /// The part of the original query that "selects" the data to send in that primary response
     /// once the plan in `node` completes). Note that if the parent `DeferNode` is nested, then it
@@ -132,6 +141,7 @@ pub struct PrimaryDeferBlock {
 }
 
 /// A deferred block of a `DeferNode`.
+#[derive(Debug)]
 pub struct DeferredDeferBlock {
     /// References one or more fetch node(s) (by `id`) within `DeferNode.primary.node`. The plan of
     /// this deferred part should not be started until all such fetches return.
@@ -153,11 +163,13 @@ pub struct DeferredDeferBlock {
     node: Option<PlanNode>,
 }
 
+#[derive(Debug)]
 pub struct DeferredDependency {
     /// A `FetchNode` ID.
     id: NodeStr,
 }
 
+#[derive(Debug)]
 pub struct ConditionNode {
     condition_variable: Name,
     if_clause: Option<PlanNode>,
@@ -221,4 +233,12 @@ pub enum FetchDataPathElement {
 pub enum QueryPathElement {
     Field(Field),
     InlineFragment(InlineFragment),
+}
+
+impl QueryPlan {
+    fn new(node: impl Into<TopLevelPlanNode>) -> Self {
+        Self {
+            node: Some(node.into()),
+        }
+    }
 }

--- a/src/query_plan/query_planner.rs
+++ b/src/query_plan/query_planner.rs
@@ -438,9 +438,9 @@ type User
     #[test]
     fn it_does_not_crash() {
         let supergraph = Supergraph::new(TEST_SUPERGRAPH).unwrap();
-        let planner = QueryPlanner::new(&supergraph, Default::default()).unwrap();
+        let _planner = QueryPlanner::new(&supergraph, Default::default()).unwrap();
 
-        let document = ExecutableDocument::parse_and_validate(
+        let _document = ExecutableDocument::parse_and_validate(
             supergraph
                 .to_api_schema(Default::default())
                 .unwrap()

--- a/src/query_plan/query_planner.rs
+++ b/src/query_plan/query_planner.rs
@@ -4,6 +4,8 @@ use crate::link::federation_spec_definition::FEDERATION_INTERFACEOBJECT_DIRECTIV
 use crate::link::spec::Identity;
 use crate::query_graph::build_federated_query_graph;
 use crate::query_graph::QueryGraph;
+use crate::query_plan::operation::normalize_operation;
+use crate::query_plan::QueryPlan;
 use crate::schema::position::AbstractTypeDefinitionPosition;
 use crate::schema::position::InterfaceTypeDefinitionPosition;
 use crate::schema::position::ObjectTypeDefinitionPosition;
@@ -12,11 +14,14 @@ use crate::schema::ValidFederationSchema;
 use crate::ApiSchemaOptions;
 use crate::Supergraph;
 use apollo_compiler::schema::ExtendedType;
+use apollo_compiler::validation::Valid;
+use apollo_compiler::ExecutableDocument;
 use apollo_compiler::NodeStr;
 use indexmap::IndexMap;
 use indexmap::IndexSet;
 use std::sync::Arc;
 
+#[derive(Debug, Clone)]
 pub struct QueryPlannerConfig {
     /// Whether the query planner should try to reused the named fragments of the planned query in
     /// subgraph fetches.
@@ -63,7 +68,7 @@ impl Default for QueryPlannerConfig {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Clone, Default)]
 pub struct QueryPlanIncrementalDeliveryConfig {
     /// Enables @defer support by the query planner.
     ///
@@ -74,6 +79,7 @@ pub struct QueryPlanIncrementalDeliveryConfig {
     enable_defer: bool,
 }
 
+#[derive(Debug, Clone)]
 pub struct QueryPlannerDebugConfig {
     /// If used and the supergraph is built from a single subgraph, then user queries do not go
     /// through the normal query planning and instead a fetch to the one subgraph is built directly
@@ -140,11 +146,12 @@ pub struct QueryPlanner {
     abstract_types_with_inconsistent_runtime_types: IndexSet<AbstractTypeDefinitionPosition>,
     // TODO: Port _lastGeneratedPlanStatistics from the JS codebase in a way that keeps QueryPlanner
     // immutable.
+    // last_generated_plan_statistics: QueryPlanningStatistics,
 }
 
 impl QueryPlanner {
     pub fn new(
-        supergraph: Supergraph,
+        supergraph: &Supergraph,
         config: QueryPlannerConfig,
     ) -> Result<Self, FederationError> {
         let supergraph_schema = supergraph.schema.clone();
@@ -245,6 +252,44 @@ impl QueryPlanner {
             interface_types_with_interface_objects,
             abstract_types_with_inconsistent_runtime_types,
         })
+    }
+
+    // PORT_NOTE: this receives an `Operation` object in JS which is a concept that doesn't exist in apollo-rs.
+    pub fn build_query_plan(
+        &self,
+        document: &Valid<ExecutableDocument>,
+        operation_name: Option<&str>,
+    ) -> Result<QueryPlan, FederationError> {
+        let operation = document
+            .get_operation(operation_name)
+            // TODO(@goto-bus-stop) this is not an internal error
+            .map_err(|_| FederationError::internal("requested operation does not exist"))?;
+
+        // TODO(@goto-bus-stop) this isn't valid GraphQL so it should never happen given a
+        // `Valid<ExecutableDocument>`?
+        // The JS code checks this *again* post-normalization. That should be enough
+        if operation.selection_set.selections.is_empty() {
+            return Ok(QueryPlan::default());
+        }
+
+        if self.config.debug.bypass_planner_for_single_subgraph {
+            todo!("return a single fetch node for the whole operation");
+        }
+
+        let normalized_operation = normalize_operation(
+            operation,
+            &document.fragments,
+            &self.api_schema,
+            &self.interface_types_with_interface_objects,
+        )?;
+
+        // TODO(@goto-bus-stop): some defer stuff
+
+        if normalized_operation.selection_set.selections.is_empty() {
+            return Ok(QueryPlan::default());
+        }
+
+        todo!("the rest of the owl")
     }
 }
 
@@ -393,6 +438,18 @@ type User
     #[test]
     fn it_does_not_crash() {
         let supergraph = Supergraph::new(TEST_SUPERGRAPH).unwrap();
-        QueryPlanner::new(supergraph, Default::default()).unwrap();
+        let planner = QueryPlanner::new(&supergraph, Default::default()).unwrap();
+
+        let document = ExecutableDocument::parse_and_validate(
+            supergraph
+                .to_api_schema(Default::default())
+                .unwrap()
+                .schema(),
+            "{ userById(id: 1) { name email } }",
+            "operation.graphql",
+        )
+        .unwrap();
+        // This part does crash :)
+        // let _plan = planner.build_query_plan(&document, None).unwrap();
     }
 }


### PR DESCRIPTION
Just call into the parts that already exist (operation normalisation)

This is intended to be a stub to start experimenting with router integration (like getting all the types in order).