### PR TITLE
Ported anImplementationIsEntityWithFieldShareable from JS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub use crate::query_graph::extract_subgraphs_from_supergraph::ValidFederationSu
 use crate::schema::ValidFederationSchema;
 use crate::subgraph::ValidSubgraph;
 use apollo_compiler::validation::Valid;
+use apollo_compiler::NodeStr;
 use apollo_compiler::Schema;
 use link::join_spec_definition::JOIN_VERSIONS;
 use schema::FederationSchema;
@@ -128,3 +129,8 @@ const _: () = {
     assert_thread_safe::<Supergraph>();
     assert_thread_safe::<query_plan::query_planner::QueryPlanner>();
 };
+
+/// Returns if the type of the node is a scalar or enum.
+pub(crate) fn is_leaf_type(schema: &Schema, ty: &NodeStr) -> bool {
+    schema.get_scalar(ty).is_some() || schema.get_enum(ty).is_some()
+}

--- a/src/query_graph/graph_path.rs
+++ b/src/query_graph/graph_path.rs
@@ -25,7 +25,7 @@ use crate::schema::position::{
 use crate::schema::ValidFederationSchema;
 use apollo_compiler::ast::Value;
 use apollo_compiler::executable::DirectiveList;
-use apollo_compiler::schema::{ExtendedType, Name, NamedType};
+use apollo_compiler::schema::{ExtendedType, Name};
 use apollo_compiler::NodeStr;
 use indexmap::{IndexMap, IndexSet};
 use petgraph::graph::{EdgeIndex, NodeIndex};
@@ -2140,10 +2140,8 @@ impl OpGraphPath {
                 }
                 let field_ty = field.ty.inner_named_type();
                 if field_ty != base_ty_name
-                    || schema
-                        .get_object(field_ty)
-                        .or_else(|| schema.get_interface(field_ty))
-                        .is_none()
+                    || !(schema.get_object(field_ty).is_some()
+                        || schema.get_interface(field_ty).is_some())
                 {
                     // We have a genuine difference here, so we should explore type explosion.
                     return Ok(true);

--- a/src/query_graph/graph_path.rs
+++ b/src/query_graph/graph_path.rs
@@ -2139,11 +2139,7 @@ impl OpGraphPath {
                 let Some(field) = other_fields.get(&itf.field_name) else {
                     continue;
                 };
-                if field
-                    .directives
-                    .iter()
-                    .any(|d| d.name == shareable_directive.name)
-                {
+                if !field.directives.has(&shareable_directive.name) {
                     continue;
                 }
                 let field_ty = field.ty.inner_named_type();

--- a/src/query_graph/graph_path.rs
+++ b/src/query_graph/graph_path.rs
@@ -2066,7 +2066,7 @@ impl OpGraphPath {
         _source: &NodeStr,
         itf: InterfaceFieldDefinitionPosition,
     ) -> Result<bool, FederationError> {
-        if self.graph.schema()?.0.metadata().is_none() {
+        if self.graph.schema()?.metadata().is_none() {
             return Err(FederationError::internal(
                 "Interface should have come from a federation subgraph",
             ));

--- a/src/query_graph/graph_path.rs
+++ b/src/query_graph/graph_path.rs
@@ -2130,8 +2130,9 @@ impl OpGraphPath {
                                 )))
                             }
                         };
-                        let Some((_, field)) = fields.clone().find(|f| f.0 == &itf.field_name) else {
-                            continue
+                        let Some((_, field)) = fields.clone().find(|f| f.0 == &itf.field_name)
+                        else {
+                            continue;
                         };
                         if field.directives.iter().any(|d| d.name == "shareable") {
                             continue;

--- a/src/query_graph/mod.rs
+++ b/src/query_graph/mod.rs
@@ -355,11 +355,11 @@ impl QueryGraph {
     pub(crate) fn nodes_for_type<'c, 'b: 'c, 'a: 'c>(
         &'a self,
         name: &'b Name,
-    ) -> impl 'c + Iterator<Item = &'a NodeIndex> {
+    ) -> impl 'c + Iterator<Item = NodeIndex> {
         self.types_to_nodes_by_source
             .values()
             .filter_map(|tys| tys.get(name))
-            .flat_map(|vs| vs.iter())
+            .flat_map(|vs| vs.iter().cloned())
     }
 
     pub(crate) fn types_to_nodes(

--- a/src/query_graph/mod.rs
+++ b/src/query_graph/mod.rs
@@ -352,9 +352,11 @@ impl QueryGraph {
     }
 
     /// Returns an iterator over of node indices whose name matches the given type name.
-    pub(crate) fn nodes_for_type<'c, 'b: 'c, 'a: 'c>(&'a self, name: &'b Name) -> impl 'c + Iterator<Item = &'a NodeIndex> {
-        self
-            .types_to_nodes_by_source
+    pub(crate) fn nodes_for_type<'c, 'b: 'c, 'a: 'c>(
+        &'a self,
+        name: &'b Name,
+    ) -> impl 'c + Iterator<Item = &'a NodeIndex> {
+        self.types_to_nodes_by_source
             .values()
             .filter_map(|tys| tys.get(name))
             .flat_map(|vs| vs.iter())

--- a/src/query_graph/mod.rs
+++ b/src/query_graph/mod.rs
@@ -351,6 +351,15 @@ impl QueryGraph {
         self.sources.iter()
     }
 
+    /// Returns an iterator over of node indices whose name matches the given type name.
+    pub(crate) fn nodes_for_type<'c, 'b: 'c, 'a: 'c>(&'a self, name: &'b Name) -> impl 'c + Iterator<Item = &'a NodeIndex> {
+        self
+            .types_to_nodes_by_source
+            .values()
+            .filter_map(|tys| tys.get(name))
+            .flat_map(|vs| vs.iter())
+    }
+
     pub(crate) fn types_to_nodes(
         &self,
     ) -> Result<&IndexMap<NamedType, IndexSet<NodeIndex>>, FederationError> {


### PR DESCRIPTION
This PR addresses FED-33 and is a port of [`anImplementationIsEntityWithFieldShareable`](https://github.com/apollographql/federation/blob/main/query-graphs-js/src/graphPath.ts#L2279).

There are a number of differences between how the JS code and Rust code represent query graphs, graph paths, nodes, and edges. The original source code is linked above. I tried to keep everything one-to-one, but there is one thing that seems to not be needed: the `baseType` function. This is called a few times in the original JS code, but I was unable to find a translation for it.