### PR TITLE
Mark join v0.4 as supported for non-query planning purpose

### DIFF
--- a/src/link/join_spec_definition.rs
+++ b/src/link/join_spec_definition.rs
@@ -72,6 +72,7 @@ pub(crate) struct EnumValueDirectiveArguments {
     pub(crate) graph: Name,
 }
 
+#[derive(Clone)]
 pub(crate) struct JoinSpecDefinition {
     url: Url,
     minimum_federation_version: Option<Version>,
@@ -321,11 +322,18 @@ lazy_static! {
         ));
         definitions.add(JoinSpecDefinition::new(
             Version { major: 0, minor: 3 },
-            None,
-        ));
-        definitions.add(JoinSpecDefinition::new(
-            Version { major: 0, minor: 1 },
             Some(Version { major: 2, minor: 0 }),
+        ));
+        definitions
+    };
+
+    /// Versions supported for purpose other than query planning.
+    /// TODO: remove once v0.4 is properly implemented in query planning
+    pub(crate) static ref NON_QUERY_PLANNING_JOIN_VERSIONS: SpecDefinitions<JoinSpecDefinition> = {
+        let mut definitions = JOIN_VERSIONS.clone();
+        definitions.add(JoinSpecDefinition::new(
+            Version { major: 0, minor: 4 },
+            Some(Version { major: 2, minor: 7 }),
         ));
         definitions
     };

--- a/src/link/spec_definition.rs
+++ b/src/link/spec_definition.rs
@@ -142,6 +142,7 @@ pub(crate) trait SpecDefinition {
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct SpecDefinitions<T: SpecDefinition> {
     identity: Identity,
     definitions: BTreeMap<Version, T>,

--- a/src/query_graph/extract_subgraphs_from_supergraph.rs
+++ b/src/query_graph/extract_subgraphs_from_supergraph.rs
@@ -18,7 +18,6 @@ use crate::schema::position::{
     TypeDefinitionPosition, UnionTypeDefinitionPosition,
 };
 use crate::schema::{FederationSchema, ValidFederationSchema};
-use crate::validate_supergraph;
 use apollo_compiler::ast::FieldDefinition;
 use apollo_compiler::executable::{Field, Selection, SelectionSet};
 use apollo_compiler::schema::{
@@ -45,7 +44,8 @@ pub(crate) fn extract_subgraphs_from_supergraph(
     validate_extracted_subgraphs: Option<bool>,
 ) -> Result<ValidFederationSubgraphs, FederationError> {
     let validate_extracted_subgraphs = validate_extracted_subgraphs.unwrap_or(true);
-    let (link_spec_definition, join_spec_definition) = validate_supergraph(supergraph_schema)?;
+    let (link_spec_definition, join_spec_definition) =
+        crate::validate_supergraph_for_query_planning(supergraph_schema)?;
     let is_fed_1 = *join_spec_definition.version() == Version { major: 0, minor: 1 };
     let (mut subgraphs, federation_spec_definitions, graph_enum_value_name_to_subgraph_name) =
         collect_empty_subgraphs(supergraph_schema, join_spec_definition)?;


### PR DESCRIPTION
This unblocks initial integration in the Router.

Also fix the minimum supported version of v0.3, aligning with: https://github.com/apollographql/federation/blob/%40apollo/federation-internals%402.7.2/internals-js/src/specs/joinSpec.ts#L264-L268