### PR TITLE
Ported maybe_dump_subgraph_schema from JS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ autotests = false                                               # Integration te
 
 [dependencies]
 apollo-compiler = "=1.0.0-beta.14"
+chrono = { version = "0.4.37", default-features = false, features = ["clock"] }
 derive_more = "0.99.17"
 indexmap = "2.1.0"
 lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ autotests = false                                               # Integration te
 
 [dependencies]
 apollo-compiler = "=1.0.0-beta.14"
-chrono = { version = "0.4.37", default-features = false, features = ["clock"] }
+time = { version = "0.3.34", default-features = false, features = ["local-offset"] }
 derive_more = "0.99.17"
 indexmap = "2.1.0"
 lazy_static = "1.4.0"

--- a/src/query_graph/extract_subgraphs_from_supergraph.rs
+++ b/src/query_graph/extract_subgraphs_from_supergraph.rs
@@ -35,6 +35,7 @@ use std::fmt;
 use std::fmt::Write;
 use std::ops::Deref;
 use std::sync::Arc;
+use time::OffsetDateTime;
 
 /// Assumes the given schema has been validated.
 ///
@@ -2054,10 +2055,8 @@ fn maybe_dump_subgraph_schema(subgraph: FederationSubgraph, message: &mut String
             return;
         }
     }
-    let filename = match time::OffsetDateTime::now_local() {
-        Ok(time) => format!("extracted-subgraph-{}-{time}.graphql", subgraph.name,),
-        Err(_) => format!("extracted-subgraph-{}.graphql", subgraph.name,),
-    };
+    let time = OffsetDateTime::now_local().unwrap_or_else(|_| OffsetDateTime::now_utc());
+    let filename = format!("extracted-subgraph-{}-{time}.graphql", subgraph.name,);
     let contents = format!("{}", subgraph.schema.schema());
     _ = match std::fs::write(&filename, contents) {
         Ok(_) => write!(

--- a/src/query_graph/extract_subgraphs_from_supergraph.rs
+++ b/src/query_graph/extract_subgraphs_from_supergraph.rs
@@ -2050,8 +2050,12 @@ fn maybe_dump_subgraph_schema(subgraph: FederationSubgraph, message: &mut String
         let _ = write!(message, "Re-run with environment variable '{DEBUG_SUBGRAPHS_ENV_VARIABLE_NAME}' set to 'true' to extract the invalid subgraph");
         return;
     }
-    let filename = format!("extracted-subgraph-{}.graphql", subgraph.name);
-    let contents = format!("{:?}", subgraph.schema);
+    let filename = format!(
+        "extracted-subgraph-{}-{}.graphql",
+        subgraph.name,
+        chrono::Local::now()
+    );
+    let contents = format!("{}", subgraph.schema.schema());
     let _ = match std::fs::write(&filename, contents) {
         Ok(_) => write!(
             message,


### PR DESCRIPTION
This PR addresses Jira ticket FED-53.

This method, ported from JS, appends additional information to error messages when attempting to extract subgraphs from a supergraph. Users can also set the environment variable `APOLLO_FEDERATION_DEBUG_SUBGRAPHS` to have the schema written to a file.