### PR TITLE
Port queryPlanSerializer as Display impls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,14 @@ repository = "https://github.com/apollographql/federation-next"
 license = "Elastic-2.0"
 autotests = false                                               # Integration tests are modules of tests/main.rs
 
-[dependencies]
+[workspace.dependencies]
 apollo-compiler = "=1.0.0-beta.15"
-time = { version = "0.3.34", default-features = false, features = ["local-offset"] }
+
+[dependencies]
+apollo-compiler.workspace = true
+time = { version = "0.3.34", default-features = false, features = [
+    "local-offset",
+] }
 derive_more = "0.99.17"
 indexmap = "2.1.0"
 lazy_static = "1.4.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -4,5 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+apollo-compiler.workspace = true
 apollo-federation = { path = ".." }
 clap = { version = "4.5.4", features = ["derive"] }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,8 +4,11 @@ use std::io;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
+use apollo_compiler::ExecutableDocument;
 use apollo_federation::error::FederationError;
 use apollo_federation::query_graph;
+use apollo_federation::query_plan::query_planner::QueryPlanner;
+use apollo_federation::query_plan::query_planner::QueryPlannerConfig;
 use apollo_federation::subgraph;
 
 /// CLI arguments. See <https://docs.rs/clap/latest/clap/_derive/index.html>
@@ -32,6 +35,12 @@ enum Command {
         /// Path(s) to one supergraph schema file or multiple subgraph schemas.
         schemas: Vec<PathBuf>,
     },
+    /// Outputs the formatted query plan for the given query and schema
+    Plan {
+        query: PathBuf,
+        /// Path(s) to one supergraph schema file or multiple subgraph schemas.
+        schemas: Vec<PathBuf>,
+    },
 }
 
 fn main() -> ExitCode {
@@ -40,6 +49,7 @@ fn main() -> ExitCode {
         Command::Api { supegraph_schema } => to_api_schema(&supegraph_schema),
         Command::QueryGraph { schemas } => dot_query_graph(&schemas),
         Command::FederatedGraph { schemas } => dot_federated_graph(&schemas),
+        Command::Plan { query, schemas } => plan(&query, &schemas),
     };
     match result {
         Err(error) => {
@@ -51,12 +61,16 @@ fn main() -> ExitCode {
     }
 }
 
-fn to_api_schema(input_path: &PathBuf) -> Result<(), FederationError> {
-    let input = if input_path == std::path::Path::new("-") {
+fn read_input(input_path: &PathBuf) -> String {
+    if input_path == std::path::Path::new("-") {
         io::read_to_string(io::stdin()).unwrap()
     } else {
         fs::read_to_string(input_path).unwrap()
-    };
+    }
+}
+
+fn to_api_schema(input_path: &PathBuf) -> Result<(), FederationError> {
+    let input = read_input(input_path);
     let supergraph = apollo_federation::Supergraph::new(&input)?;
     let api_schema = supergraph.to_api_schema(apollo_federation::ApiSchemaOptions {
         include_defer: true,
@@ -108,5 +122,17 @@ fn dot_federated_graph(file_paths: &[PathBuf]) -> Result<(), FederationError> {
     let query_graph =
         query_graph::build_federated_query_graph(supergraph.schema, api_schema, None, None)?;
     println!("{}", query_graph::output::to_dot(&query_graph));
+    Ok(())
+}
+
+fn plan(query_path: &PathBuf, schema_paths: &[PathBuf]) -> Result<(), FederationError> {
+    let query = read_input(query_path);
+    let supergraph = load_supergraph(schema_paths)?;
+    let query_doc =
+        ExecutableDocument::parse_and_validate(supergraph.schema.schema(), query, query_path)?;
+    // TODO: add CLI parameters for config as needed
+    let config = QueryPlannerConfig::default();
+    let planner = QueryPlanner::new(&supergraph, config)?;
+    print!("{}", planner.build_query_plan(&query_doc, None)?);
     Ok(())
 }

--- a/src/query_plan/display.rs
+++ b/src/query_plan/display.rs
@@ -1,0 +1,439 @@
+use super::*;
+use apollo_compiler::executable;
+use std::fmt;
+
+pub(crate) struct State<'fmt, 'fmt2> {
+    indent_level: usize,
+    output: &'fmt mut fmt::Formatter<'fmt2>,
+}
+
+impl State<'_, '_> {
+    fn write<T: fmt::Display>(&mut self, value: T) -> fmt::Result {
+        write!(self.output, "{}", value)
+    }
+
+    fn new_line(&mut self) -> fmt::Result {
+        self.write("\n")?;
+        for _ in 0..self.indent_level {
+            self.write("  ")?
+        }
+        Ok(())
+    }
+
+    fn indent_no_new_line(&mut self) {
+        self.indent_level += 1;
+    }
+
+    fn indent(&mut self) -> fmt::Result {
+        self.indent_no_new_line();
+        self.new_line()
+    }
+
+    fn dedent(&mut self) -> fmt::Result {
+        self.indent_level -= 1;
+        self.new_line()
+    }
+}
+
+impl QueryPlan {
+    fn write_indented(&self, state: &mut State<'_, '_>) -> fmt::Result {
+        let Self { node } = self;
+        state.write("QueryPlan {")?;
+        if let Some(node) = node {
+            state.indent()?;
+            node.write_indented(state)?;
+            state.dedent()?;
+        }
+        state.write("}")
+    }
+}
+
+impl TopLevelPlanNode {
+    fn write_indented(&self, state: &mut State<'_, '_>) -> fmt::Result {
+        match self {
+            Self::Subscription(node) => node.write_indented(state),
+            Self::Fetch(node) => node.write_indented(state),
+            Self::Sequence(node) => node.write_indented(state),
+            Self::Parallel(node) => node.write_indented(state),
+            Self::Flatten(node) => node.write_indented(state),
+            Self::Defer(node) => node.write_indented(state),
+            Self::Condition(node) => node.write_indented(state),
+        }
+    }
+}
+
+impl PlanNode {
+    fn write_indented(&self, state: &mut State<'_, '_>) -> fmt::Result {
+        match self {
+            Self::Fetch(node) => node.write_indented(state),
+            Self::Sequence(node) => node.write_indented(state),
+            Self::Parallel(node) => node.write_indented(state),
+            Self::Flatten(node) => node.write_indented(state),
+            Self::Defer(node) => node.write_indented(state),
+            Self::Condition(node) => node.write_indented(state),
+        }
+    }
+}
+
+impl SubscriptionNode {
+    fn write_indented(&self, state: &mut State<'_, '_>) -> fmt::Result {
+        let Self { primary, rest } = self;
+        state.write("Subscription {")?;
+        state.indent()?;
+
+        state.write("Primary: {")?;
+        primary.write_indented(state)?;
+        state.write("}")?;
+
+        if let Some(rest) = rest {
+            state.new_line()?;
+            state.write("Rest: {")?;
+            rest.write_indented(state)?;
+            state.write("}")?;
+        }
+
+        state.dedent()?;
+        state.write("}")
+    }
+}
+
+impl FetchNode {
+    fn write_indented(&self, state: &mut State<'_, '_>) -> fmt::Result {
+        let Self {
+            subgraph_name,
+            id,
+            variable_usages: _,
+            requires,
+            operation_document,
+            operation_name: _,
+            operation_kind: _,
+            input_rewrites: _,
+            output_rewrites: _,
+        } = self;
+        state.write(format_args!("Fetch(service: {subgraph_name:?}"))?;
+        if let Some(id) = id {
+            state.write(format_args!(", id: {id:?}"))?;
+        }
+        state.write(") {")?;
+        state.indent()?;
+
+        if !requires.is_empty() {
+            write_selections(state, requires)?;
+            state.write(" => ")?;
+        }
+        write_operation(state, operation_document)?;
+
+        state.dedent()?;
+        state.write("}")
+    }
+}
+
+impl SequenceNode {
+    fn write_indented(&self, state: &mut State<'_, '_>) -> fmt::Result {
+        let Self { nodes } = self;
+        state.write("Sequence {")?;
+
+        write_indented_lines(state, nodes, |state, node| node.write_indented(state))?;
+
+        state.write("}")
+    }
+}
+
+impl ParallelNode {
+    fn write_indented(&self, state: &mut State<'_, '_>) -> fmt::Result {
+        let Self { nodes } = self;
+        state.write("Parallel {")?;
+
+        write_indented_lines(state, nodes, |state, node| node.write_indented(state))?;
+
+        state.write("}")
+    }
+}
+
+impl FlattenNode {
+    fn write_indented(&self, state: &mut State<'_, '_>) -> fmt::Result {
+        let Self { path, node } = self;
+        state.write("Flatten(path: \"")?;
+        if let Some((first, rest)) = path.split_first() {
+            state.write(first)?;
+            for element in rest {
+                state.write(".")?;
+                state.write(element)?;
+            }
+        }
+        state.write("\") {")?;
+        state.indent()?;
+
+        node.write_indented(state)?;
+
+        state.dedent()?;
+        state.write("}")
+    }
+}
+
+impl ConditionNode {
+    fn write_indented(&self, state: &mut State<'_, '_>) -> fmt::Result {
+        let Self {
+            condition_variable,
+            if_clause,
+            else_clause,
+        } = self;
+        match (if_clause, else_clause) {
+            (Some(if_clause), Some(else_clause)) => {
+                state.write(format_args!("Condition(if: ${condition_variable}) {{"))?;
+                state.indent()?;
+
+                state.write("Then {")?;
+                state.indent()?;
+                if_clause.write_indented(state)?;
+                state.dedent()?;
+                state.write("}")?;
+
+                state.write("Else {")?;
+                state.indent()?;
+                else_clause.write_indented(state)?;
+                state.dedent()?;
+                state.write("}")?;
+
+                state.dedent()?;
+                state.write("}")
+            }
+
+            (Some(if_clause), None) => {
+                state.write(format_args!("Include(if: ${condition_variable}) {{"))?;
+                state.indent()?;
+
+                if_clause.write_indented(state)?;
+
+                state.dedent()?;
+                state.write("}")
+            }
+
+            (None, Some(else_clause)) => {
+                state.write(format_args!("Skip(if: ${condition_variable}) {{"))?;
+                state.indent()?;
+
+                else_clause.write_indented(state)?;
+
+                state.dedent()?;
+                state.write("}")
+            }
+
+            // Shouldn’t happen?
+            (None, None) => state.write("Condition {}"),
+        }
+    }
+}
+
+impl DeferNode {
+    fn write_indented(&self, state: &mut State<'_, '_>) -> fmt::Result {
+        let Self { primary, deferred } = self;
+        state.write("Defer {")?;
+        state.indent()?;
+
+        primary.write_indented(state)?;
+        if !deferred.is_empty() {
+            state.write(", [")?;
+            write_indented_lines(state, deferred, |state, deferred| {
+                deferred.write_indented(state)
+            })?;
+            state.write("]")?;
+        }
+
+        state.dedent()?;
+        state.write("}")
+    }
+}
+
+impl PrimaryDeferBlock {
+    fn write_indented(&self, state: &mut State<'_, '_>) -> fmt::Result {
+        let Self {
+            sub_selection,
+            node,
+        } = self;
+        state.write("Primary {")?;
+        if sub_selection.is_some() || node.is_some() {
+            state.indent()?;
+
+            if let Some(sub_selection) = sub_selection {
+                state.write(
+                    sub_selection
+                        .serialize()
+                        .initial_indent_level(state.indent_level),
+                )?;
+                if node.is_some() {
+                    state.write(":")?;
+                    state.new_line()?;
+                }
+            }
+            if let Some(node) = node {
+                node.write_indented(state)?;
+            }
+
+            state.dedent()?;
+        }
+        state.write("}")
+    }
+}
+
+impl DeferredDeferBlock {
+    fn write_indented(&self, state: &mut State<'_, '_>) -> fmt::Result {
+        let Self {
+            depends,
+            label,
+            query_path,
+            sub_selection,
+            node,
+        } = self;
+        state.write("Deferred(depends: [")?;
+        if let Some((DeferredDependency { id }, rest)) = depends.split_first() {
+            state.write(id)?;
+            for DeferredDependency { id } in rest {
+                state.write(", ")?;
+                state.write(id)?;
+            }
+        }
+        state.write("], path: \"")?;
+        if let Some((first, rest)) = query_path.split_first() {
+            state.write(first)?;
+            for element in rest {
+                state.write("/")?;
+                state.write(element)?;
+            }
+        }
+        state.write("\"")?;
+        if let Some(label) = label {
+            state.write(", label: \"")?;
+            state.write(label)?;
+            state.write("\"")?;
+        }
+        state.write(") {")?;
+        if sub_selection.is_some() || node.is_some() {
+            state.indent()?;
+
+            if let Some(sub_selection) = sub_selection {
+                write_selections(state, &sub_selection.selections)?;
+            }
+            if let Some(node) = node {
+                node.write_indented(state)?;
+            }
+
+            state.dedent()?;
+        }
+        state.write("}")
+    }
+}
+
+/// When we serialize a query plan, we want to serialize the operation
+/// but not show the root level `query` definition or the `_entities` call.
+/// This function flattens those nodes to only show their selection sets
+fn write_operation(
+    state: &mut State<'_, '_>,
+    operation_document: &ExecutableDocument,
+) -> fmt::Result {
+    let operation = operation_document
+        .get_operation(None)
+        .expect("expected a single-operation document");
+    if operation.operation_type == OperationType::Query {
+        write_selections(state, &operation.selection_set.selections)?
+    } else {
+        state.write(
+            operation
+                .serialize()
+                .initial_indent_level(state.indent_level),
+        )?
+    }
+    for fragment in operation_document.fragments.values() {
+        state.new_line()?;
+        state.write(
+            fragment
+                .serialize()
+                .initial_indent_level(state.indent_level),
+        )?
+    }
+    Ok(())
+}
+
+fn write_selections(
+    state: &mut State<'_, '_>,
+    mut selections: &[executable::Selection],
+) -> fmt::Result {
+    if let Some(executable::Selection::Field(field)) = selections.first() {
+        if field.name == "_entities" {
+            selections = &field.selection_set.selections
+        }
+    }
+    state.write("{")?;
+    write_indented_lines(state, selections, |state, sel| {
+        state.write(sel.serialize().initial_indent_level(state.indent_level))
+    })?;
+    state.write("}")
+}
+
+fn write_indented_lines<T>(
+    state: &mut State<'_, '_>,
+    values: &[T],
+    mut write_line: impl FnMut(&mut State<'_, '_>, &T) -> fmt::Result,
+) -> fmt::Result {
+    if !values.is_empty() {
+        state.indent_no_new_line();
+        for value in values {
+            state.new_line()?;
+            write_line(state, value)?;
+        }
+        state.dedent()?;
+    }
+    Ok(())
+}
+
+impl fmt::Display for FetchDataPathElement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Key(name) => f.write_str(name),
+            Self::AnyIndex => f.write_str("*"),
+            Self::TypenameEquals(name) => write!(f, "... on {name}"),
+        }
+    }
+}
+
+impl fmt::Display for QueryPathElement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Field(field) => f.write_str(field.response_key()),
+            Self::InlineFragment(inline) => {
+                if let Some(cond) = &inline.type_condition {
+                    write!(f, "... on {cond}")
+                } else {
+                    Ok(())
+                }
+            }
+        }
+    }
+}
+
+macro_rules! impl_display {
+    ($( $Ty: ty )+) => {
+        $(
+            impl fmt::Display for $Ty {
+                fn fmt(&self, output: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    self.write_indented(&mut State { indent_level: 0, output })
+                }
+            }
+        )+
+    };
+}
+
+impl_display! {
+    QueryPlan
+    TopLevelPlanNode
+    PlanNode
+    SubscriptionNode
+    FetchNode
+    SequenceNode
+    ParallelNode
+    FlattenNode
+    ConditionNode
+    DeferNode
+    PrimaryDeferBlock
+    DeferredDeferBlock
+}

--- a/src/query_plan/mod.rs
+++ b/src/query_plan/mod.rs
@@ -6,6 +6,7 @@ use apollo_compiler::{ExecutableDocument, NodeStr};
 use std::sync::Arc;
 
 pub(crate) mod conditions;
+mod display;
 pub(crate) mod fetch_dependency_graph;
 pub(crate) mod fetch_dependency_graph_processor;
 pub mod generate;


### PR DESCRIPTION
… and add a `cargo cli plan <query.graphql> <schema.graphql>` CLI subcommand. For now it panics because query planing logic (creating the plan to display) has not yet been entirely ported.

These impls will also be used:

* In snapshot tests to be ported from `buildQueryPlan.test.ts` and `buildPlan*.test.ts`
* In the Router `expose_query_plan` plugin

This new code is **untested**. However, compiler exhaustiveness checks show that it’s mostly there. When snapshot tests start exercising it we can adjust it as needed.