### PR TITLE
Derive PartialEq and Hash for OpGraphPathContext

### DIFF
--- a/src/query_graph/graph_path.rs
+++ b/src/query_graph/graph_path.rs
@@ -31,7 +31,7 @@ use petgraph::graph::{EdgeIndex, NodeIndex};
 use petgraph::visit::EdgeRef;
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
-use std::hash::{Hash, Hasher};
+use std::hash::Hash;
 use std::ops::Deref;
 use std::sync::{atomic, Arc};
 
@@ -278,7 +278,7 @@ impl From<NormalizedInlineFragment> for OpGraphPathTrigger {
 
 /// Records, as we walk a path within a GraphQL operation, important directives encountered
 /// (currently `@include` and `@skip` with their conditions).
-#[derive(Debug, Clone, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub(crate) struct OpGraphPathContext {
     /// A list of conditionals (e.g. `[{ kind: Include, value: true}, { kind: Skip, value: $foo }]`)
     /// in the reverse order in which they were applied (so the first element is the inner-most
@@ -302,18 +302,6 @@ impl OpGraphPathContext {
                 .extend(new_conditionals.into_iter().map(Arc::new));
         }
         Ok(new_context)
-    }
-}
-
-impl PartialEq for OpGraphPathContext {
-    fn eq(&self, _other: &Self) -> bool {
-        todo!()
-    }
-}
-
-impl Hash for OpGraphPathContext {
-    fn hash<H: Hasher>(&self, _state: &mut H) {
-        todo!()
     }
 }
 


### PR DESCRIPTION
This PR addresses Jira ticket FED-28.

After verifying that the `PartialEq` implementation on `Arc` does the desired short-circuiting and the derived behavior matches what is expected in the JS code, the stubs for the manual implementation of `PartialEq` and `Hash` were replaced with derived implementations.