### PR TITLE
Prepare 0.0.11 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,24 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 ## Documentation-->
 
+# [0.0.11](https://crates.io/crates/apollo-federation/0.0.11) - 2024-04-12
+
 # [0.0.10](https://crates.io/crates/apollo-federation/0.0.10) - 2024-04-09
+
+## Fixes
+- Forbid aliases in `@requires(fields:)` / `@key(fields:)` argument, by [duckki] in [pull/251]
+
+## Features
+- Expose subgraphs schemas to crate consumers, by [SimonSapin] in [pull/257]
+
+## Maintenance
+- Update `apollo-compiler`, by [goto-bus-stop]
+
+[duckki]: https://github.com/duckki
+[goto-bus-stop]: https://github.com/goto-bus-stop
+[SimonSapin]: https://github.com/SimonSapin
+[pull/251]: https://github.com/apollographql/federation-next/pull/251
+[pull/257]: https://github.com/apollographql/federation-next/pull/257
 
 ## Features
 - Query plan changes for initial router integration, by [SimonSapin] in [pull/240]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 # [0.0.11](https://crates.io/crates/apollo-federation/0.0.11) - 2024-04-12
 
-# [0.0.10](https://crates.io/crates/apollo-federation/0.0.10) - 2024-04-09
-
 ## Fixes
 - Forbid aliases in `@requires(fields:)` / `@key(fields:)` argument, by [duckki] in [pull/251]
 
@@ -35,6 +33,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 [SimonSapin]: https://github.com/SimonSapin
 [pull/251]: https://github.com/apollographql/federation-next/pull/251
 [pull/257]: https://github.com/apollographql/federation-next/pull/257
+
+# [0.0.10](https://crates.io/crates/apollo-federation/0.0.10) - 2024-04-09
 
 ## Features
 - Query plan changes for initial router integration, by [SimonSapin] in [pull/240]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "cli"]
 
 [package]
 name = "apollo-federation"
-version = "0.0.10"
+version = "0.0.11"
 authors = ["The Apollo GraphQL Contributors"]
 edition = "2021"
 description = "Apollo Federation"


### PR DESCRIPTION
- apollo-compiler update to release rust-only validation in router;
- #257 to support QP integration in router.