### PR TITLE
Prepare 0.0.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 ## Documentation-->
 
+# [0.0.9](https://crates.io/crates/apollo-federation/0.0.9) - 2024-03-20
+
+## Features
+- Continued work on core query planning implementation, by [goto-bus-stop] in [pull/229]
+
+## Maintenance
+- Update `apollo-compiler`, by [goto-bus-stop] in [pull/230]
+
+[goto-bus-stop]: https://github.com/goto-bus-stop
+[pull/229]: https://github.com/apollographql/federation-next/pull/229
+[pull/230]: https://github.com/apollographql/federation-next/pull/230
+
 # [0.0.8](https://crates.io/crates/apollo-federation/0.0.8) - 2024-03-06
 
 ## Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-federation"
-version = "0.0.8"
+version = "0.0.9"
 authors = ["The Apollo GraphQL Contributors"]
 edition = "2021"
 description = "Apollo Federation"


### PR DESCRIPTION
Just to get new apollo-compiler into router

## Features
- Continued work on core query planning implementation, by [goto-bus-stop] in [pull/229]

## Maintenance
- Update `apollo-compiler`, by [goto-bus-stop] in [pull/230]

[goto-bus-stop]: https://github.com/goto-bus-stop
[pull/229]: https://github.com/apollographql/federation-next/pull/229
[pull/230]: https://github.com/apollographql/federation-next/pull/230