### PR TITLE
Ported the GraphViz `dot`-format output for query graphs

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -80,7 +80,7 @@ fn load_supergraph(
             .iter()
             .map(|pathname| {
                 let doc_str = std::fs::read_to_string(pathname).unwrap();
-                let url = "file://".to_string() + pathname.to_str().unwrap();
+                let url = format!("file://{}", pathname.to_str().unwrap());
                 let basename = pathname.file_stem().unwrap().to_str().unwrap();
                 subgraph::Subgraph::parse_and_expand(basename, &url, &doc_str).unwrap()
             })

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,6 +2,11 @@ use clap::Parser;
 use std::fs;
 use std::io;
 use std::path::PathBuf;
+use std::process::ExitCode;
+
+use apollo_federation::error::FederationError;
+use apollo_federation::query_graph;
+use apollo_federation::subgraph;
 
 /// CLI arguments. See <https://docs.rs/clap/latest/clap/_derive/index.html>
 #[derive(Parser)]
@@ -17,27 +22,98 @@ enum Command {
         /// The path to the supegraph schema file, or `-` for stdin
         supegraph_schema: PathBuf,
     },
+    /// Outputs the query graph from a supergraph schema or subgraph schemas
+    QueryGraph {
+        /// Path(s) to one supergraph schema file or multiple subgraph schemas.
+        schemas: Vec<PathBuf>,
+    },
+    /// Outputs the federated query graph from a supergraph schema or subgraph schemas
+    FederatedGraph {
+        /// Path(s) to one supergraph schema file or multiple subgraph schemas.
+        schemas: Vec<PathBuf>,
+    },
 }
 
-fn main() {
+fn main() -> ExitCode {
     let args = Args::parse();
     match args.command {
-        Command::Api { supegraph_schema } => to_api_schema(supegraph_schema),
+        Command::Api { supegraph_schema } =>
+            run_federation_task( &|| { to_api_schema(&supegraph_schema) } ),
+        Command::QueryGraph { schemas } => {
+            run_federation_task( &|| { dot_query_graph(&schemas) } )
+        },
+        Command::FederatedGraph { schemas } => {
+            run_federation_task( &|| { dot_federated_graph(&schemas) } )
+        },
     }
 }
 
-fn to_api_schema(input_path: PathBuf) {
+fn run_federation_task( func: &dyn Fn() -> Result<(), FederationError> ) -> ExitCode {
+    match func() {
+        Err(error) => {
+            eprintln!("{error}");
+            ExitCode::FAILURE
+        },
+
+        Ok(_) => {
+            ExitCode::SUCCESS
+        }
+    }
+}
+
+fn to_api_schema(input_path: &PathBuf) -> Result<(), FederationError> {
     let input = if input_path == std::path::Path::new("-") {
         io::read_to_string(io::stdin()).unwrap()
     } else {
         fs::read_to_string(input_path).unwrap()
     };
-    let supergraph = apollo_federation::Supergraph::new(&input).unwrap();
+    let supergraph = apollo_federation::Supergraph::new(&input)?;
     let api_schema = supergraph
         .to_api_schema(apollo_federation::ApiSchemaOptions {
             include_defer: true,
             include_stream: false,
-        })
-        .unwrap();
-    println!("{}", api_schema.schema())
+        })?;
+    println!("{}", api_schema.schema());
+    Ok(())
+}
+
+/// Load either single supergraph schema file or compose one from multiple subgraph files.
+fn load_supergraph(file_paths: &Vec<PathBuf>) -> Result<apollo_federation::Supergraph, FederationError> {
+    if file_paths.len() == 0 {
+        panic!("Error: missing command arguments");
+    }
+    else if file_paths.len() == 1 {
+        let doc_str = std::fs::read_to_string(&file_paths[0]).unwrap();
+        apollo_federation::Supergraph::new(&doc_str)
+    }
+    else {
+        let schemas: Vec<_>
+            = file_paths.iter().map(|pathname| {
+                let doc_str = std::fs::read_to_string(&pathname).unwrap();
+                let url = "file://".to_string() + pathname.to_str().unwrap();
+                let basename = pathname.file_stem().unwrap().to_str().unwrap();
+                subgraph::Subgraph::parse_and_expand(basename, &url, &doc_str).unwrap()
+            }).collect();
+        Ok(apollo_federation::Supergraph::compose(schemas.iter().collect()).unwrap())
+    }
+}
+
+fn dot_query_graph(file_paths: &Vec<PathBuf>) -> Result<(), FederationError> {
+    let supergraph = load_supergraph(file_paths)?;
+    let name : &str = if file_paths.len() == 1 {
+                        file_paths[0].file_stem().unwrap().to_str().unwrap()
+                      } else {
+                        "supergraph"
+                      };
+    let query_graph = query_graph::build_query_graph::build_query_graph(name.into(), supergraph.schema)?;
+    println!("{}", query_graph::output::to_dot(&query_graph));
+    Ok(())
+}
+
+fn dot_federated_graph(file_paths: &Vec<PathBuf>) -> Result<(), FederationError> {
+    let supergraph = load_supergraph(file_paths)?;
+    let api_schema = supergraph.to_api_schema(Default::default())?;
+    let query_graph = query_graph::build_federated_query_graph(supergraph.schema, api_schema, None, None)?;
+    println!("{}", query_graph::output::to_dot(&query_graph));
+    Ok(())
 }

--- a/src/query_graph/mod.rs
+++ b/src/query_graph/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod extract_subgraphs_from_supergraph;
 mod field_set;
 pub(crate) mod graph_path;
 pub(crate) mod path_tree;
+pub mod output;
 
 pub use build_query_graph::build_federated_query_graph;
 

--- a/src/query_graph/mod.rs
+++ b/src/query_graph/mod.rs
@@ -22,8 +22,8 @@ pub(crate) mod condition_resolver;
 pub(crate) mod extract_subgraphs_from_supergraph;
 mod field_set;
 pub(crate) mod graph_path;
-pub(crate) mod path_tree;
 pub mod output;
+pub(crate) mod path_tree;
 
 pub use build_query_graph::build_federated_query_graph;
 

--- a/src/query_graph/output.rs
+++ b/src/query_graph/output.rs
@@ -104,7 +104,7 @@ fn to_dot_federated(graph: &QueryGraph) -> String {
     for i in stable_graph.node_indices() {
         let node = &stable_graph[i];
         if node.source == graph.name() {
-            dot_str.push_str(&format!("  {} [{}]\n", i.index(), label_node(&node)));
+            dot_str.push_str(&format!("  {} [{}]\n", i.index(), label_node(node)));
         }
     }
 
@@ -119,6 +119,6 @@ fn to_dot_federated(graph: &QueryGraph) -> String {
         }
     }
 
-    dot_str.push_str("}");
+    dot_str.push('}');
     dot_str
 }

--- a/src/query_graph/output.rs
+++ b/src/query_graph/output.rs
@@ -1,13 +1,11 @@
 // Output module for query graphs
 // - Corresponds to the `graphviz` and `mermaid` modules from the JS federation.
 
+use crate::query_graph::{QueryGraph, QueryGraphEdge, QueryGraphNode};
 use apollo_compiler::NodeStr;
-use crate::query_graph::{
-    QueryGraph, QueryGraphNode, QueryGraphEdge,
-};
+use petgraph::dot::{Config, Dot};
 use petgraph::graph::{DiGraph, EdgeIndex};
 use petgraph::stable_graph::StableGraph;
-use petgraph::dot::{Dot, Config};
 
 type InnerGraph = DiGraph<QueryGraphNode, QueryGraphEdge>;
 type StableInnerGraph = StableGraph<QueryGraphNode, QueryGraphEdge>;
@@ -19,8 +17,7 @@ fn label_edge(edge: &QueryGraphEdge) -> String {
     let label = edge.to_string();
     if label.is_empty() {
         String::new()
-    }
-    else {
+    } else {
         format!("label=\"{}\"", edge)
     }
 }
@@ -31,38 +28,41 @@ fn label_node(node: &QueryGraphNode) -> String {
 
 pub fn to_dot(graph: &QueryGraph) -> String {
     if graph.sources.len() > 1 {
-        return to_dot_federated(graph)
+        return to_dot_federated(graph);
     }
 
     // Note: Use label_edge/label_node as `attr_getters` in order to create custom label
     //       strings, instead of the default labeling.
     let config = [Config::NodeNoLabel, Config::EdgeNoLabel];
-    Dot::with_attr_getters( &graph.graph, &config
-                          , &(|_, er| label_edge(er.weight()))
-                          , &(|_, (_, node)| label_node(node))
-                          ).to_string()
+    Dot::with_attr_getters(
+        &graph.graph,
+        &config,
+        &(|_, er| label_edge(er.weight())),
+        &(|_, (_, node)| label_node(node)),
+    )
+    .to_string()
 }
 
 fn to_dot_federated(graph: &QueryGraph) -> String {
-
-    fn edge_within_cluster( graph: &StableInnerGraph, cluster_name: &NodeStr, edge_index: EdgeIndex ) -> bool {
+    fn edge_within_cluster(
+        graph: &StableInnerGraph,
+        cluster_name: &NodeStr,
+        edge_index: EdgeIndex,
+    ) -> bool {
         match graph.edge_endpoints(edge_index) {
             None => false,
 
             Some((n1, n2)) => {
-                graph[n1].source == *cluster_name
-                && graph[n2].source == *cluster_name
+                graph[n1].source == *cluster_name && graph[n2].source == *cluster_name
             }
         }
     }
 
-    fn edge_across_clusters( graph: &StableInnerGraph, edge_index: EdgeIndex ) -> bool {
+    fn edge_across_clusters(graph: &StableInnerGraph, edge_index: EdgeIndex) -> bool {
         match graph.edge_endpoints(edge_index) {
             None => false,
 
-            Some((n1, n2)) => {
-                graph[n1].source != graph[n2].source
-            }
+            Some((n1, n2)) => graph[n1].source != graph[n2].source,
         }
     }
 
@@ -72,28 +72,49 @@ fn to_dot_federated(graph: &QueryGraph) -> String {
 
     // Build a stable graph, so we can derive subgraph clusters with the same indices.
     let stable_graph = StableGraph::from(graph.graph.clone());
-    let cluster_dot_config = [Config::NodeNoLabel, Config::EdgeNoLabel, Config::GraphContentOnly];
+    let cluster_dot_config = [
+        Config::NodeNoLabel,
+        Config::EdgeNoLabel,
+        Config::GraphContentOnly,
+    ];
 
-    let mut dot_str : String = format!("digraph \"{}\" {{\n", graph.name());
+    let mut dot_str: String = format!("digraph \"{}\" {{\n", graph.name());
 
     // Subgraph clusters
-    for (cluster_name,_) in graph.sources.iter() {
+    for (cluster_name, _) in graph.sources.iter() {
         if cluster_name == graph.name() {
             continue; // skip non-subgraph nodes
         }
 
-        let filtered_graph : StableInnerGraph
-            = stable_graph.filter_map(
-                |_i, n| if n.source == *cluster_name {Some(n.clone())} else {None},
-                |i, e| if edge_within_cluster(&stable_graph, cluster_name, i) {Some(e.clone())} else {None}
-            );
-        let s = Dot::with_attr_getters( &filtered_graph, &cluster_dot_config
-                                      , &(|_, er| label_edge(er.weight()))
-                                      , &(|_, (_, node)| label_cluster_node(node))
-                                     ).to_string();
+        let filtered_graph: StableInnerGraph = stable_graph.filter_map(
+            |_i, n| {
+                if n.source == *cluster_name {
+                    Some(n.clone())
+                } else {
+                    None
+                }
+            },
+            |i, e| {
+                if edge_within_cluster(&stable_graph, cluster_name, i) {
+                    Some(e.clone())
+                } else {
+                    None
+                }
+            },
+        );
+        let s = Dot::with_attr_getters(
+            &filtered_graph,
+            &cluster_dot_config,
+            &(|_, er| label_edge(er.weight())),
+            &(|_, (_, node)| label_cluster_node(node)),
+        )
+        .to_string();
 
         dot_str.push_str(&format!("  subgraph \"cluster_{}\" {{\n", &cluster_name));
-        dot_str.push_str(&format!("    label = \"Subgraph \\\"{}\\\"\";\n", &cluster_name));
+        dot_str.push_str(&format!(
+            "    label = \"Subgraph \\\"{}\\\"\";\n",
+            &cluster_name
+        ));
         dot_str.push_str("    color = \"black;\"\n");
         dot_str.push_str("    style = \"\"\n");
         dot_str.push_str(&s);
@@ -109,12 +130,16 @@ fn to_dot_federated(graph: &QueryGraph) -> String {
     }
 
     // Supergraph edges
-    for i in stable_graph.edge_indices()
-    {
+    for i in stable_graph.edge_indices() {
         if edge_across_clusters(&stable_graph, i) {
             if let Some((n1, n2)) = stable_graph.edge_endpoints(i) {
                 let edge = &stable_graph[i];
-                dot_str.push_str(&format!("  {} -> {} [{}]\n", n1.index(), n2.index(), label_edge(edge)));
+                dot_str.push_str(&format!(
+                    "  {} -> {} [{}]\n",
+                    n1.index(),
+                    n2.index(),
+                    label_edge(edge)
+                ));
             }
         }
     }

--- a/src/query_graph/output.rs
+++ b/src/query_graph/output.rs
@@ -1,0 +1,124 @@
+// Output module for query graphs
+// - Corresponds to the `graphviz` and `mermaid` modules from the JS federation.
+
+use apollo_compiler::NodeStr;
+use crate::query_graph::{
+    QueryGraph, QueryGraphNode, QueryGraphEdge,
+};
+use petgraph::graph::{DiGraph, EdgeIndex};
+use petgraph::stable_graph::StableGraph;
+use petgraph::dot::{Dot, Config};
+
+type InnerGraph = DiGraph<QueryGraphNode, QueryGraphEdge>;
+type StableInnerGraph = StableGraph<QueryGraphNode, QueryGraphEdge>;
+
+//////////////////////////////////////////////////////////////////////////////
+// GraphViz output for QueryGraph
+
+fn label_edge(edge: &QueryGraphEdge) -> String {
+    let label = edge.to_string();
+    if label.is_empty() {
+        String::new()
+    }
+    else {
+        format!("label=\"{}\"", edge)
+    }
+}
+
+fn label_node(node: &QueryGraphNode) -> String {
+    format!("label=\"{}\"", node.type_)
+}
+
+pub fn to_dot(graph: &QueryGraph) -> String {
+    if graph.sources.len() > 1 {
+        return to_dot_federated(graph)
+    }
+
+    // Note: Use label_edge/label_node as `attr_getters` in order to create custom label
+    //       strings, instead of the default labeling.
+    let config = [Config::NodeNoLabel, Config::EdgeNoLabel];
+    Dot::with_attr_getters( &graph.graph, &config
+                          , &(|_, er| label_edge(er.weight()))
+                          , &(|_, (_, node)| label_node(node))
+                          ).to_string()
+}
+
+fn to_dot_federated(graph: &QueryGraph) -> String {
+
+    fn edge_within_cluster( graph: &StableInnerGraph, cluster_name: &NodeStr, edge_index: EdgeIndex ) -> bool {
+        match graph.edge_endpoints(edge_index) {
+            None => false,
+
+            Some((n1, n2)) => {
+                graph[n1].source == *cluster_name
+                && graph[n2].source == *cluster_name
+            }
+        }
+    }
+
+    fn edge_across_clusters( graph: &StableInnerGraph, edge_index: EdgeIndex ) -> bool {
+        match graph.edge_endpoints(edge_index) {
+            None => false,
+
+            Some((n1, n2)) => {
+                graph[n1].source != graph[n2].source
+            }
+        }
+    }
+
+    fn label_cluster_node(node: &QueryGraphNode) -> String {
+        format!("label=\"{}@{}\"", node.type_, node.source)
+    }
+
+    // Build a stable graph, so we can derive subgraph clusters with the same indices.
+    let stable_graph = StableGraph::from(graph.graph.clone());
+    let cluster_dot_config = [Config::NodeNoLabel, Config::EdgeNoLabel, Config::GraphContentOnly];
+
+    let mut dot_str : String = format!("digraph \"{}\" {{\n", graph.name());
+
+    // Subgraph clusters
+    for (cluster_name,_) in graph.sources.iter() {
+        if cluster_name == graph.name() {
+            continue; // skip non-subgraph nodes
+        }
+
+        let filtered_graph : StableInnerGraph
+            = stable_graph.filter_map(
+                |_i, n| if n.source == *cluster_name {Some(n.clone())} else {None},
+                |i, e| if edge_within_cluster(&stable_graph, cluster_name, i) {Some(e.clone())} else {None}
+            );
+        let s = Dot::with_attr_getters( &filtered_graph, &cluster_dot_config
+                                      , &(|_, er| label_edge(er.weight()))
+                                      , &(|_, (_, node)| label_cluster_node(node))
+                                     ).to_string();
+
+        dot_str.push_str(&format!("  subgraph \"cluster_{}\" {{\n", &cluster_name));
+        dot_str.push_str(&format!("    label = \"Subgraph \\\"{}\\\"\";\n", &cluster_name));
+        dot_str.push_str("    color = \"black;\"\n");
+        dot_str.push_str("    style = \"\"\n");
+        dot_str.push_str(&s);
+        dot_str.push_str("  }\n");
+    }
+
+    // Supergraph nodes
+    for i in stable_graph.node_indices() {
+        let node = &stable_graph[i];
+        if node.source == graph.name() {
+            dot_str.push_str(&format!("  {} [{}]\n", i.index(), label_node(&node)));
+        }
+    }
+
+    // Supergraph edges
+    for i in stable_graph.edge_indices()
+    {
+        if edge_across_clusters(&stable_graph, i) {
+            if let Some((n1, n2)) = stable_graph.edge_endpoints(i) {
+                let edge = &stable_graph[i];
+                dot_str.push_str(&format!("  {} -> {} [{}]\n", n1.index(), n2.index(), label_edge(edge)));
+            }
+        }
+    }
+
+    dot_str.push_str("}");
+    dot_str
+}


### PR DESCRIPTION
added query_graph::output::to_dot function
- outputs query graphs in the GraphViz Dot format
- supports both federated schemas and non-federated ones
