### PR TITLE
FED-46: Implemented `ConditionResolver` trait for `QueryPlanningTraversal`

### DIFF
--- a/src/query_graph/condition_resolver.rs
+++ b/src/query_graph/condition_resolver.rs
@@ -4,6 +4,7 @@ use crate::query_graph::graph_path::{
 };
 use crate::query_graph::path_tree::OpPathTree;
 use crate::query_plan::QueryPlanCost;
+use indexmap::IndexMap;
 use petgraph::graph::EdgeIndex;
 use std::sync::Arc;
 
@@ -47,6 +48,10 @@ impl ConditionResolution {
     }
 }
 
+// PORT_NOTE: In JS version, `QueryPlanningTraversal` has a caching condition resolver as a field.
+//            But in Rust, `QueryPlanningTraversal` implements `ConditionResolver` trait itself,
+//            using `ConditionResolverCache` struct below.
+//            However, `CachingConditionResolver` may still be used in the composition in the future.
 pub(crate) struct CachingConditionResolver;
 
 impl ConditionResolver for CachingConditionResolver {
@@ -58,5 +63,146 @@ impl ConditionResolver for CachingConditionResolver {
         _excluded_conditions: &ExcludedConditions,
     ) -> Result<ConditionResolution, FederationError> {
         todo!()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum ConditionResolutionCacheResult {
+    /// Cache hit.
+    Hit(ConditionResolution),
+    /// Cache miss; can be inserted into cache.
+    Miss,
+    /// The value can't be cached; Or, an incompatible value is already in cache.
+    NotApplicable,
+}
+
+impl ConditionResolutionCacheResult {
+    pub(crate) fn is_hit(&self) -> bool {
+        matches!(self, Self::Hit(_))
+    }
+
+    pub(crate) fn is_miss(&self) -> bool {
+        matches!(self, Self::Miss)
+    }
+
+    pub(crate) fn is_not_applicable(&self) -> bool {
+        matches!(self, Self::NotApplicable)
+    }
+}
+
+pub(crate) struct ConditionResolverCache {
+    // For every edge having a condition, we cache the resolution its conditions when possible.
+    // We save resolution with the set of excluded edges that were used to compute it: the reason we do this is
+    // that excluded edges impact the resolution, so we should only used a cached value if we know the excluded
+    // edges are the same as when caching, and while we could decide to cache only when we have no excluded edges
+    // at all, this would sub-optimal for types that have multiple keys, as the algorithm will always at least
+    // include the previous key edges to the excluded edges of other keys. In other words, if we only cached
+    // when we have no excluded edges, we'd only ever use the cache for the first key of every type. However,
+    // as the algorithm always try keys in the same order (the order of the edges in the query graph), including
+    // the excluded edges we see on the first ever call is actually the proper thing to do.
+    edge_states: IndexMap<EdgeIndex, (ConditionResolution, ExcludedDestinations)>,
+}
+
+impl ConditionResolverCache {
+    pub(crate) fn new() -> Self {
+        Self {
+            edge_states: Default::default(),
+        }
+    }
+
+    pub(crate) fn contains(
+        &mut self,
+        edge: EdgeIndex,
+        context: &OpGraphPathContext,
+        excluded_destinations: &ExcludedDestinations,
+        excluded_conditions: &ExcludedConditions,
+    ) -> ConditionResolutionCacheResult {
+        // We don't cache if there is a context or excluded conditions because those would impact the resolution and
+        // we don't want to cache a value per-context and per-excluded-conditions (we also don't cache per-excluded-edges though
+        // instead we cache a value only for the first-see excluded edges; see above why that work in practice).
+        // TODO: we could actually have a better handling of the context: it doesn't really change how we'd resolve the condition, it's only
+        // that the context, if not empty, would have to be added to the trigger of key edges in the resolution path tree when appropriate
+        // and we currently don't handle that. But we could cache with an empty context, and then apply the proper transformation on the
+        // cached value `pathTree` when the context is not empty. That said, the context is about active @include/@skip and it's not use
+        // that commonly, so this is probably not an urgent improvement.
+        if !context.is_empty() || !excluded_conditions.is_empty() {
+            return ConditionResolutionCacheResult::NotApplicable;
+        }
+
+        if let Some((cached_resolution, cached_excluded_destinations)) = self.edge_states.get(&edge)
+        {
+            // Cache hit.
+            // Ensure we have the same excluded destinations as when we cached the value.
+            if cached_excluded_destinations.is_equivalent(excluded_destinations) {
+                return ConditionResolutionCacheResult::Hit(cached_resolution.clone());
+            }
+            // Otherwise, fall back to non-cached computation
+            ConditionResolutionCacheResult::NotApplicable
+        } else {
+            // Cache miss
+            ConditionResolutionCacheResult::Miss
+        }
+    }
+
+    pub(crate) fn insert(
+        &mut self,
+        edge: EdgeIndex,
+        resolution: ConditionResolution,
+        excluded_destinations: ExcludedDestinations,
+    ) {
+        self.edge_states
+            .insert(edge, (resolution, excluded_destinations));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query_graph::graph_path::OpGraphPathContext;
+    //use crate::link::graphql_definition::{OperationConditional, OperationConditionalKind, BooleanOrVariable};
+
+    #[test]
+    fn test_condition_resolver_cache() {
+        let mut cache = ConditionResolverCache::new();
+
+        let edge1 = EdgeIndex::new(1);
+        let empty_context = OpGraphPathContext::default();
+        let empty_destinations = ExcludedDestinations::default();
+        let empty_conditions = ExcludedConditions::default();
+
+        assert!(cache
+            .contains(
+                edge1,
+                &empty_context,
+                &empty_destinations,
+                &empty_conditions
+            )
+            .is_miss());
+
+        cache.insert(
+            edge1,
+            ConditionResolution::unsatisfied_conditions(),
+            empty_destinations.clone(),
+        );
+
+        assert!(cache
+            .contains(
+                edge1,
+                &empty_context,
+                &empty_destinations,
+                &empty_conditions
+            )
+            .is_hit());
+
+        let edge2 = EdgeIndex::new(2);
+
+        assert!(cache
+            .contains(
+                edge2,
+                &empty_context,
+                &empty_destinations,
+                &empty_conditions
+            )
+            .is_miss());
     }
 }

--- a/src/query_graph/condition_resolver.rs
+++ b/src/query_graph/condition_resolver.rs
@@ -133,7 +133,7 @@ impl ConditionResolverCache {
         {
             // Cache hit.
             // Ensure we have the same excluded destinations as when we cached the value.
-            if cached_excluded_destinations.is_equivalent(excluded_destinations) {
+            if cached_excluded_destinations == excluded_destinations {
                 return ConditionResolutionCacheResult::Hit(cached_resolution.clone());
             }
             // Otherwise, fall back to non-cached computation

--- a/src/query_graph/graph_path.rs
+++ b/src/query_graph/graph_path.rs
@@ -312,6 +312,10 @@ impl OpGraphPathContext {
         }
         Ok(new_context)
     }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.conditionals.is_empty()
+    }
 }
 
 impl Display for OpGraphPathContext {
@@ -356,6 +360,13 @@ pub(crate) struct SimultaneousPathsWithLazyIndirectPaths {
 #[derive(Debug, Clone)]
 pub(crate) struct ExcludedDestinations(Arc<Vec<Name>>);
 
+impl ExcludedDestinations {
+    /// See if two `ExcludedDestinations` have the same set of values, regardless of their ordering.
+    pub(crate) fn is_equivalent(&self, other: &ExcludedDestinations) -> bool {
+        self.0.len() == other.0.len() && self.0.iter().all(|x| other.0.contains(x))
+    }
+}
+
 impl Default for ExcludedDestinations {
     fn default() -> Self {
         ExcludedDestinations(Arc::new(vec![]))
@@ -364,6 +375,12 @@ impl Default for ExcludedDestinations {
 
 #[derive(Debug, Clone)]
 pub(crate) struct ExcludedConditions(Arc<Vec<Arc<NormalizedSelectionSet>>>);
+
+impl ExcludedConditions {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
 
 impl Default for ExcludedConditions {
     fn default() -> Self {

--- a/src/query_graph/graph_path.rs
+++ b/src/query_graph/graph_path.rs
@@ -360,9 +360,9 @@ pub(crate) struct SimultaneousPathsWithLazyIndirectPaths {
 #[derive(Debug, Clone)]
 pub(crate) struct ExcludedDestinations(Arc<Vec<Name>>);
 
-impl ExcludedDestinations {
+impl PartialEq for ExcludedDestinations {
     /// See if two `ExcludedDestinations` have the same set of values, regardless of their ordering.
-    pub(crate) fn is_equivalent(&self, other: &ExcludedDestinations) -> bool {
+    fn eq(&self, other: &ExcludedDestinations) -> bool {
         self.0.len() == other.0.len() && self.0.iter().all(|x| other.0.contains(x))
     }
 }
@@ -379,6 +379,13 @@ pub(crate) struct ExcludedConditions(Arc<Vec<Arc<NormalizedSelectionSet>>>);
 impl ExcludedConditions {
     pub(crate) fn is_empty(&self) -> bool {
         self.0.is_empty()
+    }
+
+    /// Immutable version of `push`.
+    pub(crate) fn add_item(&self, value: &NormalizedSelectionSet) -> ExcludedConditions {
+        let mut result = self.0.as_ref().clone();
+        result.push(value.clone().into());
+        ExcludedConditions(Arc::new(result))
     }
 }
 

--- a/src/query_graph/mod.rs
+++ b/src/query_graph/mod.rs
@@ -47,6 +47,12 @@ pub(crate) struct QueryGraphNode {
     pub(crate) root_kind: Option<SchemaRootDefinitionKind>,
 }
 
+impl QueryGraphNode {
+    pub fn is_root_node(&self) -> bool {
+        matches!(self.type_, QueryGraphNodeType::FederatedRootType(_))
+    }
+}
+
 impl Display for QueryGraphNode {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}({})", self.type_, self.source)?;

--- a/src/query_plan/fetch_dependency_graph_processor.rs
+++ b/src/query_plan/fetch_dependency_graph_processor.rs
@@ -42,6 +42,7 @@ const FETCH_COST: QueryPlanCost = 1000;
 /// The exact number is a tad  arbitrary however.
 const PIPELINING_COST: QueryPlanCost = 100;
 
+#[derive(Clone)]
 pub(crate) struct FetchDependencyGraphToQueryPlanProcessor {
     config: Arc<QueryPlannerConfig>,
     variable_definitions: Vec<Node<VariableDefinition>>,
@@ -73,6 +74,7 @@ pub(crate) struct FetchDependencyGraphToQueryPlanProcessor {
 ///    it assumes that the networking and other query processing costs are much higher than
 ///    the cost of resolving a single field. Or to put it more concretely, it assumes that
 ///    a fetch of 5 fields is probably not too different from than of 2 fields.
+#[derive(Clone, Copy)]
 pub(crate) struct FetchDependencyGraphToCostProcessor;
 
 /// Generic interface for "processing" a (reduced) dependency graph of fetch dependency nodes

--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -2992,6 +2992,7 @@ impl NamedFragments {
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct RebasedFragments {
     original_fragments: NamedFragments,
     // JS PORT NOTE: In JS implementation values were optional

--- a/src/query_plan/query_planner.rs
+++ b/src/query_plan/query_planner.rs
@@ -509,6 +509,8 @@ fn compute_root_parallel_best_plan(
         has_defers,
         parameters.operation.root_kind,
         FetchDependencyGraphToCostProcessor,
+        /*excluded_destinations*/ &Default::default(),
+        /*excluded_conditions*/ &Default::default(),
     );
 
     // Getting no plan means the query is essentially unsatisfiable (it's a valid query, but we can prove it will never return a result),

--- a/src/query_plan/query_planning_traversal.rs
+++ b/src/query_plan/query_planning_traversal.rs
@@ -1,8 +1,10 @@
 use crate::error::FederationError;
-use crate::query_graph::condition_resolver::CachingConditionResolver;
+use crate::query_graph::condition_resolver::{
+    ConditionResolution, ConditionResolutionCacheResult, ConditionResolver, ConditionResolverCache,
+};
 use crate::query_graph::graph_path::{
-    ClosedBranch, ClosedPath, OpPathElement, OpenBranch, SimultaneousPaths,
-    SimultaneousPathsWithLazyIndirectPaths,
+    ClosedBranch, ClosedPath, ExcludedConditions, ExcludedDestinations, OpGraphPathContext,
+    OpPathElement, OpenBranch, SimultaneousPaths, SimultaneousPathsWithLazyIndirectPaths,
 };
 use crate::query_graph::path_tree::OpPathTree;
 use crate::query_graph::{QueryGraph, QueryGraphNodeType};
@@ -21,13 +23,15 @@ use crate::schema::position::SchemaRootDefinitionKind;
 use crate::schema::position::{AbstractTypeDefinitionPosition, OutputTypeDefinitionPosition};
 use crate::schema::ValidFederationSchema;
 use indexmap::IndexSet;
-use petgraph::graph::NodeIndex;
+use petgraph::graph::{EdgeIndex, NodeIndex};
 use std::sync::Arc;
 
 // PORT_NOTE: Named `PlanningParameters` in the JS codebase, but there was no particular reason to
 // leave out to the `Query` prefix, so it's been added for consistency. Similar to `GraphPath`, we
 // don't have a distinguished type for when the head is a root vertex, so we instead check this at
 // runtime (introducing the new field `head_must_be_root`).
+// NOTE: `head_must_be_root` can be deduced from the `head` node's type, so we might be able to
+//       remove it.
 pub(crate) struct QueryPlanningParameters {
     /// The supergraph schema that generated the federated query graph.
     pub(crate) supergraph_schema: ValidFederationSchema,
@@ -67,8 +71,6 @@ pub(crate) struct QueryPlanningTraversal<'a> {
     /// True if this query planning is at top-level (note that query planning can recursively start
     /// further query planning).
     is_top_level: bool,
-    /// A query plan resolver for edge conditions that caches the outcome per edge.
-    condition_resolver: CachingConditionResolver,
     /// The stack of open branches left to plan, along with state indicating the next selection to
     /// plan for them.
     // PORT_NOTE: The `stack` in the JS codebase only contained one selection per stack entry, but
@@ -80,6 +82,9 @@ pub(crate) struct QueryPlanningTraversal<'a> {
     closed_branches: Vec<ClosedBranch>,
     /// The best plan found as a result of query planning.
     best_plan: Option<BestQueryPlanInfo>,
+    /// The cache for condition resolution.
+    // PORT_NOTE: This is different from JS version. See `ConditionResolver` trait implementation below.
+    resolver_cache: ConditionResolverCache,
 }
 
 struct OpenBranchAndSelections {
@@ -135,12 +140,11 @@ impl<'a> QueryPlanningTraversal<'a> {
             starting_id_generation: 0,
             cost_processor,
             is_top_level,
-            // TODO: Use `self.resolve_condition_plan()` once it exists. See FED-46.
-            condition_resolver: CachingConditionResolver,
             // TODO: In JS this calls `createInitialOptions()`. Do we still need that? See FED-147.
             open_branches: Default::default(),
             closed_branches: Default::default(),
             best_plan: None,
+            resolver_cache: ConditionResolverCache::new(),
         }
     }
 
@@ -192,7 +196,7 @@ impl<'a> QueryPlanningTraversal<'a> {
             let followups_for_option = option.advance_with_operation_element(
                 self.parameters.supergraph_schema.clone(),
                 &operation_element,
-                &mut self.condition_resolver,
+                /*resolver*/ self,
             )?;
             let Some(followups_for_option) = followups_for_option else {
                 // There is no valid way to advance the current operation element from this option
@@ -653,6 +657,99 @@ impl<'a> QueryPlanningTraversal<'a> {
             )?;
         }
         Ok(())
+    }
+
+    fn resolve_condition_plan(
+        &self,
+        edge: EdgeIndex,
+        // PORT_NOTE: The following parameters are not currently used.
+        _context: &OpGraphPathContext,
+        _excluded_destinations: &ExcludedDestinations,
+        _excluded_conditions: &ExcludedConditions,
+    ) -> Result<ConditionResolution, FederationError> {
+        let graph = &self.parameters.federated_query_graph;
+        let head = graph.edge_endpoints(edge)?.0;
+        let edge_conditions = graph
+            .edge_weight(edge)?
+            .conditions
+            .as_ref()
+            .unwrap() // Note: `resolve` method checks that the edge has conditions
+            .as_ref();
+        let parameters = QueryPlanningParameters {
+            head,
+            head_must_be_root: graph.node_weight(head)?.is_root_node(),
+            // otherwise, the same as self.parameters
+            // TODO: Some fields are deep-cloned here. We might want to revisit how they should be defined.
+            supergraph_schema: self.parameters.supergraph_schema.clone(),
+            federated_query_graph: graph.clone(),
+            operation: self.parameters.operation.clone(),
+            processor: self.parameters.processor.clone(),
+            abstract_types_with_inconsistent_runtime_types: self
+                .parameters
+                .abstract_types_with_inconsistent_runtime_types
+                .clone(),
+            config: self.parameters.config.clone(),
+            statistics: self.parameters.statistics.clone(),
+        };
+        let best_plan_opt = QueryPlanningTraversal::new(
+            &parameters,
+            edge_conditions.clone(),
+            self.has_defers,
+            self.root_kind,
+            self.cost_processor,
+            // TODO: pass the following arguments
+            //excluded_destinations,
+            //excluded_conditions & edge_conditions,
+        )
+        .find_best_plan()?;
+        match best_plan_opt {
+            Some(best_plan) => Ok(ConditionResolution::Satisfied {
+                cost: best_plan.cost,
+                path_tree: Some(Arc::new(best_plan.path_tree)),
+            }),
+            None => Ok(ConditionResolution::unsatisfied_conditions()),
+        }
+    }
+}
+
+// PORT_NOTE: In JS version, QueryPlanningTraversal has `conditionResolver` field, which
+//            is a closure calling `this.resolveConditionPlan` (`this` is captured here).
+//            The same would be infeasible to implement in Rust due to the cyclic references.
+//            Thus, instead of `condition_resolver` field, QueryPlanningTraversal was made to
+//            implement `ConditionResolver` trait along with `resolver_cache` field.
+impl<'a> ConditionResolver for QueryPlanningTraversal<'a> {
+    /// A query plan resolver for edge conditions that caches the outcome per edge.
+    fn resolve(
+        &mut self,
+        edge: EdgeIndex,
+        context: &OpGraphPathContext,
+        excluded_destinations: &ExcludedDestinations,
+        excluded_conditions: &ExcludedConditions,
+    ) -> Result<ConditionResolution, FederationError> {
+        // Invariant check: The edge must have conditions.
+        let graph = &self.parameters.federated_query_graph;
+        let edge_data = graph.edge_weight(edge)?;
+        assert!(
+            edge_data.conditions.is_some(),
+            "Should not have been called for edge without conditions"
+        );
+
+        let cache_result =
+            self.resolver_cache
+                .contains(edge, context, excluded_destinations, excluded_conditions);
+
+        if let ConditionResolutionCacheResult::Hit(cached_resolution) = cache_result {
+            return Ok(cached_resolution);
+        }
+
+        let resolution =
+            self.resolve_condition_plan(edge, context, excluded_destinations, excluded_conditions)?;
+        // See if this resolution is eligible to be inserted into the cache.
+        if cache_result.is_miss() {
+            self.resolver_cache
+                .insert(edge, resolution.clone(), excluded_destinations.clone());
+        }
+        Ok(resolution)
     }
 }
 


### PR DESCRIPTION
### Background

I was tasked to implement the `CachingConditionResolver`, which is used in `QueryPlanningTraversal`. 
 The TypeScript version of `QueryPlanningTraversal` has a field `conditionResolver`, which is a closure that captures `this` (QueryPlanningTraversal) as mutable reference and calls `this.resolveConditionPlan`. The problem is that there is a cyclic reference structure: `QueryPlanningTraversal` -owns-> `conditionResolver` -captures-> `QueryPlanningTraversal`. 

In Rust, `CachingConditionResolver` can't mutably reference `QueryPlanningTraversal`, since we want `QueryPlanningTraversal`  to hold the `CachingConditionResolver` itself. (Not considering smart pointers or unsafe references)

### Proposed Solution

I decided not to implement `CachingConditionResolver`. Instead, I made `QueryPlanningTraversal` to implement `ConditionResolver` trait directly and hold its own cache. I separated the caching logic in the new`ConditionResolverCache` struct. But, the separation of caching and resolver is not as nice as the TypeScript version.

An alternative solution would be to create a wrapper struct that holds both `QueryPlanningTraversal` and a cache. But, then every references of `QueryPlanningTraversal` needs to be changed to point to the new wrapper. I didn't think it'd be worthwhile, only to gain a slightly better separation and reusability.