### PR TITLE
Add static assertions that Supergraph and QueryPlanner are thread-safe

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,3 +104,10 @@ impl Supergraph {
         )
     }
 }
+
+const _: () = {
+    const fn assert_thread_safe<T: Sync + Send>() {}
+
+    assert_thread_safe::<Supergraph>();
+    assert_thread_safe::<query_plan::query_planner::QueryPlanner>();
+};


### PR DESCRIPTION
Thread-safe meaning implementing the `Send` and `Sync` traits. They already are, but with this PR we won’t regress accidentally.

The consenquence is that we should keep using `Arc` over `Rc`, `Mutex` or `RwLock` over `Cell` or `RefCell`, etc.