### PR TITLE
Implement FetchDependencyGraph processor traversal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ time = { version = "0.3.34", default-features = false, features = [
 derive_more = "0.99.17"
 indexmap = "2.1.0"
 lazy_static = "1.4.0"
+multimap = "0.10.0"
 petgraph = "0.6.4"
 serde_json_bytes = "0.2.2"
 strum = "0.26.0"

--- a/src/query_graph/graph_path.rs
+++ b/src/query_graph/graph_path.rs
@@ -30,7 +30,6 @@ use indexmap::IndexSet;
 use petgraph::graph::{EdgeIndex, NodeIndex};
 use petgraph::visit::EdgeRef;
 use std::cmp::Ordering;
-use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
 use std::hash::Hash;
 use std::ops::Deref;
@@ -2418,13 +2417,17 @@ impl SimultaneousPathsWithLazyIndirectPaths {
 
 // PORT_NOTE: JS passes a ConditionResolver here, we do not: see port note for
 // `SimultaneousPathsWithLazyIndirectPaths`
+// TODO(@goto-bus-stop): JS passes `override_conditions` here and maintains stores
+// references to it in the created paths. AFAICT override conditions
+// are shared mutable state among different query graphs, so having references to
+// it in many structures would require synchronization. We should likely pass it as
+// an argument to exactly the functionality that uses it.
 pub fn create_initial_options(
     initial_path: GraphPath<OpGraphPathTrigger, Option<EdgeIndex>>,
     initial_type: &QueryGraphNodeType,
     initial_context: OpGraphPathContext,
     excluded_edges: ExcludedDestinations,
     excluded_conditions: ExcludedConditions,
-    _override_conditions: HashSet<String>,
 ) -> Result<Vec<SimultaneousPathsWithLazyIndirectPaths>, FederationError> {
     let initial_paths = SimultaneousPaths::from(initial_path);
     let mut lazy_initial_path = SimultaneousPathsWithLazyIndirectPaths::new(
@@ -2432,7 +2435,6 @@ pub fn create_initial_options(
         initial_context.clone(),
         excluded_edges,
         excluded_conditions,
-        // _override_conditions,
     );
 
     if initial_type.is_federated_root_type() {

--- a/src/query_graph/graph_path.rs
+++ b/src/query_graph/graph_path.rs
@@ -2413,10 +2413,10 @@ impl SimultaneousPathsWithLazyIndirectPaths {
 pub fn create_initial_options(
     initial_path: GraphPath<OpGraphPathTrigger, Option<EdgeIndex>>,
     initial_context: OpGraphPathContext,
-    condition_resolver: impl ConditionResolver,
+    _condition_resolver: &impl ConditionResolver,
     excluded_edges: ExcludedDestinations,
     excluded_conditions: ExcludedConditions,
-    override_conditions: HashSet<String>,
+    _override_conditions: HashSet<String>,
 ) -> Result<Vec<SimultaneousPathsWithLazyIndirectPaths>, FederationError> {
     let initial_paths = SimultaneousPaths::from(initial_path);
     let mut lazy_initial_path = SimultaneousPathsWithLazyIndirectPaths::new(
@@ -2426,9 +2426,10 @@ pub fn create_initial_options(
         excluded_conditions,
     );
 
-    // TODO: FED-147
-    /* is_federated_graph_root_type(initial_path.tail) */
+    // TODO(@goto-bus-stop): FED-147: This would need access to the graph so it can look up the
+    // node because `tail` is just a node index in the Rust codebase
     #[allow(unused)]
+    // if is_federated_graph_root_type(initial_path.tail)
     if false {
         let initial_options = lazy_initial_path.indirect_options(&initial_context, 0)?;
         Ok(lazy_initial_path.create_lazy_options(todo!(), initial_context))

--- a/src/query_graph/mod.rs
+++ b/src/query_graph/mod.rs
@@ -66,6 +66,15 @@ pub(crate) enum QueryGraphNodeType {
     FederatedRootType(SchemaRootDefinitionKind),
 }
 
+impl QueryGraphNodeType {
+    pub fn is_schema_type(&self) -> bool {
+        matches!(self, Self::SchemaType(_))
+    }
+    pub fn is_federated_root_type(&self) -> bool {
+        matches!(self, Self::FederatedRootType(_))
+    }
+}
+
 impl Display for QueryGraphNodeType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/src/query_graph/mod.rs
+++ b/src/query_graph/mod.rs
@@ -60,19 +60,10 @@ impl Display for QueryGraphNode {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, derive_more::From)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, derive_more::From, derive_more::IsVariant)]
 pub(crate) enum QueryGraphNodeType {
     SchemaType(OutputTypeDefinitionPosition),
     FederatedRootType(SchemaRootDefinitionKind),
-}
-
-impl QueryGraphNodeType {
-    pub fn is_schema_type(&self) -> bool {
-        matches!(self, Self::SchemaType(_))
-    }
-    pub fn is_federated_root_type(&self) -> bool {
-        matches!(self, Self::FederatedRootType(_))
-    }
 }
 
 impl Display for QueryGraphNodeType {
@@ -80,7 +71,7 @@ impl Display for QueryGraphNodeType {
         match self {
             QueryGraphNodeType::SchemaType(pos) => pos.fmt(f),
             QueryGraphNodeType::FederatedRootType(root_kind) => {
-                write!(f, "[{}]", root_kind)
+                write!(f, "[{root_kind}]")
             }
         }
     }

--- a/src/query_plan/conditions.rs
+++ b/src/query_plan/conditions.rs
@@ -29,6 +29,36 @@ pub(crate) enum Condition {
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct VariableConditions(pub(crate) Arc<IndexMap<Name, bool>>);
 
+impl VariableConditions {
+    pub fn new() -> Self {
+        Self(Arc::new(IndexMap::new()))
+    }
+
+    pub fn insert(&mut self, name: Name, negated: bool) {
+        Arc::make_mut(&mut self.0).insert(name, negated);
+    }
+
+    /// Returns true if there are no conditions.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns a variable condition by name.
+    pub fn get(&self, name: &str) -> Option<VariableCondition> {
+        self.0.get(name).map(|&negated| {
+            // The name string existing in the map implies that it exists as a
+            // `Name` instance, and thus that it's a valid name.
+            let variable = Name::new_unchecked(name.into());
+            VariableCondition { variable, negated }
+        })
+    }
+
+    /// Returns whether a variable condition is negated, or None if there is no condition for the variable name.
+    pub fn is_negated(&self, name: &str) -> Option<bool> {
+        self.0.get(name).copied()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct VariableCondition {
     variable: Name,
@@ -81,6 +111,32 @@ impl Conditions {
             Some(map) => Self::Variables(VariableConditions(Arc::new(map))),
             None => Self::Boolean(true),
         })
+    }
+
+    pub(crate) fn update_with(&self, new_conditions: &Self) -> Self {
+        match (new_conditions, self) {
+            (Conditions::Boolean(_), _) | (_, Conditions::Boolean(_)) => new_conditions.clone(),
+            (Conditions::Variables(new_conditions), Conditions::Variables(handled_conditions)) => {
+                let mut filtered = VariableConditions::new();
+                for (cond_name, &cond_negated) in new_conditions.0.iter() {
+                    match handled_conditions.is_negated(&cond_name) {
+                        Some(handled_cond) if cond_negated != handled_cond => {
+                            // If we've already handled that exact condition, we can skip it.
+                            // But if we've already handled the _negation_ of this condition, then this mean the overall conditions
+                            // are unreachable and we can just return `false` directly.
+                            return Conditions::Boolean(false);
+                        }
+                        Some(_) => {}
+                        None => filtered.insert(cond_name.clone(), cond_negated),
+                    }
+                }
+                if filtered.is_empty() {
+                    Conditions::Boolean(true)
+                } else {
+                    Conditions::Variables(filtered)
+                }
+            }
+        }
     }
 
     pub(crate) fn merge(self, other: Self) -> Self {

--- a/src/query_plan/conditions.rs
+++ b/src/query_plan/conditions.rs
@@ -129,7 +129,7 @@ impl Conditions {
             (Conditions::Variables(new_conditions), Conditions::Variables(handled_conditions)) => {
                 let mut filtered = IndexMap::new();
                 for (cond_name, &cond_negated) in new_conditions.0.iter() {
-                    match handled_conditions.is_negated(&cond_name) {
+                    match handled_conditions.is_negated(cond_name) {
                         Some(handled_cond) if cond_negated != handled_cond => {
                             // If we've already handled that exact condition, we can skip it.
                             // But if we've already handled the _negation_ of this condition, then this mean the overall conditions

--- a/src/query_plan/conditions.rs
+++ b/src/query_plan/conditions.rs
@@ -33,7 +33,7 @@ impl VariableConditions {
     /// Construct VariableConditions from a non-empty map of variable names.
     ///
     /// In release builds, this does not check if the map is empty.
-    pub fn new_unchecked(map: IndexMap<Name, bool>) -> Self {
+    fn new_unchecked(map: IndexMap<Name, bool>) -> Self {
         debug_assert!(!map.is_empty());
         Self(Arc::new(map))
     }

--- a/src/query_plan/conditions.rs
+++ b/src/query_plan/conditions.rs
@@ -55,10 +55,8 @@ impl VariableConditions {
 
     /// Returns a variable condition by name.
     pub fn get(&self, name: &str) -> Option<VariableCondition> {
-        self.0.get(name).map(|&negated| {
-            // The name string existing in the map implies that it exists as a
-            // `Name` instance, and thus that it's a valid name.
-            let variable = Name::new_unchecked(name.into());
+        self.0.get_key_value(name).map(|(variable, &negated)| {
+            let variable = variable.clone();
             VariableCondition { variable, negated }
         })
     }

--- a/src/query_plan/fetch_dependency_graph.rs
+++ b/src/query_plan/fetch_dependency_graph.rs
@@ -194,7 +194,9 @@ pub(crate) struct DeferContext {
 ///    be shorter than its parent's, in which case the `path`, which is essentially `child-mergeAt - parent-mergeAt`, does
 ///    not make sense (or rather, it's negative, which we cannot represent)). Tl;dr, `undefined` for the `path` means that
 ///    should make no assumption and bail on any merging that uses said path.
-#[derive(Debug, Clone)]
+// PORT_NOTE: In JS this uses reference equality, not structural equality, so maybe we should just
+// do pointer comparisons?
+#[derive(Debug, Clone, PartialEq)]
 struct ParentRelation<'a> {
     parent_node_id: NodeIndex,
     path_in_parent: Option<&'a Arc<OpPath>>,

--- a/src/query_plan/fetch_dependency_graph.rs
+++ b/src/query_plan/fetch_dependency_graph.rs
@@ -204,9 +204,8 @@ struct ParentRelation {
 }
 
 /// UnhandledNode is used while processing fetch nodes in dependency order to track nodes for which
-/// one of the parents has been processed/handled but which has other parents. So it is a set of
-/// nodes and for each group which parent(s) remains to be processed before the group itself can be
-/// processed.
+/// one of the parents has been processed/handled but which has other parents.
+// PORT_NOTE: In JS this was a tuple
 #[derive(Debug)]
 struct UnhandledNode {
     /// The unhandled node.

--- a/src/query_plan/fetch_dependency_graph.rs
+++ b/src/query_plan/fetch_dependency_graph.rs
@@ -235,6 +235,19 @@ struct UnhandledNode {
     unhandled_parents: Vec<ParentRelation>,
 }
 
+impl std::fmt::Display for UnhandledNode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} (missing: [", self.node.index(),)?;
+        for (i, unhandled) in self.unhandled_parents.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{}", unhandled.parent_node_id.index())?;
+        }
+        write!(f, "])")
+    }
+}
+
 /// Used during the processing of fetch nodes in dependency order.
 #[derive(Debug)]
 struct ProcessingState {
@@ -958,9 +971,13 @@ impl FetchDependencyGraph {
         );
         assert!(
             new_state.unhandled.is_empty(),
-            "Root nodes:\n{}\nshould have no remaining nodes unhandled, but got: {}",
-            "TODO", // rootGroups.map((g) => ` - ${g}`).join('\n'),
-            "TODO", // printUnhandled(new_state.unhandled)
+            "Root nodes should have no remaining nodes unhandled, but got: [{}]",
+            new_state
+                .unhandled
+                .iter()
+                .map(|unhandled| unhandled.to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
         );
         let mut all_deferred_groups = other_defer_groups.cloned().unwrap_or_default();
         all_deferred_groups.extend(deferred_groups);

--- a/src/query_plan/fetch_dependency_graph.rs
+++ b/src/query_plan/fetch_dependency_graph.rs
@@ -94,7 +94,7 @@ impl FetchIdGenerator {
 
     /// Generate a new ID for a fetch dependency node.
     pub fn next_id(&self) -> u64 {
-        self.next.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+        self.next.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
     }
 }
 

--- a/src/query_plan/fetch_dependency_graph.rs
+++ b/src/query_plan/fetch_dependency_graph.rs
@@ -855,7 +855,11 @@ impl FetchDependencyGraph {
         let conditions = handled_conditions.update_with(&node.selection_set.conditions);
         let new_handled_conditions = conditions.clone().merge(handled_conditions);
 
-        let processed = processor.on_node(Arc::make_mut(node), &new_handled_conditions)?;
+        let processed = processor.on_node(
+            &self.federated_query_graph,
+            Arc::make_mut(node),
+            &new_handled_conditions,
+        )?;
         if children.is_empty() {
             return Ok((
                 processor.on_conditions(&conditions, processed),
@@ -1164,7 +1168,7 @@ impl FetchDependencyGraphNode {
 
         let node = super::PlanNode::Fetch(Box::new(super::FetchNode {
             subgraph_name: self.subgraph_name.clone(),
-            id: self.id,
+            id: self.id.get().copied(),
             variable_usages,
             requires: input_nodes.map(|sel| executable::SelectionSet::from(sel).selections),
             operation_document,

--- a/src/query_plan/fetch_dependency_graph.rs
+++ b/src/query_plan/fetch_dependency_graph.rs
@@ -117,7 +117,7 @@ type FetchDependencyGraphPetgraph =
 ///
 /// In the graph, two fetches are connected if one of them (the parent/head) must be performed
 /// strictly before the other one (the child/tail).
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct FetchDependencyGraph {
     /// The supergraph schema that generated the federated query graph.
     supergraph_schema: ValidFederationSchema,
@@ -144,7 +144,7 @@ pub(crate) struct FetchDependencyGraph {
 }
 
 // TODO: Write docstrings
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct DeferTracking {
     pub(crate) top_level_deferred: IndexSet<NodeStr>,
     pub(crate) deferred: IndexMap<NodeStr, DeferredInfo>,
@@ -152,7 +152,7 @@ pub(crate) struct DeferTracking {
 }
 
 // TODO: Write docstrings
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct DeferredInfo {
     pub(crate) label: NodeStr,
     pub(crate) path: FetchDependencyGraphPath,

--- a/src/query_plan/fetch_dependency_graph_processor.rs
+++ b/src/query_plan/fetch_dependency_graph_processor.rs
@@ -292,8 +292,8 @@ impl FetchDependencyGraphProcessor<Option<PlanNode>, DeferredDeferBlock>
                 condition.then_some(value)
             }
             Conditions::Variables(variables) => {
-                for (name, negated) in variables.0.iter() {
-                    let (if_clause, else_clause) = if *negated {
+                for (name, negated) in variables.iter() {
+                    let (if_clause, else_clause) = if negated {
                         (None, Some(Box::new(value)))
                     } else {
                         (Some(Box::new(value)), None)

--- a/src/query_plan/query_planner.rs
+++ b/src/query_plan/query_planner.rs
@@ -739,7 +739,7 @@ type User
             "operation.graphql",
         )
         .unwrap();
-        let plan = planner.build_query_plan(&document, None).unwrap();
+        // let plan = planner.build_query_plan(&document, None).unwrap();
     }
 
     #[test]

--- a/src/query_plan/query_planner.rs
+++ b/src/query_plan/query_planner.rs
@@ -739,7 +739,7 @@ type User
             "operation.graphql",
         )
         .unwrap();
-        // let plan = planner.build_query_plan(&document, None).unwrap();
+        let plan = planner.build_query_plan(&document, None).unwrap();
     }
 
     #[test]

--- a/src/query_plan/query_planner.rs
+++ b/src/query_plan/query_planner.rs
@@ -724,9 +724,9 @@ type User
     #[test]
     fn it_does_not_crash() {
         let supergraph = Supergraph::new(TEST_SUPERGRAPH).unwrap();
-        let _planner = QueryPlanner::new(&supergraph, Default::default()).unwrap();
+        let planner = QueryPlanner::new(&supergraph, Default::default()).unwrap();
 
-        let _document = ExecutableDocument::parse_and_validate(
+        let document = ExecutableDocument::parse_and_validate(
             supergraph
                 .to_api_schema(Default::default())
                 .unwrap()
@@ -735,7 +735,8 @@ type User
             "operation.graphql",
         )
         .unwrap();
-        // This part does crash :)
-        // let _plan = planner.build_query_plan(&document, None).unwrap();
+        let plan = planner.build_query_plan(&document, None).unwrap();
+
+        todo!("{plan}");
     }
 }

--- a/src/query_plan/query_planner.rs
+++ b/src/query_plan/query_planner.rs
@@ -720,6 +720,7 @@ type User
     "#;
 
     #[test]
+    #[allow(unused)] // remove when build_query_plan() can run without panicking
     fn it_does_not_crash() {
         let supergraph = Supergraph::new(TEST_SUPERGRAPH).unwrap();
         let api_schema = supergraph.to_api_schema(Default::default()).unwrap();
@@ -738,9 +739,7 @@ type User
             "operation.graphql",
         )
         .unwrap();
-        let plan = planner.build_query_plan(&document, None).unwrap();
-
-        todo!("{plan}");
+        // let plan = planner.build_query_plan(&document, None).unwrap();
     }
 
     #[test]

--- a/src/query_plan/query_planner.rs
+++ b/src/query_plan/query_planner.rs
@@ -539,10 +539,10 @@ fn compute_plan_internal(
                 None => local_main,
             };
             deferred.extend(local_deferred);
-            let new_selection = dependency_graph.defer_tracking.primary_selection.as_deref();
+            let new_selection = dependency_graph.defer_tracking.primary_selection;
             match primary_selection.as_mut() {
-                Some(selection) => selection.merge_into(new_selection.into_iter())?,
-                None => primary_selection = new_selection.cloned(),
+                Some(selection) => selection.merge_into(new_selection.iter())?,
+                None => primary_selection = new_selection,
             }
         }
         (main, deferred, primary_selection)
@@ -551,11 +551,7 @@ fn compute_plan_internal(
 
         let (main, deferred) = dependency_graph.process(&mut parameters.processor, root_kind)?;
         // XXX(@goto-bus-stop) Maybe `.defer_tracking` should be on the return value of `process()`..?
-        let primary_selection = dependency_graph
-            .defer_tracking
-            .primary_selection
-            .as_deref()
-            .cloned();
+        let primary_selection = dependency_graph.defer_tracking.primary_selection;
 
         (main, deferred, primary_selection)
     };

--- a/src/query_plan/query_planner.rs
+++ b/src/query_plan/query_planner.rs
@@ -726,14 +726,19 @@ type User
     #[test]
     fn it_does_not_crash() {
         let supergraph = Supergraph::new(TEST_SUPERGRAPH).unwrap();
+        let api_schema = supergraph.to_api_schema(Default::default()).unwrap();
         let planner = QueryPlanner::new(&supergraph, Default::default()).unwrap();
 
         let document = ExecutableDocument::parse_and_validate(
-            supergraph
-                .to_api_schema(Default::default())
-                .unwrap()
-                .schema(),
-            "{ userById(id: 1) { name email } }",
+            api_schema.schema(),
+            r#"
+            {
+                userById(id: 1) {
+                    name
+                    email
+                }
+            }
+            "#,
             "operation.graphql",
         )
         .unwrap();

--- a/src/query_plan/query_planner.rs
+++ b/src/query_plan/query_planner.rs
@@ -509,7 +509,7 @@ fn compute_root_parallel_best_plan(
         has_defers,
         parameters.operation.root_kind,
         FetchDependencyGraphToCostProcessor,
-    );
+    )?;
 
     // Getting no plan means the query is essentially unsatisfiable (it's a valid query, but we can prove it will never return a result),
     // so we just return an empty plan.

--- a/src/query_plan/query_planning_traversal.rs
+++ b/src/query_plan/query_planning_traversal.rs
@@ -142,6 +142,8 @@ impl<'a> QueryPlanningTraversal<'a> {
         )
     }
 
+    // Many arguments is okay for a private constructor function.
+    #[allow(clippy::too_many_arguments)]
     fn new_inner(
         parameters: &'a QueryPlanningParameters,
         selection_set: NormalizedSelectionSet,

--- a/src/query_plan/query_planning_traversal.rs
+++ b/src/query_plan/query_planning_traversal.rs
@@ -182,7 +182,7 @@ impl<'a> QueryPlanningTraversal<'a> {
         let initial_options = create_initial_options(
             initial_path,
             initial_context,
-            condition_resolver,
+            &condition_resolver,
             excluded_destinations,
             excluded_conditions,
             override_conditions,
@@ -198,7 +198,7 @@ impl<'a> QueryPlanningTraversal<'a> {
             starting_id_generation,
             cost_processor,
             is_top_level,
-            condition_resolver: CachingConditionResolver,
+            condition_resolver,
             open_branches,
             closed_branches: Default::default(),
             best_plan: None,

--- a/src/query_plan/query_planning_traversal.rs
+++ b/src/query_plan/query_planning_traversal.rs
@@ -80,8 +80,8 @@ pub(crate) struct QueryPlanningTraversal<'a> {
     /// The closed branches that have been planned.
     closed_branches: Vec<ClosedBranch>,
     /// The best plan found as a result of query planning.
-    // TODO(@goto-bus-stop): can we remove this? `find_best_plan` consumes `self` and returns the
-    // best plan, so it should not be necessary to store it
+    // TODO(@goto-bus-stop): FED-164: can we remove this? `find_best_plan` consumes `self` and returns the
+    // best plan, so it should not be necessary to store it.
     best_plan: Option<BestQueryPlanInfo>,
 }
 

--- a/src/query_plan/query_planning_traversal.rs
+++ b/src/query_plan/query_planning_traversal.rs
@@ -172,10 +172,6 @@ impl<'a> QueryPlanningTraversal<'a> {
             parameters.head,
         )
         .unwrap();
-        // TODO(@goto-bus-stop): This is parameters.override_conditions
-        // It looks like that will be mutated by the traversal?
-        // Keeping it like this for the time being.
-        let override_conditions = Default::default();
         // In JS this is done *inside* create_initial_options, which would require awareness of the
         // query graph.
         let tail = parameters
@@ -188,7 +184,6 @@ impl<'a> QueryPlanningTraversal<'a> {
             initial_context,
             excluded_destinations,
             excluded_conditions,
-            override_conditions,
         )?;
 
         let open_branches = map_options_to_selections(selection_set, initial_options);


### PR DESCRIPTION
This ports the `process*` functions from FetchDependencyGraph. All the process functions are renamed from `process*Group*` to `process*Node*`. Internal types like `DeferredGroup` are renamed to `DeferredNode`.

I also implemented `create_initial_options` which lets us actually get to a `todo!()` again instead of early returning an empty plan.

`VariableConditions` had a documented invariant that it's never empty, but the type's API didn't uphold the invariant and allowed outside access to internals. Now the `conditions` module and the public API uphold this invariant.