### PR TITLE
Add skeleton CLI tool

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,5 @@
 [alias]
-xtask = "run --package xtask --"
+cli = "run -p apollo-federation-cli --"
 
 # circle seems to install cargo packages via ssh:// rather than https://
 [net]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = [".", "cli"]
+
 [package]
 name = "apollo-federation"
 version = "0.0.9"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Checkout the [Federation 2 docs](https://www.apollographql.com/docs/federation) 
 
 TODO
 
+### CLI tool
+
+`cargo cli --help`
+
 ## Contributing
 
 TODO

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "apollo-federation-cli"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+apollo-federation = { path = ".." }
+clap = { version = "4.5.4", features = ["derive"] }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,0 +1,43 @@
+use clap::Parser;
+use std::fs;
+use std::io;
+use std::path::PathBuf;
+
+/// CLI arguments. See <https://docs.rs/clap/latest/clap/_derive/index.html>
+#[derive(Parser)]
+struct Args {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(clap::Subcommand)]
+enum Command {
+    /// Converts a supergraph schema to the corresponding API schema
+    Api {
+        /// The path to the supegraph schema file, or `-` for stdin
+        supegraph_schema: PathBuf,
+    },
+}
+
+fn main() {
+    let args = Args::parse();
+    match args.command {
+        Command::Api { supegraph_schema } => to_api_schema(supegraph_schema),
+    }
+}
+
+fn to_api_schema(input_path: PathBuf) {
+    let input = if input_path == std::path::Path::new("-") {
+        io::read_to_string(io::stdin()).unwrap()
+    } else {
+        fs::read_to_string(input_path).unwrap()
+    };
+    let supergraph = apollo_federation::Supergraph::new(&input).unwrap();
+    let api_schema = supergraph
+        .to_api_schema(apollo_federation::ApiSchemaOptions {
+            include_defer: true,
+            include_stream: false,
+        })
+        .unwrap();
+    println!("{}", api_schema.schema())
+}


### PR DESCRIPTION
Example usage: `cargo cli api ../router/examples/graphql/supergraph.graphql`

This executable is intended to be the successor of https://github.com/apollographql/composer-tool. Initially it has a single `api` subcommand that converts a supergraph schema to its corresponding API schema. (Error handling can be improved.)

The CLI is a separate crate so that the library crate does not need to depend on `clap`. See https://blog.axo.dev/2024/03/its-a-lib-and-a-bin