### PR TITLE
deps: update apollo-compiler to 1.0.0-beta.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "Elastic-2.0"
 autotests = false                                               # Integration tests are modules of tests/main.rs
 
 [dependencies]
-apollo-compiler = "=1.0.0-beta.14"
+apollo-compiler = "=1.0.0-beta.15"
 time = { version = "0.3.34", default-features = false, features = ["local-offset"] }
 derive_more = "0.99.17"
 indexmap = "2.1.0"


### PR DESCRIPTION
Adds a validation rule that's especially useful for synthetic schemas (types must have at least 1 field) and a serialization feature for #244.