### PR TITLE
parse_field_set: forbid aliases

### DIFF
--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -488,10 +488,10 @@ impl FederationError {
     }
 }
 
-// Converts a SingleFederationError array into `Result<(), FederationError>`.
+// Converts a SingleFederationError slice into `Result<(), FederationError>`.
 // The return value can be either Ok, Err with a SingleFederationError or MultipleFederationErrors,
 // depending on the number of errors in the input.
-pub(crate) fn check_federation_errors(
+fn convert_single_errors_to_result(
     errors: &[SingleFederationError],
 ) -> Result<(), FederationError> {
     match errors.len().cmp(&1) {
@@ -501,6 +501,19 @@ pub(crate) fn check_federation_errors(
             errors: errors.to_vec(),
         }
         .into()),
+    }
+}
+
+impl FromIterator<SingleFederationError> for Result<(), FederationError> {
+    fn from_iter<T: IntoIterator<Item = SingleFederationError>>(iter: T) -> Self {
+        let errors: Vec<_> = iter.into_iter().collect();
+        convert_single_errors_to_result(&errors)
+    }
+}
+
+impl MultipleFederationErrors {
+    pub fn to_result(&self) -> Result<(), FederationError> {
+        convert_single_errors_to_result(&self.errors)
     }
 }
 

--- a/src/query_graph/field_set.rs
+++ b/src/query_graph/field_set.rs
@@ -1,4 +1,4 @@
-use crate::error::{FederationError, SingleFederationError};
+use crate::error::{FederationError, MultipleFederationErrors, SingleFederationError};
 use crate::query_plan::operation::{FragmentSpreadNormalizationOption, NormalizedSelectionSet};
 use crate::schema::ValidFederationSchema;
 use apollo_compiler::executable::{FieldSet, SelectionSet};
@@ -14,7 +14,7 @@ fn check_absence_of_aliases(
     field_set: &Valid<FieldSet>,
     code_str: &NodeStr,
 ) -> Result<(), FederationError> {
-    field_set.selection_set.fields().filter_map(|field| {
+    let aliases = field_set.selection_set.fields().filter_map(|field| {
         field.alias.as_ref().map(|alias|
             SingleFederationError::UnsupportedFeature {
                 // PORT_NOTE: The JS version also quotes the directive name in the error message.
@@ -23,7 +23,8 @@ fn check_absence_of_aliases(
                     r#"Cannot use alias "{}" in "{}": aliases are not currently supported in the used directive"#,
                     alias, code_str)
             })
-    }).collect()
+    });
+    MultipleFederationErrors::from_iter(aliases).into_result()
 }
 
 // TODO: In the JS codebase, this has some error-rewriting to help give the user better hints around

--- a/src/query_graph/field_set.rs
+++ b/src/query_graph/field_set.rs
@@ -1,4 +1,4 @@
-use crate::error::{check_federation_errors, FederationError, SingleFederationError};
+use crate::error::{FederationError, SingleFederationError};
 use crate::query_plan::operation::{FragmentSpreadNormalizationOption, NormalizedSelectionSet};
 use crate::schema::ValidFederationSchema;
 use apollo_compiler::executable::{FieldSet, SelectionSet};
@@ -14,7 +14,7 @@ fn check_absence_of_aliases(
     field_set: &Valid<FieldSet>,
     code_str: &NodeStr,
 ) -> Result<(), FederationError> {
-    let alias_errors: Vec<_> = field_set.selection_set.fields().filter_map(|field| {
+    field_set.selection_set.fields().filter_map(|field| {
         field.alias.as_ref().map(|alias|
             SingleFederationError::UnsupportedFeature {
                 // PORT_NOTE: The JS version also quotes the directive name in the error message.
@@ -23,8 +23,7 @@ fn check_absence_of_aliases(
                     r#"Cannot use alias "{}" in "{}": aliases are not currently supported in the used directive"#,
                     alias, code_str)
             })
-    }).collect();
-    check_federation_errors(&alias_errors)
+    }).collect()
 }
 
 // TODO: In the JS codebase, this has some error-rewriting to help give the user better hints around


### PR DESCRIPTION
Added a check for the absence of aliases in field set directive arguments.

### Rationale

Federation-next uses the apollo-compiler to parse the field-set argument string as GraphQL code. Similarly, the JS federation uses graphql-js to parse it. Both GraphQL parsers allow aliases in it, while federation does not allow it. That’s why the JS federation looks for aliases after parsing it. I think it makes sense to do the same thing in the Rust implementation so we don’t need to make changes in the apollo-compiler itself.

### Side note

I did not attempt to make our error message to match exactly with the JS implementation. First of all, it's not necessary for unblocking QP work, while improving error messages will require further refactoring elsewhere. We might want to revisit the whole error message business later when we get to composition porting.