### PR TITLE
Port of selection_set_is_fully_local_from_all_nodes

### DIFF
--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -24,8 +24,6 @@ use crate::query_plan::FetchDataRewrite;
 use crate::schema::definitions::is_composite_type;
 use crate::schema::definitions::types_can_be_merged;
 use crate::schema::definitions::AbstractType;
-use crate::schema::position::FieldDefinitionPosition;
-use crate::schema::position::UnionTypeDefinitionPosition;
 use crate::schema::position::{
     CompositeTypeDefinitionPosition, InterfaceTypeDefinitionPosition, ObjectTypeDefinitionPosition,
     SchemaRootDefinitionKind,
@@ -854,10 +852,7 @@ pub(crate) mod normalized_field_selection {
         NormalizedSelectionSet,
     };
     use crate::query_plan::FetchDataPathElement;
-    use crate::schema::position::{
-        CompositeTypeDefinitionPosition, FieldDefinitionPosition, InterfaceTypeDefinitionPosition,
-        ObjectTypeDefinitionPosition, TypeDefinitionPosition, UnionTypeDefinitionPosition,
-    };
+    use crate::schema::position::{FieldDefinitionPosition, TypeDefinitionPosition};
     use crate::schema::ValidFederationSchema;
     use apollo_compiler::ast::{Argument, Directive, DirectiveList, Name};
     use apollo_compiler::Node;

--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -3478,7 +3478,9 @@ impl NormalizedInlineFragmentSelection {
         parent_type: &CompositeTypeDefinitionPosition,
         schema: &ValidFederationSchema,
     ) -> bool {
-        if &self.inline_fragment.data().parent_type_position == parent_type {
+        if &self.inline_fragment.data().parent_type_position == parent_type
+            && self.inline_fragment.data().schema == *schema
+        {
             return true;
         }
         let Some(ty) = self
@@ -3488,7 +3490,7 @@ impl NormalizedInlineFragmentSelection {
         else {
             return false;
         };
-        if self.inline_fragment.data().parent_type_position != ty {
+        if self.selection_set.type_position != ty {
             for sel in self.selection_set.selections.values() {
                 if !sel.can_add_to(&ty, schema) {
                     return false;

--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -517,12 +517,6 @@ pub(crate) trait HasNormalizedSelectionKey {
     fn key(&self) -> NormalizedSelectionKey;
 }
 
-impl HasNormalizedSelectionKey for NormalizedSelectionKey {
-    fn key(&self) -> NormalizedSelectionKey {
-        self.clone()
-    }
-}
-
 /// An analogue of the apollo-compiler type `Selection` that stores our other selection analogues
 /// instead of the apollo-compiler types.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3084,7 +3078,7 @@ impl NormalizedField {
         schema: &ValidFederationSchema,
     ) -> Option<CompositeTypeDefinitionPosition> {
         let data = self.data();
-        if &data.field_position.parent() == parent_type && &data.schema == schema {
+        if data.field_position.parent() == *parent_type && data.schema == *schema {
             let base_ty_name = data
                 .field_position
                 .get(schema.schema())

--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -1462,11 +1462,8 @@ pub(crate) mod normalized_inline_fragment_selection {
             &self,
             parent_type: &CompositeTypeDefinitionPosition,
         ) -> (bool, Option<CompositeTypeDefinitionPosition>) {
-            if self.type_condition_position.is_none() {
-                return (true, None);
-            }
             let Some(ty) = self.type_condition_position.as_ref() else {
-                return (false, None);
+                return (true, None);
             };
             match self
                 .schema

--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -972,13 +972,8 @@ pub(crate) mod normalized_field_selection {
                 return Ok(Some(digest));
             }
             if data.name() == parent_type.type_name() {
-                todo!()
+                return Ok(Some(parent_type.introspection_typename_field().into()));
             }
-            /*
-            if (this.name === typenameFieldName) {
-                return parentType.typenameField()?.type;
-            }
-            */
             if self.can_rebase_on(parent_type, schema) {
                 // parent_type.field(self.data.name())?
                 todo!()

--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -3088,10 +3088,26 @@ impl NormalizedField {
                 .ok();
         }
         if data.name() == &TYPENAME_FIELD {
-            return Some(parent_type.introspection_typename_field().parent());
+            let type_name = parent_type
+                .introspection_typename_field()
+                .get(schema.schema())
+                .ok()?
+                .ty
+                .inner_named_type();
+            return schema.try_get_type(type_name.clone())?.try_into().ok();
         }
-        self.can_rebase_on(parent_type, schema)
-            .then(|| data.field_position.parent())
+        if self.can_rebase_on(parent_type, schema) {
+            let type_name = parent_type
+                .field(data.field_position.field_name().clone())
+                .ok()?
+                .get(schema.schema())
+                .ok()?
+                .ty
+                .inner_named_type();
+            schema.try_get_type(type_name.clone())?.try_into().ok()
+        } else {
+            None
+        }
     }
 }
 

--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -3654,24 +3654,6 @@ impl NormalizedInlineFragment {
             (false, None)
         }
     }
-
-    pub(crate) fn can_add_to(
-        &self,
-        parent_type: &CompositeTypeDefinitionPosition,
-    ) -> Result<bool, FederationError> {
-        if &self.data().parent_type_position == parent_type {
-            return Ok(true);
-        }
-        let Some(ty) = self.data().casted_type_if_add_to(parent_type) else {
-            return Ok(false);
-        };
-        if self.data().parent_type_position != ty {
-            todo!()
-            // return this.selectionSet.selections().every((s) => s.canAddTo(type));
-        } else {
-            Ok(true)
-        }
-    }
 }
 
 pub(crate) fn merge_selection_sets(

--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -974,17 +974,9 @@ pub(crate) mod normalized_field_selection {
             if data.name() == parent_type.type_name() {
                 return Ok(Some(parent_type.introspection_typename_field().into()));
             }
-            if self.can_rebase_on(parent_type, schema) {
-                // parent_type.field(self.data.name())?
-                todo!()
-            } else {
-                Ok(None)
-            }
-            /*
-            return this.canRebaseOn(parentType)
-                ? parentType.field(this.name)?.type
-                : undefined;
-            */
+            Ok(self
+                .can_rebase_on(parent_type, schema)
+                .then(|| data.field_position.parent()))
         }
         pub(crate) fn with_updated_directives(&self, directives: DirectiveList) -> NormalizedField {
             let mut data = self.data.clone();

--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -972,7 +972,7 @@ pub(crate) mod normalized_field_selection {
                 return Ok(Some(digest));
             }
             if data.name() == parent_type.type_name() {
-                return Ok(Some(parent_type.introspection_typename_field().into()));
+                return Ok(Some(parent_type.introspection_typename_field().parent()));
             }
             Ok(self
                 .can_rebase_on(parent_type, schema)

--- a/src/query_plan/query_planning_traversal.rs
+++ b/src/query_plan/query_planning_traversal.rs
@@ -16,7 +16,7 @@ use crate::query_plan::fetch_dependency_graph_processor::{
 };
 use crate::query_plan::generate::{generate_all_plans_and_find_best, PlanBuilder};
 use crate::query_plan::operation::{
-    NormalizedOperation, NormalizedSelection, NormalizedSelectionSet,
+    HasNormalizedSelectionKey, NormalizedOperation, NormalizedSelection, NormalizedSelectionSet,
 };
 use crate::query_plan::query_planner::QueryPlannerConfig;
 use crate::query_plan::query_planner::QueryPlanningStatistics;
@@ -451,7 +451,7 @@ impl<'a> QueryPlanningTraversal<'a> {
         // PORT_NOTE: The JS code performs the last check lazily. Instead of that, this check is
         // skipped if `nodes` is empty.
         if !nodes.is_empty()
-            && selection.selections.keys().any(|k| match k {
+            && selection.selections.values().any(|val| match val.key() {
                 NormalizedSelectionKey::InlineFragment {
                     type_condition: Some(name),
                     ..
@@ -459,7 +459,7 @@ impl<'a> QueryPlanningTraversal<'a> {
                     .parameters
                     .abstract_types_with_inconsistent_runtime_types
                     .iter()
-                    .any(|ty| ty.type_name() == name),
+                    .any(|ty| *ty.type_name() == name),
                 _ => false,
             })
         {

--- a/src/query_plan/query_planning_traversal.rs
+++ b/src/query_plan/query_planning_traversal.rs
@@ -476,7 +476,7 @@ impl<'a> QueryPlanningTraversal<'a> {
                 }
                 QueryGraphNodeType::FederatedRootType(_) => return Ok(false),
             };
-            if n.has_reachable_cross_subgraph_edges || selection.can_rebase_on(&parent_ty)? {
+            if n.has_reachable_cross_subgraph_edges || selection.can_rebase_on(&parent_ty) {
                 return Ok(false);
             }
         }

--- a/src/query_plan/query_planning_traversal.rs
+++ b/src/query_plan/query_planning_traversal.rs
@@ -466,8 +466,7 @@ impl<'a> QueryPlanningTraversal<'a> {
             return Ok(false);
         }
         for node in nodes {
-            let qg = self.parameters.federated_query_graph.graph();
-            let n = &qg[*node];
+            let n = self.parameters.federated_query_graph.node_weight(*node)?;
             let parent_ty = match &n.type_ {
                 QueryGraphNodeType::SchemaType(ty) => match ty {
                     OutputTypeDefinitionPosition::Object(ty) => {

--- a/src/query_plan/query_planning_traversal.rs
+++ b/src/query_plan/query_planning_traversal.rs
@@ -476,7 +476,7 @@ impl<'a> QueryPlanningTraversal<'a> {
                 }
                 QueryGraphNodeType::FederatedRootType(_) => return Ok(false),
             };
-            if n.has_reachable_cross_subgraph_edges || selection.can_rebase_on(&parent_ty) {
+            if n.has_reachable_cross_subgraph_edges || !selection.can_rebase_on(&parent_ty) {
                 return Ok(false);
             }
         }

--- a/src/query_plan/query_planning_traversal.rs
+++ b/src/query_plan/query_planning_traversal.rs
@@ -16,7 +16,7 @@ use crate::query_plan::fetch_dependency_graph_processor::{
 };
 use crate::query_plan::generate::{generate_all_plans_and_find_best, PlanBuilder};
 use crate::query_plan::operation::{
-    HasNormalizedSelectionKey, NormalizedOperation, NormalizedSelection, NormalizedSelectionSet,
+    NormalizedOperation, NormalizedSelection, NormalizedSelectionSet,
 };
 use crate::query_plan::query_planner::QueryPlannerConfig;
 use crate::query_plan::query_planner::QueryPlanningStatistics;
@@ -28,8 +28,6 @@ use crate::schema::ValidFederationSchema;
 use indexmap::IndexSet;
 use petgraph::graph::{EdgeIndex, NodeIndex};
 use std::sync::Arc;
-
-use super::operation::NormalizedSelectionKey;
 
 // PORT_NOTE: Named `PlanningParameters` in the JS codebase, but there was no particular reason to
 // leave out to the `Query` prefix, so it's been added for consistency. Similar to `GraphPath`, we

--- a/src/query_plan/query_planning_traversal.rs
+++ b/src/query_plan/query_planning_traversal.rs
@@ -468,19 +468,12 @@ impl<'a> QueryPlanningTraversal<'a> {
         for node in nodes {
             let n = self.parameters.federated_query_graph.node_weight(*node)?;
             let parent_ty = match &n.type_ {
-                QueryGraphNodeType::SchemaType(ty) => match ty {
-                    OutputTypeDefinitionPosition::Object(ty) => {
-                        CompositeTypeDefinitionPosition::Object(ty.clone())
+                QueryGraphNodeType::SchemaType(ty) => {
+                    match CompositeTypeDefinitionPosition::try_from(ty.clone()) {
+                        Ok(ty) => ty,
+                        _ => return Ok(false),
                     }
-                    OutputTypeDefinitionPosition::Interface(ty) => {
-                        CompositeTypeDefinitionPosition::Interface(ty.clone())
-                    }
-                    OutputTypeDefinitionPosition::Union(ty) => {
-                        CompositeTypeDefinitionPosition::Union(ty.clone())
-                    }
-                    OutputTypeDefinitionPosition::Scalar(_)
-                    | OutputTypeDefinitionPosition::Enum(_) => return Ok(false),
-                },
+                }
                 QueryGraphNodeType::FederatedRootType(_) => return Ok(false),
             };
             if n.has_reachable_cross_subgraph_edges || selection.can_rebase_on(&parent_ty)? {

--- a/src/schema/position.rs
+++ b/src/schema/position.rs
@@ -201,6 +201,24 @@ pub(crate) enum CompositeTypeDefinitionPosition {
     Union(UnionTypeDefinitionPosition),
 }
 
+impl From<FieldDefinitionPosition> for CompositeTypeDefinitionPosition {
+    fn from(value: FieldDefinitionPosition) -> Self {
+        match value {
+            FieldDefinitionPosition::Object(ty) => Self::Object(ObjectTypeDefinitionPosition {
+                type_name: ty.type_name,
+            }),
+            FieldDefinitionPosition::Interface(ty) => {
+                Self::Interface(InterfaceTypeDefinitionPosition {
+                    type_name: ty.type_name,
+                })
+            }
+            FieldDefinitionPosition::Union(ty) => Self::Union(UnionTypeDefinitionPosition {
+                type_name: ty.type_name,
+            }),
+        }
+    }
+}
+
 impl Debug for CompositeTypeDefinitionPosition {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/src/schema/position.rs
+++ b/src/schema/position.rs
@@ -201,24 +201,6 @@ pub(crate) enum CompositeTypeDefinitionPosition {
     Union(UnionTypeDefinitionPosition),
 }
 
-impl From<FieldDefinitionPosition> for CompositeTypeDefinitionPosition {
-    fn from(value: FieldDefinitionPosition) -> Self {
-        match value {
-            FieldDefinitionPosition::Object(ty) => Self::Object(ObjectTypeDefinitionPosition {
-                type_name: ty.type_name,
-            }),
-            FieldDefinitionPosition::Interface(ty) => {
-                Self::Interface(InterfaceTypeDefinitionPosition {
-                    type_name: ty.type_name,
-                })
-            }
-            FieldDefinitionPosition::Union(ty) => Self::Union(UnionTypeDefinitionPosition {
-                type_name: ty.type_name,
-            }),
-        }
-    }
-}
-
 impl Debug for CompositeTypeDefinitionPosition {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/src/schema/position.rs
+++ b/src/schema/position.rs
@@ -582,26 +582,6 @@ pub(crate) enum FieldDefinitionPosition {
     Union(UnionTypenameFieldDefinitionPosition),
 }
 
-impl PartialEq<CompositeTypeDefinitionPosition> for FieldDefinitionPosition {
-    fn eq(&self, other: &CompositeTypeDefinitionPosition) -> bool {
-        match (self, other) {
-            (
-                FieldDefinitionPosition::Object(ty_a),
-                CompositeTypeDefinitionPosition::Object(ty_b),
-            ) => ty_a.type_name == ty_b.type_name,
-            (
-                FieldDefinitionPosition::Interface(ty_a),
-                CompositeTypeDefinitionPosition::Interface(ty_b),
-            ) => ty_a.type_name == ty_b.type_name,
-            (
-                FieldDefinitionPosition::Union(ty_a),
-                CompositeTypeDefinitionPosition::Union(ty_b),
-            ) => ty_a.type_name == ty_b.type_name,
-            _ => false,
-        }
-    }
-}
-
 impl Debug for FieldDefinitionPosition {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/src/schema/position.rs
+++ b/src/schema/position.rs
@@ -582,6 +582,26 @@ pub(crate) enum FieldDefinitionPosition {
     Union(UnionTypenameFieldDefinitionPosition),
 }
 
+impl PartialEq<CompositeTypeDefinitionPosition> for FieldDefinitionPosition {
+    fn eq(&self, other: &CompositeTypeDefinitionPosition) -> bool {
+        match (self, other) {
+            (
+                FieldDefinitionPosition::Object(ty_a),
+                CompositeTypeDefinitionPosition::Object(ty_b),
+            ) => ty_a.type_name == ty_b.type_name,
+            (
+                FieldDefinitionPosition::Interface(ty_a),
+                CompositeTypeDefinitionPosition::Interface(ty_b),
+            ) => ty_a.type_name == ty_b.type_name,
+            (
+                FieldDefinitionPosition::Union(ty_a),
+                CompositeTypeDefinitionPosition::Union(ty_b),
+            ) => ty_a.type_name == ty_b.type_name,
+            _ => false,
+        }
+    }
+}
+
 impl Debug for FieldDefinitionPosition {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -2731,6 +2751,10 @@ pub(crate) struct InterfaceTypeDefinitionPosition {
 }
 
 impl InterfaceTypeDefinitionPosition {
+    pub(crate) fn new(type_name: Name) -> Self {
+        Self { type_name }
+    }
+
     pub(crate) fn field(&self, field_name: Name) -> InterfaceFieldDefinitionPosition {
         InterfaceFieldDefinitionPosition {
             type_name: self.type_name.clone(),
@@ -3964,6 +3988,10 @@ pub(crate) struct UnionTypeDefinitionPosition {
 }
 
 impl UnionTypeDefinitionPosition {
+    pub(crate) fn new(type_name: Name) -> Self {
+        Self { type_name }
+    }
+
     pub(crate) fn introspection_typename_field(&self) -> UnionTypenameFieldDefinitionPosition {
         UnionTypenameFieldDefinitionPosition {
             type_name: self.type_name.clone(),


### PR DESCRIPTION
This PR addresses FED-42 and ports [selectionIsFullyLocalFromAllVertices](https://github.com/apollographql/federation/blob/main/query-planner-js/src/buildPlan.ts#L251).
