### PR TITLE
impl Display for OpGraphPath

### DIFF
--- a/src/link/graphql_definition.rs
+++ b/src/link/graphql_definition.rs
@@ -13,6 +13,12 @@ pub(crate) struct DeferDirectiveArguments {
     if_: Option<BooleanOrVariable>,
 }
 
+impl DeferDirectiveArguments {
+    pub(crate) fn label(&self) -> Option<&NodeStr> {
+        self.label.as_ref()
+    }
+}
+
 pub(crate) fn defer_directive_arguments(
     application: &Node<Directive>,
 ) -> Result<DeferDirectiveArguments, FederationError> {

--- a/src/link/graphql_definition.rs
+++ b/src/link/graphql_definition.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use crate::error::FederationError;
 use crate::link::argument::{
     directive_optional_string_argument, directive_optional_variable_boolean_argument,
@@ -52,4 +54,13 @@ pub(crate) enum OperationConditionalKind {
 pub(crate) enum BooleanOrVariable {
     Boolean(bool),
     Variable(Name),
+}
+
+impl Display for BooleanOrVariable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BooleanOrVariable::Boolean(b) => b.fmt(f),
+            BooleanOrVariable::Variable(name) => name.fmt(f),
+        }
+    }
 }

--- a/src/query_graph/graph_path.rs
+++ b/src/query_graph/graph_path.rs
@@ -1378,7 +1378,7 @@ impl OpGraphPath {
                             {
                                 let edge_weight = self.graph.edge_weight(edge)?;
                                 return Err(FederationError::internal(format!(
-                                    "Unexpectedly missing {} for {} from {}",
+                                    "Unexpectedly missing {} for {} from path {}",
                                     operation_field, edge_weight, self,
                                 )));
                             }
@@ -2011,8 +2011,14 @@ impl OpGraphPath {
 }
 
 impl Display for OpGraphPath {
-    fn fmt(&self, _f: &mut Formatter<'_>) -> std::fmt::Result {
-        todo!()
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[")?;
+        let mut iter = self.edges.iter();
+        if let Some(edge) = iter.next() {
+            write!(f, "{edge:?}")?;
+            iter.try_for_each(|edge| write!(f, ", {edge:?}"))?;
+        }
+        write!(f, "]")
     }
 }
 

--- a/src/query_graph/graph_path.rs
+++ b/src/query_graph/graph_path.rs
@@ -35,8 +35,6 @@ use std::hash::Hash;
 use std::ops::Deref;
 use std::sync::{atomic, Arc};
 
-use super::{QueryGraphEdge, QueryGraphNode};
-
 /// An immutable path in a query graph.
 ///
 /// A "path" here is mostly understood in the graph-theoretical sense of the term, i.e. as "a


### PR DESCRIPTION
This PR addresses Jira ticket FED-20.

Display for `OpGraphPath` has been implemented by representing the path with an array of edges. The edges are represented with their Debug impl, which can be changed. Currently, this implementation is the same as the debug impl of the edges.

Since the `edges` are `Option<EdgeIndex>>`, I am unsure how to represent the `None` case or if that was a concern at all. If there is a preferred way to represent the edges, I'll gladly change it.