### PR TITLE
Implementation of `QueryPlanner::build_query_plan`

### DIFF
--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -180,6 +180,8 @@ pub enum SingleFederationError {
     InterfaceKeyNotOnImplementation { message: String },
     #[error("{message}")]
     InterfaceKeyMissingImplementationType { message: String },
+    #[error("@defer is not supported on subscriptions")]
+    DeferredSubscriptionUnsupported,
 }
 
 impl SingleFederationError {
@@ -350,6 +352,7 @@ impl SingleFederationError {
             SingleFederationError::InterfaceKeyMissingImplementationType { .. } => {
                 ErrorCode::InterfaceKeyMissingImplementationType
             }
+            SingleFederationError::DeferredSubscriptionUnsupported => ErrorCode::Internal,
         }
     }
 }

--- a/src/query_graph/build_query_graph.rs
+++ b/src/query_graph/build_query_graph.rs
@@ -1343,7 +1343,7 @@ impl FederatedQueryGraphBuilder {
                         message: "Singleton list was unexpectedly empty".to_owned(),
                     })?
             } else {
-                merge_selection_sets(all_conditions.into_iter())?
+                merge_selection_sets(all_conditions)?
             };
             let edge_weight_mut = self.base.query_graph.edge_weight_mut(edge)?;
             edge_weight_mut.conditions = Some(Arc::new(new_conditions));
@@ -1414,7 +1414,7 @@ impl FederatedQueryGraphBuilder {
                         message: "Singleton list was unexpectedly empty".to_owned(),
                     })?
             } else {
-                merge_selection_sets(all_conditions.into_iter())?
+                merge_selection_sets(all_conditions)?
             };
             // We make a copy of the tail node (representing the field's type) with all the same
             // out-edges, and we change this particular in-edge to point to the new copy. We then

--- a/src/query_graph/mod.rs
+++ b/src/query_graph/mod.rs
@@ -597,39 +597,6 @@ impl QueryGraph {
         _node: NodeIndex,
     ) -> Result<Option<NormalizedSelectionSet>, FederationError> {
         todo!()
-        // let node = self.graph.node_weight(node).unwrap();
-
-        // let Some(schema) = self.sources.get(&node.source) else {
-        //     unreachable!();
-        // };
-        // let Some(metadata) = schema.metadata() else {
-        //     unreachable!("no federation metadata for source {}", node.source);
-        // };
-
-        // let QueryGraphNodeType::SchemaType(type_position) = node.type_.clone() else {
-        //     return Err(FederationError::internal(
-        //         "Unexpectedly encountered federation root node as field collection node.",
-        //     ));
-        // };
-        // let ty = crate::schema::position::TypeDefinitionPosition::from(type_position)
-        //     .get(schema.schema())?;
-
-        // for key in ty.directives().get_all("key") {
-        //     let Some(fields) = key
-        //         .argument_by_name("fields")
-        //         .and_then(|fields| fields.as_node_str())
-        //         .cloned()
-        //     else {
-        //         continue;
-        //     };
-        //     let selection = parse_field_set(schema, ty.name().clone(), fields)?;
-
-        //     if !selection_selects_any_external_field(selection) {
-        //         return Ok(Some(selection));
-        //     }
-        // }
-
-        // Ok(None)
     }
 
     pub(crate) fn is_cross_subgraph_edge(&self, edge: EdgeIndex) -> Result<bool, FederationError> {

--- a/src/query_graph/mod.rs
+++ b/src/query_graph/mod.rs
@@ -1,4 +1,5 @@
 use crate::error::{FederationError, SingleFederationError};
+use crate::query_graph::field_set::parse_field_set;
 use crate::query_plan::operation::normalized_field_selection::NormalizedField;
 use crate::query_plan::operation::normalized_inline_fragment_selection::NormalizedInlineFragment;
 use crate::query_plan::operation::NormalizedSelectionSet;
@@ -335,8 +336,8 @@ impl QueryGraph {
         })
     }
 
-    pub(crate) fn sources(&self) -> impl Iterator<Item = &ValidFederationSchema> {
-        self.sources.values()
+    pub(crate) fn sources(&self) -> impl Iterator<Item = (&NodeStr, &ValidFederationSchema)> {
+        self.sources.iter()
     }
 
     pub(crate) fn types_to_nodes(
@@ -594,9 +595,42 @@ impl QueryGraph {
 
     pub(crate) fn get_locally_satisfiable_key(
         &self,
-        _node: NodeIndex,
+        node: NodeIndex,
     ) -> Result<Option<NormalizedSelectionSet>, FederationError> {
         todo!()
+        // let node = self.graph.node_weight(node).unwrap();
+
+        // let Some(schema) = self.sources.get(&node.source) else {
+        //     unreachable!();
+        // };
+        // let Some(metadata) = schema.metadata() else {
+        //     unreachable!("no federation metadata for source {}", node.source);
+        // };
+
+        // let QueryGraphNodeType::SchemaType(type_position) = node.type_.clone() else {
+        //     return Err(FederationError::internal(
+        //         "Unexpectedly encountered federation root node as field collection node.",
+        //     ));
+        // };
+        // let ty = crate::schema::position::TypeDefinitionPosition::from(type_position)
+        //     .get(schema.schema())?;
+
+        // for key in ty.directives().get_all("key") {
+        //     let Some(fields) = key
+        //         .argument_by_name("fields")
+        //         .and_then(|fields| fields.as_node_str())
+        //         .cloned()
+        //     else {
+        //         continue;
+        //     };
+        //     let selection = parse_field_set(schema, ty.name().clone(), fields)?;
+
+        //     if !selection_selects_any_external_field(selection) {
+        //         return Ok(Some(selection));
+        //     }
+        // }
+
+        // Ok(None)
     }
 
     pub(crate) fn is_cross_subgraph_edge(&self, edge: EdgeIndex) -> Result<bool, FederationError> {

--- a/src/query_graph/mod.rs
+++ b/src/query_graph/mod.rs
@@ -1,5 +1,4 @@
 use crate::error::{FederationError, SingleFederationError};
-use crate::query_graph::field_set::parse_field_set;
 use crate::query_plan::operation::normalized_field_selection::NormalizedField;
 use crate::query_plan::operation::normalized_inline_fragment_selection::NormalizedInlineFragment;
 use crate::query_plan::operation::NormalizedSelectionSet;
@@ -595,7 +594,7 @@ impl QueryGraph {
 
     pub(crate) fn get_locally_satisfiable_key(
         &self,
-        node: NodeIndex,
+        _node: NodeIndex,
     ) -> Result<Option<NormalizedSelectionSet>, FederationError> {
         todo!()
         // let node = self.graph.node_weight(node).unwrap();

--- a/src/query_plan/display.rs
+++ b/src/query_plan/display.rs
@@ -37,7 +37,10 @@ impl State<'_, '_> {
 
 impl QueryPlan {
     fn write_indented(&self, state: &mut State<'_, '_>) -> fmt::Result {
-        let Self { node } = self;
+        let Self {
+            node,
+            statistics: _,
+        } = self;
         state.write("QueryPlan {")?;
         if let Some(node) = node {
             state.indent()?;

--- a/src/query_plan/fetch_dependency_graph.rs
+++ b/src/query_plan/fetch_dependency_graph.rs
@@ -595,7 +595,7 @@ impl FetchDependencyGraph {
     ) -> Result<(TProcessed, Vec<TDeferred>), FederationError> {
         self.reduce_and_optimize();
 
-        todo!("FED-62") // I think this is FED-62?
+        todo!("FED-146")
     }
 }
 

--- a/src/query_plan/fetch_dependency_graph.rs
+++ b/src/query_plan/fetch_dependency_graph.rs
@@ -561,8 +561,8 @@ impl FetchDependencyGraph {
     /// Returns a main part and a (potentially empty) deferred part.
     pub(crate) fn process<TProcessed, TDeferred>(
         &mut self,
-        processor: impl FetchDependencyGraphProcessor<TProcessed, TDeferred>,
-        root_kind: SchemaRootDefinitionKind,
+        _processor: impl FetchDependencyGraphProcessor<TProcessed, TDeferred>,
+        _root_kind: SchemaRootDefinitionKind,
     ) -> Result<(TProcessed, Vec<TDeferred>), FederationError> {
         todo!()
     }

--- a/src/query_plan/fetch_dependency_graph_processor.rs
+++ b/src/query_plan/fetch_dependency_graph_processor.rs
@@ -52,7 +52,13 @@ pub(crate) struct FetchDependencyGraphToQueryPlanProcessor {
 }
 
 // TODO
-pub(crate) struct RebasedFragments;
+pub(crate) struct RebasedFragments();
+
+impl RebasedFragments {
+    pub fn new(fragments) ->Self{
+        Self()
+    }
+}
 
 /// Computes the cost of a Plan.
 ///

--- a/src/query_plan/fetch_dependency_graph_processor.rs
+++ b/src/query_plan/fetch_dependency_graph_processor.rs
@@ -55,9 +55,9 @@ pub(crate) struct FetchDependencyGraphToQueryPlanProcessor {
 pub(crate) struct RebasedFragments();
 
 impl RebasedFragments {
-    // TODO(@goto-bus-stop): Remove post https://github.com/apollographql/federation-next/pull/239
+    // TODO(@goto-bus-stop): Remove after https://github.com/apollographql/federation-next/pull/239
     pub fn new(
-        fragments: &Arc<indexmap::IndexMap<Name, Node<super::operation::NormalizedFragment>>>,
+        _fragments: &Arc<indexmap::IndexMap<Name, Node<super::operation::NormalizedFragment>>>,
     ) -> Self {
         Self()
     }

--- a/src/query_plan/fetch_dependency_graph_processor.rs
+++ b/src/query_plan/fetch_dependency_graph_processor.rs
@@ -52,16 +52,7 @@ pub(crate) struct FetchDependencyGraphToQueryPlanProcessor {
 }
 
 // TODO
-pub(crate) struct RebasedFragments();
-
-impl RebasedFragments {
-    // TODO(@goto-bus-stop): Remove after https://github.com/apollographql/federation-next/pull/239
-    pub fn new(
-        _fragments: &Arc<indexmap::IndexMap<Name, Node<super::operation::NormalizedFragment>>>,
-    ) -> Self {
-        Self()
-    }
-}
+pub(crate) struct RebasedFragments;
 
 /// Computes the cost of a Plan.
 ///

--- a/src/query_plan/fetch_dependency_graph_processor.rs
+++ b/src/query_plan/fetch_dependency_graph_processor.rs
@@ -55,7 +55,10 @@ pub(crate) struct FetchDependencyGraphToQueryPlanProcessor {
 pub(crate) struct RebasedFragments();
 
 impl RebasedFragments {
-    pub fn new(fragments) ->Self{
+    // TODO(@goto-bus-stop): Remove post https://github.com/apollographql/federation-next/pull/239
+    pub fn new(
+        fragments: &Arc<indexmap::IndexMap<Name, Node<super::operation::NormalizedFragment>>>,
+    ) -> Self {
         Self()
     }
 }

--- a/src/query_plan/mod.rs
+++ b/src/query_plan/mod.rs
@@ -35,7 +35,7 @@ pub enum TopLevelPlanNode {
 #[derive(Debug, Clone)]
 pub struct SubscriptionNode {
     pub primary: Box<FetchNode>,
-    // TODO(@goto-bus-stop) Is this not just always a SequenceNode?
+    // XXX(@goto-bus-stop) Is this not just always a SequenceNode?
     pub rest: Option<Box<PlanNode>>,
 }
 

--- a/src/query_plan/mod.rs
+++ b/src/query_plan/mod.rs
@@ -3,7 +3,6 @@ use apollo_compiler::executable::{
 };
 use apollo_compiler::validation::Valid;
 use apollo_compiler::{ExecutableDocument, NodeStr};
-use std::sync::Arc;
 
 pub(crate) mod conditions;
 pub(crate) mod fetch_dependency_graph;
@@ -23,31 +22,36 @@ pub struct QueryPlan {
 #[derive(Debug, derive_more::From)]
 pub enum TopLevelPlanNode {
     Subscription(SubscriptionNode),
-    Fetch(FetchNode),
+    #[from(types(FetchNode))]
+    Fetch(Box<FetchNode>),
     Sequence(SequenceNode),
     Parallel(ParallelNode),
     Flatten(FlattenNode),
     Defer(DeferNode),
-    Condition(ConditionNode),
+    #[from(types(ConditionNode))]
+    Condition(Box<ConditionNode>),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SubscriptionNode {
-    pub primary: FetchNode,
-    pub rest: Option<PlanNode>,
+    pub primary: Box<FetchNode>,
+    // TODO(@goto-bus-stop) Is this not just always a SequenceNode?
+    pub rest: Option<Box<PlanNode>>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone, derive_more::From)]
 pub enum PlanNode {
-    Fetch(Arc<FetchNode>),
-    Sequence(Arc<SequenceNode>),
-    Parallel(Arc<ParallelNode>),
-    Flatten(Arc<FlattenNode>),
-    Defer(Arc<DeferNode>),
-    Condition(Arc<ConditionNode>),
+    #[from(types(FetchNode))]
+    Fetch(Box<FetchNode>),
+    Sequence(SequenceNode),
+    Parallel(ParallelNode),
+    Flatten(FlattenNode),
+    Defer(DeferNode),
+    #[from(types(ConditionNode))]
+    Condition(Box<ConditionNode>),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FetchNode {
     pub subgraph_name: NodeStr,
     /// Optional identifier for the fetch for defer support. All fetches of a given plan will be
@@ -77,20 +81,20 @@ pub struct FetchNode {
     pub output_rewrites: Vec<FetchDataRewrite>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SequenceNode {
     pub nodes: Vec<PlanNode>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ParallelNode {
     pub nodes: Vec<PlanNode>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FlattenNode {
     pub path: Vec<FetchDataPathElement>,
-    pub node: PlanNode,
+    pub node: Box<PlanNode>,
 }
 
 /// A `DeferNode` corresponds to one or more `@defer` applications at the same level of "nestedness"
@@ -109,7 +113,7 @@ pub struct FlattenNode {
 /// we implement more advanced server-side heuristics to decide if deferring is judicious or not.
 /// This allows the executor of the plan to consistently send a defer-abiding multipart response to
 /// the client.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DeferNode {
     /// The "primary" part of a defer, that is the non-deferred part (though could be deferred
     /// itself for a nested defer).
@@ -121,7 +125,7 @@ pub struct DeferNode {
 }
 
 /// The primary block of a `DeferNode`.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PrimaryDeferBlock {
     /// The part of the original query that "selects" the data to send in that primary response
     /// once the plan in `node` completes). Note that if the parent `DeferNode` is nested, then it
@@ -133,11 +137,11 @@ pub struct PrimaryDeferBlock {
     /// The plan to get all the data for the primary block. Same notes as for subselection: usually
     /// defined, but can be undefined in some corner cases where nothing is to be done in the
     /// primary block.
-    pub node: Option<PlanNode>,
+    pub node: Option<Box<PlanNode>>,
 }
 
 /// A deferred block of a `DeferNode`.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DeferredDeferBlock {
     /// References one or more fetch node(s) (by `id`) within `DeferNode.primary.node`. The plan of
     /// this deferred part should not be started until all such fetches return.
@@ -156,20 +160,20 @@ pub struct DeferredDeferBlock {
     /// deferred response), but without declaring additional fetches. This happens for @defer
     /// applications that cannot be handled through the query planner and where the defer cannot be
     /// passed through to the subgraph).
-    pub node: Option<PlanNode>,
+    pub node: Option<Box<PlanNode>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DeferredDependency {
     /// A `FetchNode` ID.
     pub id: NodeStr,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ConditionNode {
     pub condition_variable: Name,
-    pub if_clause: Option<PlanNode>,
-    pub else_clause: Option<PlanNode>,
+    pub if_clause: Option<Box<PlanNode>>,
+    pub else_clause: Option<Box<PlanNode>>,
 }
 
 /// The type of rewrites currently supported on the input/output data of fetches.

--- a/src/query_plan/mod.rs
+++ b/src/query_plan/mod.rs
@@ -1,3 +1,4 @@
+use crate::query_plan::query_planner::QueryPlanningStatistics;
 use apollo_compiler::executable::{
     Field, InlineFragment, Name, OperationType, Selection, SelectionSet,
 };
@@ -17,6 +18,7 @@ pub type QueryPlanCost = i64;
 #[derive(Debug, Default)]
 pub struct QueryPlan {
     pub node: Option<TopLevelPlanNode>,
+    statistics: QueryPlanningStatistics,
 }
 
 #[derive(Debug, derive_more::From)]
@@ -236,9 +238,10 @@ pub enum QueryPathElement {
 }
 
 impl QueryPlan {
-    fn new(node: impl Into<TopLevelPlanNode>) -> Self {
+    fn new(node: impl Into<TopLevelPlanNode>, statistics: QueryPlanningStatistics) -> Self {
         Self {
             node: Some(node.into()),
+            statistics,
         }
     }
 }

--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -84,7 +84,7 @@ impl NormalizedOperation {
         todo!()
     }
 
-    pub(crate) fn without_defer(mut self) -> Self {
+    pub(crate) fn without_defer(self) -> Self {
         fn field_has_defer(field: &NormalizedFieldSelection) -> bool {
             field.field.data().directives.has("defer")
                 || field

--- a/src/query_plan/query_planner.rs
+++ b/src/query_plan/query_planner.rs
@@ -555,7 +555,7 @@ fn compute_plan_for_defer_conditionals(
     _parameters: QueryPlanningParameters,
     _defer_conditions: IndexMap<String, IndexSet<String>>,
 ) -> Result<Option<PlanNode>, FederationError> {
-    todo!()
+    todo!("FED-95")
 }
 
 #[cfg(test)]

--- a/src/query_plan/query_planner.rs
+++ b/src/query_plan/query_planner.rs
@@ -525,7 +525,7 @@ fn compute_plan_internal(
             deferred.extend(local_deferred);
             let new_selection = dependency_graph.defer_tracking.primary_selection.clone();
             match primary_selection.as_mut() {
-                Some(selection) => selection.merge_into(new_selection.into_iter())?,
+                Some(selection) => selection.merge_into(new_selection.as_deref().into_iter())?,
                 None => primary_selection = new_selection,
             }
         }

--- a/src/query_plan/query_planner.rs
+++ b/src/query_plan/query_planner.rs
@@ -353,9 +353,9 @@ impl QueryPlanner {
             if defer.has_defers && is_subscription {
                 return Err(SingleFederationError::DeferredSubscriptionUnsupported.into());
             }
-            assigned_defer_labels = defer.assigned_defer_labels;
+            assigned_defer_labels = Some(defer.assigned_defer_labels);
             has_defers = defer.has_defers;
-            defer_conditions = defer.defer_conditions;
+            defer_conditions = Some(defer.defer_conditions);
             defer.operation
         } else {
             // If defer is not enabled, we remove all @defer from the query. This feels cleaner do this once here than
@@ -536,6 +536,13 @@ fn compute_plan_internal(
             dependency_graph.process(parameters.processor, parameters.operation.root_kind)?;
         primary_selection = dependency_graph.defer_tracking.primary_selection.clone();
     }
+    todo!()
+}
+
+fn compute_plan_for_defer_conditionals(
+    _parameters: QueryPlanningParameters,
+    _defer_conditions: IndexMap<String, IndexSet<String>>,
+) -> Result<Option<PlanNode>, FederationError> {
     todo!()
 }
 

--- a/src/query_plan/query_planner.rs
+++ b/src/query_plan/query_planner.rs
@@ -483,9 +483,7 @@ fn compute_root_parallel_best_plan(
         parameters,
         selection,
         has_defers,
-        // TODO
-        SchemaRootDefinitionKind::Query, // parameters.head,
-        // TODO
+        parameters.operation.root_kind,
         FetchDependencyGraphToCostProcessor,
     );
 

--- a/src/query_plan/query_planner.rs
+++ b/src/query_plan/query_planner.rs
@@ -12,6 +12,7 @@ use crate::query_plan::fetch_dependency_graph_processor::FetchDependencyGraphToQ
 use crate::query_plan::operation::normalize_operation;
 use crate::query_plan::operation::NormalizedDefer;
 use crate::query_plan::operation::NormalizedSelectionSet;
+use crate::query_plan::operation::RebasedFragments;
 use crate::query_plan::query_planning_traversal::BestQueryPlanInfo;
 use crate::query_plan::query_planning_traversal::QueryPlanningParameters;
 use crate::query_plan::query_planning_traversal::QueryPlanningTraversal;
@@ -404,9 +405,7 @@ impl QueryPlanner {
         let processor = FetchDependencyGraphToQueryPlanProcessor::new(
             Arc::new(self.config.clone()),
             operation.variables.clone(),
-            // TODO(@goto-bus-stop): Use the new RebasedFragments type from
-            // https://github.com/apollographql/federation-next/pull/239
-            None, // RebasedFragments::new(normalized_operation.fragments),
+            Some(RebasedFragments::new(&normalized_operation.named_fragments)),
             operation_name.clone(),
             assigned_defer_labels,
         );

--- a/src/query_plan/query_planner.rs
+++ b/src/query_plan/query_planner.rs
@@ -383,6 +383,8 @@ impl QueryPlanner {
         let processor = FetchDependencyGraphToQueryPlanProcessor::new(
             Arc::new(self.config.clone()),
             operation.variables.clone(),
+            // TODO(@goto-bus-stop): Use the new RebasedFragments type from
+            // https://github.com/apollographql/federation-next/pull/239
             None, // RebasedFragments::new(normalized_operation.fragments),
             operation_name.clone(),
             assigned_defer_labels,

--- a/src/query_plan/query_planner.rs
+++ b/src/query_plan/query_planner.rs
@@ -462,7 +462,7 @@ fn compute_root_serial_dependency_graph(
     _parameters: &QueryPlanningParameters,
     _has_defers: bool,
 ) -> Result<Vec<FetchDependencyGraph>, FederationError> {
-    todo!()
+    todo!("FED-127")
 }
 
 fn compute_root_parallel_dependency_graph(

--- a/src/query_plan/query_planner.rs
+++ b/src/query_plan/query_planner.rs
@@ -504,7 +504,7 @@ fn compute_plan_internal(
     let root_kind = parameters.operation.root_kind;
 
     let (main, deferred, primary_selection) = if root_kind == SchemaRootDefinitionKind::Mutation {
-        let dependency_graphs = compute_root_serial_dependency_graph(&parameters, has_defers)?;
+        let dependency_graphs = compute_root_serial_dependency_graph(parameters, has_defers)?;
         let mut main = None;
         let mut deferred = vec![];
         let mut primary_selection = None::<NormalizedSelectionSet>;
@@ -526,7 +526,7 @@ fn compute_plan_internal(
         }
         (main, deferred, primary_selection)
     } else {
-        let mut dependency_graph = compute_root_parallel_dependency_graph(&parameters, has_defers)?;
+        let mut dependency_graph = compute_root_parallel_dependency_graph(parameters, has_defers)?;
 
         let (main, deferred) = dependency_graph.process(&mut parameters.processor, root_kind)?;
         // XXX(@goto-bus-stop) Maybe `.defer_tracking` should be on the return value of `process()`..?

--- a/src/query_plan/query_planner.rs
+++ b/src/query_plan/query_planner.rs
@@ -412,7 +412,8 @@ impl QueryPlanner {
             operation: Arc::new(normalized_operation),
             processor,
             head: *root,
-            // FIXME(@goto-bus-stop): Is hardcoding this correct?
+            // PORT_NOTE(@goto-bus-stop): In JS, `root` is a `RootVertex`, which is dynamically
+            // checked at various points in query planning. This is our Rust equivalent of that.
             head_must_be_root: true,
             statistics,
             abstract_types_with_inconsistent_runtime_types: self
@@ -420,7 +421,7 @@ impl QueryPlanner {
                 .clone()
                 .into(),
             config: self.config.clone(),
-            // XXX(@goto-bus-stop): what about `override_conditions`?
+            // PORT_NOTE: JS provides `override_conditions` here: see port note in `QueryPlanner::new`.
         };
 
         let root_node = match defer_conditions {

--- a/src/query_plan/query_planner.rs
+++ b/src/query_plan/query_planner.rs
@@ -286,9 +286,12 @@ impl QueryPlanner {
             // TODO(@goto-bus-stop) this is not an internal error, but a user error
             .map_err(|_| FederationError::internal("requested operation does not exist"))?;
 
-        // TODO(@goto-bus-stop) this isn't valid GraphQL so it should not return Ok()?
         if operation.selection_set.selections.is_empty() {
-            return Ok(QueryPlan::default());
+            // This should never happen because `operation` comes from a known-valid document.
+            return Err(SingleFederationError::InvalidGraphQL {
+                message: "Invalid operation: empty selection set".to_string(),
+            }
+            .into());
         }
 
         let is_subscription = operation.is_subscription();

--- a/src/query_plan/query_planner.rs
+++ b/src/query_plan/query_planner.rs
@@ -340,17 +340,16 @@ impl QueryPlanner {
             }
         }
 
-        let _reuse_query_fragments = self.config.reuse_query_fragments;
-        /*
-            let fragments = operation.fragments;
-            if (fragments && !fragments.isEmpty() && reuseQueryFragments) {
-              // For all subgraph fetches we query `__typename` on every abstract types (see `FetchGroup.toPlanNode`) so if we want
-              // to have a chance to reuse fragments, we should make sure those fragments also query `__typename` for every abstract type.
-              fragments = addTypenameFieldForAbstractTypesInNamedFragments(fragments);
-            } else {
-              fragments = undefined;
-            }
-        */
+        let reuse_query_fragments = self.config.reuse_query_fragments;
+        if reuse_query_fragments && !document.fragments.is_empty() {
+            // For all subgraph fetches we query `__typename` on every abstract types (see `FetchDependencyGraphNode::to_plan_node`)
+            // so if we want to have a chance to reuse fragments, we should make sure those fragments also query `__typename` for
+            // every abstract type.
+            //
+            // TODO: FED-165
+            //
+            // JS: fragments = addTypenameFieldForAbstractTypesInNamedFragments(fragments);
+        }
 
         let normalized_operation = normalize_operation(
             operation,

--- a/src/query_plan/query_planner.rs
+++ b/src/query_plan/query_planner.rs
@@ -165,9 +165,6 @@ pub struct QueryPlanner {
     // PORT_NOTE: Named `inconsistentAbstractTypesRuntimes` in the JS codebase, which was slightly
     // confusing.
     abstract_types_with_inconsistent_runtime_types: IndexSet<AbstractTypeDefinitionPosition>,
-    // TODO: Port _lastGeneratedPlanStatistics from the JS codebase in a way that keeps QueryPlanner
-    // immutable.
-    // last_generated_plan_statistics: QueryPlanningStatistics,
 }
 
 impl QueryPlanner {
@@ -457,6 +454,11 @@ impl QueryPlanner {
             None => None,
         };
 
+        // TODO(@goto-bus-stop): This should include `statistics`, see FED-68.
+        // Punting on it because it likely requires a refactor to the `QueryPlanningParameters` structure,
+        // whether we can do that will be more clear when more of the basic query planning paths
+        // are done, and then we can decide if we refactor or if we work around the current
+        // structure
         Ok(QueryPlan { node: root_node })
     }
 }

--- a/src/query_plan/query_planner.rs
+++ b/src/query_plan/query_planner.rs
@@ -283,7 +283,7 @@ impl QueryPlanner {
     ) -> Result<QueryPlan, FederationError> {
         let operation = document
             .get_operation(operation_name.as_ref().map(|name| name.as_str()))
-            // TODO(@goto-bus-stop) this is not an internal error
+            // TODO(@goto-bus-stop) this is not an internal error, but a user error
             .map_err(|_| FederationError::internal("requested operation does not exist"))?;
 
         // TODO(@goto-bus-stop) this isn't valid GraphQL so it should not return Ok()?
@@ -395,7 +395,7 @@ impl QueryPlanner {
             operation: Arc::new(normalized_operation),
             processor,
             head: *root,
-            // TODO(@goto-bus-stop): Is hardcoding this correct?
+            // FIXME(@goto-bus-stop): Is hardcoding this correct?
             head_must_be_root: true,
             statistics,
             abstract_types_with_inconsistent_runtime_types: self
@@ -403,7 +403,7 @@ impl QueryPlanner {
                 .clone()
                 .into(),
             config: self.config.clone(),
-            // TODO(@goto-bus-stop): what about `override_conditions`?
+            // XXX(@goto-bus-stop): what about `override_conditions`?
         };
 
         let root_node = match defer_conditions {

--- a/src/query_plan/query_planner.rs
+++ b/src/query_plan/query_planner.rs
@@ -521,7 +521,7 @@ fn compute_plan_internal(
                 None => primary_selection = new_selection.cloned(),
             }
         }
-        todo!()
+        (main, deferred, primary_selection)
     } else {
         let mut dependency_graph = compute_root_parallel_dependency_graph(&parameters, has_defers)?;
 

--- a/src/query_plan/query_planning_traversal.rs
+++ b/src/query_plan/query_planning_traversal.rs
@@ -135,8 +135,9 @@ impl<'a> QueryPlanningTraversal<'a> {
             starting_id_generation: 0,
             cost_processor,
             is_top_level,
-            // TODO(@goto-bus-stop): Use `self.resolve_condition_plan()` once it exists
+            // TODO: Use `self.resolve_condition_plan()` once it exists. See FED-46.
             condition_resolver: CachingConditionResolver,
+            // TODO: In JS this calls `createInitialOptions()`. Do we still need that? See FED-147.
             open_branches: Default::default(),
             closed_branches: Default::default(),
             best_plan: None,

--- a/src/query_plan/query_planning_traversal.rs
+++ b/src/query_plan/query_planning_traversal.rs
@@ -23,31 +23,34 @@ use indexmap::IndexSet;
 use petgraph::graph::NodeIndex;
 use std::sync::Arc;
 
+use super::query_planner::QueryPlanningStatistics;
+
 // PORT_NOTE: Named `PlanningParameters` in the JS codebase, but there was no particular reason to
 // leave out to the `Query` prefix, so it's been added for consistency. Similar to `GraphPath`, we
 // don't have a distinguished type for when the head is a root vertex, so we instead check this at
 // runtime (introducing the new field `head_must_be_root`).
 pub(crate) struct QueryPlanningParameters {
     /// The supergraph schema that generated the federated query graph.
-    supergraph_schema: ValidFederationSchema,
+    pub(crate) supergraph_schema: ValidFederationSchema,
     /// The federated query graph used for query planning.
-    federated_query_graph: Arc<QueryGraph>,
+    pub(crate) federated_query_graph: Arc<QueryGraph>,
     /// The operation to be query planned.
-    operation: Arc<NormalizedOperation>,
+    pub(crate) operation: Arc<NormalizedOperation>,
     /// A processor for converting fetch dependency graphs to query plans.
-    processor: FetchDependencyGraphToQueryPlanProcessor,
+    pub(crate) processor: FetchDependencyGraphToQueryPlanProcessor,
     /// The query graph node at which query planning begins.
-    head: NodeIndex,
+    pub(crate) head: NodeIndex,
     /// Whether the head must be a root node for query planning.
-    head_must_be_root: bool,
+    pub(crate) head_must_be_root: bool,
     /// A set of the names of interface or union types that have inconsistent "runtime types" across
     /// subgraphs.
     // PORT_NOTE: Named `inconsistentAbstractTypesRuntimes` in the JS codebase, which was slightly
     // confusing.
-    abstract_types_with_inconsistent_runtime_types: Arc<IndexSet<AbstractTypeDefinitionPosition>>,
+    pub(crate) abstract_types_with_inconsistent_runtime_types:
+        Arc<IndexSet<AbstractTypeDefinitionPosition>>,
     /// The configuration for the query planner.
-    config: Arc<QueryPlannerConfig>,
-    // TODO: When `PlanningStatistics` is ported, add a field for it.
+    pub(crate) config: QueryPlannerConfig,
+    pub(crate) statistics: QueryPlanningStatistics,
 }
 
 pub(crate) struct QueryPlanningTraversal {

--- a/src/query_plan/query_planning_traversal.rs
+++ b/src/query_plan/query_planning_traversal.rs
@@ -500,7 +500,8 @@ impl<'a> QueryPlanningTraversal<'a> {
             .unwrap_or(0);
         // debug!("Query has {plan_count} possible plans");
 
-        let max_evaluated_plans = self.parameters.config.debug.max_evaluated_plans as usize;
+        let max_evaluated_plans =
+            u32::from(self.parameters.config.debug.max_evaluated_plans) as usize;
         loop {
             // Note that if `self.closed_branches[0]` is our only branch, it's fine,
             // we'll continue to remove options from it (but that is beyond unlikely).

--- a/src/query_plan/query_planning_traversal.rs
+++ b/src/query_plan/query_planning_traversal.rs
@@ -126,7 +126,7 @@ impl<'a> QueryPlanningTraversal<'a> {
         root_kind: SchemaRootDefinitionKind,
         cost_processor: FetchDependencyGraphToCostProcessor,
     ) -> Self {
-        // TODO(@goto-bus-stop): Is this correct?
+        // FIXME(@goto-bus-stop): Is this correct?
         let is_top_level = parameters.head_must_be_root;
         Self {
             parameters,
@@ -135,7 +135,7 @@ impl<'a> QueryPlanningTraversal<'a> {
             starting_id_generation: 0,
             cost_processor,
             is_top_level,
-            // TODO Use self.resolve_condition_plan()
+            // TODO(@goto-bus-stop): Use `self.resolve_condition_plan()` once it exists
             condition_resolver: CachingConditionResolver,
             open_branches: Default::default(),
             closed_branches: Default::default(),
@@ -143,10 +143,12 @@ impl<'a> QueryPlanningTraversal<'a> {
         }
     }
 
-    // PORT_NOTE: In JS, the traversal is still usable after finding the best plan.
-    // TODO(@goto-bus-stop): Do we still need it? It's easier if we can consume the traversal
+    // PORT_NOTE: In JS, the traversal is still usable after finding the best plan. Here we consume
+    // the struct so we do not need to return a reference.
+    //
+    // XXX(@goto-bus-stop): Do we still need it? It's easier if we can consume the traversal
     // struct and return an owned BestQueryPlan. Alternatively, do we need to store the `best_plan`
-    // in `self`?
+    // in `self` at all?
     pub fn find_best_plan(mut self) -> Result<Option<BestQueryPlanInfo>, FederationError> {
         self.find_best_plan_inner()?;
         Ok(self.best_plan)

--- a/src/query_plan/query_planning_traversal.rs
+++ b/src/query_plan/query_planning_traversal.rs
@@ -144,11 +144,7 @@ impl<'a> QueryPlanningTraversal<'a> {
     }
 
     // PORT_NOTE: In JS, the traversal is still usable after finding the best plan. Here we consume
-    // the struct so we do not need to return a reference.
-    //
-    // XXX(@goto-bus-stop): Do we still need it? It's easier if we can consume the traversal
-    // struct and return an owned BestQueryPlan. Alternatively, do we need to store the `best_plan`
-    // in `self` at all?
+    // the struct so we do not need to return a reference, which is very unergonomic.
     pub fn find_best_plan(mut self) -> Result<Option<BestQueryPlanInfo>, FederationError> {
         self.find_best_plan_inner()?;
         Ok(self.best_plan)

--- a/src/query_plan/query_planning_traversal.rs
+++ b/src/query_plan/query_planning_traversal.rs
@@ -14,6 +14,7 @@ use crate::query_plan::operation::{
     NormalizedOperation, NormalizedSelection, NormalizedSelectionSet,
 };
 use crate::query_plan::query_planner::QueryPlannerConfig;
+use crate::query_plan::query_planner::QueryPlanningStatistics;
 use crate::query_plan::QueryPlanCost;
 use crate::schema::position::ObjectTypeDefinitionPosition;
 use crate::schema::position::SchemaRootDefinitionKind;
@@ -22,8 +23,6 @@ use crate::schema::ValidFederationSchema;
 use indexmap::IndexSet;
 use petgraph::graph::NodeIndex;
 use std::sync::Arc;
-
-use super::query_planner::QueryPlanningStatistics;
 
 // PORT_NOTE: Named `PlanningParameters` in the JS codebase, but there was no particular reason to
 // leave out to the `Query` prefix, so it's been added for consistency. Similar to `GraphPath`, we
@@ -100,6 +99,7 @@ pub(crate) struct BestQueryPlanInfo {
 }
 
 impl BestQueryPlanInfo {
+    // PORT_NOTE: The equivalent of `createEmptyPlan` in the JS codebase.
     pub fn empty(parameters: &QueryPlanningParameters) -> Self {
         Self {
             fetch_dependency_graph: FetchDependencyGraph::new(

--- a/src/query_plan/query_planning_traversal.rs
+++ b/src/query_plan/query_planning_traversal.rs
@@ -53,9 +53,9 @@ pub(crate) struct QueryPlanningParameters {
     pub(crate) statistics: QueryPlanningStatistics,
 }
 
-pub(crate) struct QueryPlanningTraversal {
+pub(crate) struct QueryPlanningTraversal<'a> {
     /// The parameters given to query planning.
-    parameters: QueryPlanningParameters,
+    parameters: &'a QueryPlanningParameters,
     /// The root kind of the operation.
     root_kind: SchemaRootDefinitionKind,
     /// True if query planner `@defer` support is enabled and the operation contains some `@defer`
@@ -114,12 +114,13 @@ impl BestQueryPlanInfo {
     }
 }
 
-impl QueryPlanningTraversal {
+impl<'a> QueryPlanningTraversal<'a> {
     pub fn new(
-        // TODO(@goto-bus-stop): take a reference here? the traversal struct should always be
-        // short-lived? It's kind of big to copy but if the lifetime is statically knowable we
-        // should not Arc it.
-        parameters: QueryPlanningParameters,
+        // TODO(@goto-bus-stop): This probably needs a mutable reference for some of the
+        // yet-unimplemented methods, and storing a mutable ref in `Self` here smells bad.
+        // The ownership of `QueryPlanningParameters` is awkward and should probably be
+        // refactored.
+        parameters: &'a QueryPlanningParameters,
         _selection_set: NormalizedSelectionSet,
         has_defers: bool,
         root_kind: SchemaRootDefinitionKind,


### PR DESCRIPTION
The scope of this PR is to implement `build_query_plan` and the top-level functions for the *simple* planning paths (no defer, and no mutations). After this PR, a call to `build_query_plan` should ideally hit a `todo!()` somewhere deeper inside the project, not at the top level. Some lifetime changes are required to existing code which is where most of the diff comes from.

---

`planner.build_query_plan()` can now run until we get to the processor stage (where the fetch dependency graph cost is calculated). I stopped there because processing is a big chunk of code that looks like it should be part of FED-62.

Notes on the changes to existing code:
- Because we aren't working with owned selection sets in selection set merging in mutation operations, but with `Arc`s, I changed the existing selection merging in operation.rs to operate on references. This makes it more flexible. I also removed the `ExactSizeIterator` optimisation as I expect it's rare and I'd be surprised if it makes a difference (we should reintroduce if there is benchmarking to show that it helps).
- PlanNode and TopLevelPlanNode now both use `Box`es instead of `Arc`s, and the structures are exactly the same except for the additional Subscription stuff on TopLevelPlanNode. This makes it easier to convert between the two.

Everything else is part of the `build_query_plan` function.


I left a few questions in the code tagged with `XXX(@)` that i don't think *need* to be fully addressed in this review but would be nice to check in case.