### PR TITLE
implement NormalizedSelection::has_defer()

### DIFF
--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -851,7 +851,7 @@ pub(crate) mod normalized_fragment_spread_selection {
 
     impl NormalizedFragmentSpreadSelection {
         pub(crate) fn has_defer(&self) -> bool {
-            self.spread.data.directives.has("defer")
+            self.spread.data.directives.has("defer") || self.selection_set.has_defer()
         }
     }
 

--- a/src/query_plan/query_planning_traversal.rs
+++ b/src/query_plan/query_planning_traversal.rs
@@ -295,7 +295,7 @@ impl<'a> QueryPlanningTraversal<'a> {
                 }
             }
             if self.selection_set_is_fully_local_from_all_nodes(selection_set, &all_tail_nodes)?
-                && !selection.has_defer()?
+                && !selection.has_defer()
             {
                 // We known the rest of the selection is local to whichever subgraph the current
                 // options are in, and so we're going to keep that selection around and add it


### PR DESCRIPTION
Along with `NormalizedSelection::has_defer()`, additionally implements:
* `NormalizedFieldSelection::has_defer()`
* `NormalizedFragment::has_defer()` (for `NormalizedOperation::without_defer()` implementation)
* `NormalizedFragmentSpreadSelection::has_defer()`
* `NormalizedInlineFragmentSelection::has_defer()`
* `NormalizedSelectionSet::has_defer` (for `NormalizedOperation::without_defer()` implementation)