### PR TITLE
Expose subgraphs schemas to crate consumers

### DIFF
--- a/src/query_graph/mod.rs
+++ b/src/query_graph/mod.rs
@@ -231,7 +231,7 @@ pub struct QueryGraph {
     /// The sources on which the query graph was built, which is a set (potentially of size 1) of
     /// GraphQL schema keyed by the name identifying them. Note that the `source` strings in the
     /// nodes/edges of a query graph are guaranteed to be valid key in this map.
-    sources: IndexMap<NodeStr, ValidFederationSchema>,
+    pub(crate) sources: IndexMap<NodeStr, ValidFederationSchema>,
     /// A map (keyed by source) that associates type names of the underlying schema on which this
     /// query graph was built to each of the nodes that points to a type of that name. Note that for
     /// a "federated" query graph source, each type name will only map to a single node.

--- a/src/query_plan/query_planner.rs
+++ b/src/query_plan/query_planner.rs
@@ -254,6 +254,10 @@ impl QueryPlanner {
         })
     }
 
+    pub fn subgraph_schemas(&self) -> &IndexMap<NodeStr, ValidFederationSchema> {
+        &self.federated_query_graph.sources
+    }
+
     // PORT_NOTE: this receives an `Operation` object in JS which is a concept that doesn't exist in apollo-rs.
     pub fn build_query_plan(
         &self,


### PR DESCRIPTION
This is to be used in Router integration