### PR TITLE
Fix backwards error message for unsupported join spec version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,8 +50,8 @@ pub(crate) fn validate_supergraph(
         return Err(SingleFederationError::InvalidFederationSupergraph {
             message: format!(
                 "Invalid supergraph: uses unsupported join spec version {} (supported versions: {})",
-                JOIN_VERSIONS.versions().map(|v| v.to_string()).collect::<Vec<_>>().join(", "),
                 join_link.url.version,
+                JOIN_VERSIONS.versions().map(|v| v.to_string()).collect::<Vec<_>>().join(", "),
             ),
         }.into());
     };


### PR DESCRIPTION
Example previous message:

> The supergraph schema failed to produce a valid API schema: Invalid supergraph: uses unsupported join spec version 0.1, 0.2, 0.3 (supported versions: 0.4)

~~Also add https://specs.apollo.dev/join/v0.4 to the list of supported version. Are more changes needed to properly support it? This version seems to exist in https://github.com/apollographql/federation/pull/2907, but it’s not listed on https://specs.apollo.dev/ and https://specs.apollo.dev/join/v0.4 itself is a 404 error as of this writing.~~