### PR TITLE
chore(deps): update apollo-compiler to 1.0.0-beta.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Elastic-2.0"
 autotests = false                                               # Integration tests are modules of tests/main.rs
 
 [dependencies]
-apollo-compiler = "=1.0.0-beta.13"
+apollo-compiler = "=1.0.0-beta.14"
 derive_more = "0.99.17"
 indexmap = "2.1.0"
 lazy_static = "1.4.0"


### PR DESCRIPTION
will need a fed-next release to land this in router. it improves validation performance and adds a debugging aid for router, nothing relevant for fed-next.