### PR TITLE
FED-37: Port FetchInputs::add from GroupInputs.add

### DIFF
--- a/src/link/graphql_definition.rs
+++ b/src/link/graphql_definition.rs
@@ -4,6 +4,7 @@ use crate::error::FederationError;
 use crate::link::argument::{
     directive_optional_string_argument, directive_optional_variable_boolean_argument,
 };
+use apollo_compiler::ast::Value;
 use apollo_compiler::executable::{Directive, Name};
 use apollo_compiler::{name, Node, NodeStr};
 
@@ -56,6 +57,12 @@ pub(crate) enum OperationConditionalKind {
     Skip,
 }
 
+impl OperationConditionalKind {
+    pub(crate) fn to_name(&self) -> Name {
+        Name::new_unchecked(NodeStr::new(&self.to_string()))
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) enum BooleanOrVariable {
     Boolean(bool),
@@ -67,6 +74,15 @@ impl Display for BooleanOrVariable {
         match self {
             BooleanOrVariable::Boolean(b) => b.fmt(f),
             BooleanOrVariable::Variable(name) => name.fmt(f),
+        }
+    }
+}
+
+impl BooleanOrVariable {
+    pub(crate) fn to_ast_value(&self) -> Value {
+        match self {
+            BooleanOrVariable::Boolean(b) => Value::Boolean(*b),
+            BooleanOrVariable::Variable(name) => Value::Variable(name.clone()),
         }
     }
 }

--- a/src/link/graphql_definition.rs
+++ b/src/link/graphql_definition.rs
@@ -101,6 +101,6 @@ impl From<BooleanOrVariable> for Value {
 
 impl From<BooleanOrVariable> for Node<Value> {
     fn from(b: BooleanOrVariable) -> Self {
-        b.into()
+        Node::new(b.into())
     }
 }

--- a/src/link/graphql_definition.rs
+++ b/src/link/graphql_definition.rs
@@ -89,3 +89,18 @@ impl BooleanOrVariable {
         }
     }
 }
+
+impl From<BooleanOrVariable> for Value {
+    fn from(b: BooleanOrVariable) -> Self {
+        match b {
+            BooleanOrVariable::Boolean(b) => Value::Boolean(b),
+            BooleanOrVariable::Variable(name) => Value::Variable(name),
+        }
+    }
+}
+
+impl From<BooleanOrVariable> for Node<Value> {
+    fn from(b: BooleanOrVariable) -> Self {
+        b.into()
+    }
+}

--- a/src/link/graphql_definition.rs
+++ b/src/link/graphql_definition.rs
@@ -58,8 +58,11 @@ pub(crate) enum OperationConditionalKind {
 }
 
 impl OperationConditionalKind {
-    pub(crate) fn to_name(&self) -> Name {
-        Name::new_unchecked(NodeStr::new(&self.to_string()))
+    pub(crate) fn name(&self) -> Name {
+        match self {
+            OperationConditionalKind::Include => name!("include"),
+            OperationConditionalKind::Skip => name!("skip"),
+        }
     }
 }
 

--- a/src/query_graph/graph_path.rs
+++ b/src/query_graph/graph_path.rs
@@ -407,6 +407,10 @@ impl OpGraphPathContext {
     pub(crate) fn is_empty(&self) -> bool {
         self.conditionals.is_empty()
     }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &OperationConditional> {
+        self.conditionals.iter().map(|x| x.as_ref())
+    }
 }
 
 impl Display for OpGraphPathContext {

--- a/src/query_plan/fetch_dependency_graph.rs
+++ b/src/query_plan/fetch_dependency_graph.rs
@@ -11,9 +11,12 @@ use crate::query_plan::fetch_dependency_graph_processor::FetchDependencyGraphPro
 use crate::query_plan::operation::normalized_field_selection::{
     NormalizedField, NormalizedFieldData,
 };
+use crate::query_plan::operation::normalized_inline_fragment_selection::{
+    NormalizedInlineFragment, NormalizedInlineFragmentData,
+};
 use crate::query_plan::operation::{
     NormalizedOperation, NormalizedSelection, NormalizedSelectionSet, RebasedFragments,
-    TYPENAME_FIELD,
+    SelectionId, TYPENAME_FIELD,
 };
 use crate::query_plan::FetchDataPathElement;
 use crate::query_plan::{FetchDataRewrite, QueryPlanCost};
@@ -23,10 +26,10 @@ use crate::schema::position::{
 };
 use crate::schema::ValidFederationSchema;
 use crate::subgraph::spec::{ANY_SCALAR_NAME, ENTITIES_QUERY};
-use apollo_compiler::ast::{OperationType, Type};
+use apollo_compiler::ast::{Argument, Directive, OperationType, Type};
 use apollo_compiler::executable::{self, VariableDefinition};
 use apollo_compiler::schema::{self, Name};
-use apollo_compiler::{Node, NodeStr};
+use apollo_compiler::{name, Node, NodeStr};
 use indexmap::{IndexMap, IndexSet};
 use petgraph::stable_graph::{EdgeIndex, NodeIndex, StableDiGraph};
 use petgraph::visit::EdgeRef;
@@ -1143,7 +1146,28 @@ impl FetchDependencyGraphNode {
             })
         });
         Arc::make_mut(inputs).add(selection);
+        self.on_inputs_updated();
         Arc::make_mut(&mut self.input_rewrites).extend(rewrites);
+    }
+
+    // PORT_NOTE: This corresponds to the `GroupInputs.onUpdateCallback` in the JS codebase.
+    //            The callback is an optional value that is set only if the `inputs` is non-null
+    //            in the `FetchGroup` constructor.
+    //            In Rust version, the `self.inputs` is checked every time the `inputs` is updated,
+    //            assuming `self.inputs` won't be changed from None to Some in the middle of its
+    //            lifetime.
+    fn on_inputs_updated(&mut self) {
+        if self.inputs.is_some() {
+            // (Original comment from the JS codebase with a minor adjustment for Rust version):
+            // We're trying to avoid the full recomputation of `is_useless` when we're already
+            // shown that the node is known useful (if it is shown useless, the node is removed,
+            // so we're not caching that result but it's ok). And `is_useless` basically checks if
+            // `inputs.contains(selection)`, so if a group is shown useful, it means that there
+            // is some selections not in the inputs, but as long as we add to selections (and we
+            // never remove from selections), then this won't change. Only changing inputs may
+            // require some recomputation.
+            self.is_known_useful = false;
+        }
     }
 
     pub(crate) fn cost(&mut self) -> Result<QueryPlanCost, FederationError> {
@@ -1527,12 +1551,28 @@ impl FetchInputs {
         }
     }
 
-    fn add(&self, selection: &NormalizedSelectionSet) {
+    fn add(&mut self, selection: &NormalizedSelectionSet) {
         assert_eq!(
             selection.schema, self.supergraph_schema,
             "Inputs selections must be based on the supergraph schema"
         );
-        todo!()
+        let type_selections = self
+            .selection_sets_per_parent_type
+            .entry(selection.type_position.clone())
+            .or_insert_with(|| {
+                Arc::new(NormalizedSelectionSet::empty(
+                    selection.schema.clone(),
+                    selection.type_position.clone(),
+                ))
+            });
+        Arc::make_mut(type_selections).add(selection);
+        // PORT_NOTE: `onUpdateCallback` call is moved to `FetchDependencyGraphNode::on_inputs_updated`.
+    }
+
+    fn add_all(&mut self, other: &Self) {
+        for selections in other.selection_sets_per_parent_type.values() {
+            self.add(selections);
+        }
     }
 
     fn to_selection_set_nodes(
@@ -1914,7 +1954,12 @@ fn compute_nodes_for_key_resolution<'a>(
         &mut FetchDependencyGraph::node_weight_mut(&mut dependency_graph.graph, new_node_id)?;
     new_node.add_inputs(
         &dependency_graph.supergraph_schema,
-        &wrap_input_selections(&input_type, &input_selections, new_context),
+        &wrap_input_selections(
+            &dependency_graph.supergraph_schema,
+            &input_type,
+            input_selections,
+            new_context,
+        ),
         compute_input_rewrites_on_key_fetch(input_type.type_name(), &dest_type)
             .into_iter()
             .flatten(),
@@ -2236,12 +2281,128 @@ fn compute_nodes_for_op_path_element<'a>(
     Ok(updated)
 }
 
+/// A helper function to wrap the `initial` value with nested conditions from `context`.
+fn wrap_selection_with_type_and_conditions<T>(
+    supergraph_schema: &ValidFederationSchema,
+    wrapping_type: &CompositeTypeDefinitionPosition,
+    context: &OpGraphPathContext,
+    initial: T,
+    wrap_in_fragment: fn(NormalizedInlineFragment, T) -> T,
+) -> T {
+    // PORT_NOTE: `unwrap` is used below, but the JS version asserts in `FragmentElement`'s constructor
+    // as well. However, there was a comment that we should add some validation, which is restated below.
+    // TODO: remove the `unwrap` with proper error handling, and ensure we have some intersection
+    // between the wrapping_type type and the new type condition.
+    let type_condition: CompositeTypeDefinitionPosition = supergraph_schema
+        .get_type(wrapping_type.type_name().clone())
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    if context.is_empty() {
+        // PORT_NOTE: JS code looks for type condition in the wrapping type's schema based on
+        // the name of wrapping type. Not sure why.
+        return wrap_in_fragment(
+            NormalizedInlineFragment::new(NormalizedInlineFragmentData {
+                schema: supergraph_schema.clone(),
+                parent_type_position: wrapping_type.clone(),
+                type_condition_position: Some(type_condition.clone()),
+                directives: Default::default(), // None
+                selection_id: SelectionId::new(),
+            }),
+            initial,
+        );
+    }
+
+    // We add the first include/skip to the current type-cast and then wrap in additional
+    // type-casts for the next ones if necessary. Note that we use type-casts (... on <type>), but,
+    // outside of the first one, we could well also use fragments with no type-condition. We do the
+    // former mostly to preserve older behavior, but doing the latter would technically produce
+    // slightly small query plans.
+    // TODO: Next major revision may consider changing this as stated above.
+    context.iter().fold(initial, |acc, cond| {
+        let directive = Directive {
+            name: cond.kind.to_name(),
+            arguments: vec![Argument {
+                name: name!("if"),
+                value: cond.value.to_ast_value().into(),
+            }
+            .into()],
+        };
+        wrap_in_fragment(
+            NormalizedInlineFragment::new(NormalizedInlineFragmentData {
+                schema: supergraph_schema.clone(),
+                parent_type_position: wrapping_type.clone(),
+                type_condition_position: Some(type_condition.clone()),
+                directives: Arc::new([directive].into_iter().collect()),
+                selection_id: SelectionId::new(),
+            }),
+            acc,
+        )
+    })
+}
+
 fn wrap_input_selections(
-    _wrapping_type: &CompositeTypeDefinitionPosition,
-    _selections: &NormalizedSelectionSet,
-    _context: &OpGraphPathContext,
+    supergraph_schema: &ValidFederationSchema,
+    wrapping_type: &CompositeTypeDefinitionPosition,
+    selections: NormalizedSelectionSet,
+    context: &OpGraphPathContext,
 ) -> NormalizedSelectionSet {
-    todo!() // Port `wrapInputsSelections` in `buildPlan.ts`
+    wrap_selection_with_type_and_conditions(
+        supergraph_schema,
+        wrapping_type,
+        context,
+        selections,
+        |fragment, sub_selections| {
+            /* creates a new selection set of the form:
+               {
+                   ... on <fragment's parent type> {
+                       <sub_selections>
+                   }
+               }
+            */
+            let parent_type_position = fragment.data().parent_type_position.clone();
+            let selection =
+                NormalizedSelection::from_normalized_inline_fragment(fragment, sub_selections);
+            NormalizedSelectionSet::from_selection(parent_type_position, selection)
+        },
+    )
+}
+
+fn create_fetch_initial_path(
+    supergraph_schema: &ValidFederationSchema,
+    dest_type: &CompositeTypeDefinitionPosition,
+    context: &OpGraphPathContext,
+) -> Arc<OpPath> {
+    // We make sure that all `OperationPath` are based on the supergraph as `OperationPath` is
+    // really about path on the input query/overall supergraph data (most other places already do
+    // this as the elements added to the operation path are from the input query, but this is
+    // an exception when we create an element from an type that may/usually will not be from the
+    // supergraph). Doing this make sure we can rely on things like checking subtyping between
+    // the types of a given path.
+    // PORT_NOTE: The JS code asserts these panic conditions below as well.
+    let rebased_type: Result<CompositeTypeDefinitionPosition, FederationError> = supergraph_schema
+        .get_type(dest_type.type_name().clone())
+        .and_then(|res| res.try_into());
+    match rebased_type {
+        Err(err) => panic!(
+            "{dest_type} should be composite in the supergraph but got error {}",
+            err
+        ),
+        Ok(ref rebased_type) => {
+            Arc::new(wrap_selection_with_type_and_conditions(
+                supergraph_schema,
+                rebased_type,
+                context,
+                Default::default(),
+                |fragment, sub_path| {
+                    // Return an OpPath of the form: [<fragment>, ...<sub_path>]
+                    let front = vec![Arc::new(fragment.into())];
+                    OpPath(front.into_iter().chain(sub_path.0).collect())
+                },
+            ))
+        }
+    }
 }
 
 fn compute_input_rewrites_on_key_fetch(
@@ -2249,14 +2410,6 @@ fn compute_input_rewrites_on_key_fetch(
     _dest_type: &CompositeTypeDefinitionPosition,
 ) -> Option<Vec<Arc<FetchDataRewrite>>> {
     todo!() // Port `computeInputRewritesOnKeyFetch`
-}
-
-fn create_fetch_initial_path(
-    _supergraph_schema: &ValidFederationSchema,
-    _dest_type: &CompositeTypeDefinitionPosition,
-    _new_context: &OpGraphPathContext,
-) -> Arc<OpPath> {
-    todo!() // Port `createFetchInitialPath`
 }
 
 fn extract_defer_from_operation(

--- a/src/query_plan/fetch_dependency_graph.rs
+++ b/src/query_plan/fetch_dependency_graph.rs
@@ -2326,7 +2326,7 @@ fn wrap_selection_with_type_and_conditions<T>(
     // TODO: Next major revision may consider changing this as stated above.
     context.iter().fold(initial, |acc, cond| {
         let directive = Directive {
-            name: cond.kind.to_name(),
+            name: cond.kind.name(),
             arguments: vec![Argument {
                 name: name!("if"),
                 value: cond.value.to_ast_value().into(),

--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -569,20 +569,14 @@ impl NormalizedSelection {
         }
     }
 
-    pub(crate) fn schema(&self) -> ValidFederationSchema {
+    pub(crate) fn schema(&self) -> &ValidFederationSchema {
         match self {
-            NormalizedSelection::Field(field_selection) => {
-                field_selection.field.data().schema.clone()
-            }
+            NormalizedSelection::Field(field_selection) => &field_selection.field.data().schema,
             NormalizedSelection::FragmentSpread(fragment_spread_selection) => {
-                fragment_spread_selection.spread.data().schema.clone()
+                &fragment_spread_selection.spread.data().schema
             }
             NormalizedSelection::InlineFragment(inline_fragment_selection) => {
-                inline_fragment_selection
-                    .inline_fragment
-                    .data()
-                    .schema
-                    .clone()
+                &inline_fragment_selection.inline_fragment.data().schema
             }
         }
     }
@@ -1490,9 +1484,9 @@ impl NormalizedSelectionSet {
     ) -> Self {
         let schema = selection.schema();
         let mut selection_map = NormalizedSelectionMap::new();
-        selection_map.insert(selection);
+        selection_map.insert(selection.clone());
         Self {
-            schema,
+            schema: schema.clone(),
             type_position,
             selections: Arc::new(selection_map),
         }

--- a/src/query_plan/operation.rs
+++ b/src/query_plan/operation.rs
@@ -527,6 +527,66 @@ pub(crate) enum NormalizedSelection {
 }
 
 impl NormalizedSelection {
+    pub(crate) fn from_normalized_field(
+        field: NormalizedField,
+        sub_selections: Option<NormalizedSelectionSet>,
+    ) -> Self {
+        let field_selection = NormalizedFieldSelection {
+            field,
+            selection_set: sub_selections,
+        };
+        Self::Field(Arc::new(field_selection))
+    }
+
+    pub(crate) fn from_normalized_inline_fragment(
+        inline_fragment: NormalizedInlineFragment,
+        sub_selections: NormalizedSelectionSet,
+    ) -> Self {
+        let inline_fragment_selection = NormalizedInlineFragmentSelection {
+            inline_fragment,
+            selection_set: sub_selections,
+        };
+        Self::InlineFragment(Arc::new(inline_fragment_selection))
+    }
+
+    pub(crate) fn from_element(
+        element: OpPathElement,
+        sub_selections: Option<NormalizedSelectionSet>,
+    ) -> Result<Self, FederationError> {
+        match element {
+            OpPathElement::Field(field) => Ok(Self::from_normalized_field(field, sub_selections)),
+            OpPathElement::InlineFragment(inline_fragment) => {
+                let Some(sub_selections) = sub_selections else {
+                    return Err(FederationError::internal(
+                        "unexpected inline fragment without sub-selections",
+                    ));
+                };
+                Ok(Self::from_normalized_inline_fragment(
+                    inline_fragment,
+                    sub_selections,
+                ))
+            }
+        }
+    }
+
+    pub(crate) fn schema(&self) -> ValidFederationSchema {
+        match self {
+            NormalizedSelection::Field(field_selection) => {
+                field_selection.field.data().schema.clone()
+            }
+            NormalizedSelection::FragmentSpread(fragment_spread_selection) => {
+                fragment_spread_selection.spread.data().schema.clone()
+            }
+            NormalizedSelection::InlineFragment(inline_fragment_selection) => {
+                inline_fragment_selection
+                    .inline_fragment
+                    .data()
+                    .schema
+                    .clone()
+            }
+        }
+    }
+
     fn directives(&self) -> &Arc<DirectiveList> {
         match self {
             NormalizedSelection::Field(field_selection) => &field_selection.field.data().directives,
@@ -1421,6 +1481,20 @@ impl NormalizedSelectionSet {
             schema,
             type_position,
             selections: Default::default(),
+        }
+    }
+
+    pub(crate) fn from_selection(
+        type_position: CompositeTypeDefinitionPosition,
+        selection: NormalizedSelection,
+    ) -> Self {
+        let schema = selection.schema();
+        let mut selection_map = NormalizedSelectionMap::new();
+        selection_map.insert(selection);
+        Self {
+            schema,
+            type_position,
+            selections: Arc::new(selection_map),
         }
     }
 

--- a/src/schema/position.rs
+++ b/src/schema/position.rs
@@ -1,5 +1,6 @@
 use crate::error::{FederationError, SingleFederationError};
 use crate::link::database::links_metadata;
+use crate::link::federation_spec_definition::FEDERATION_INTERFACEOBJECT_DIRECTIVE_NAME_IN_SPEC;
 use crate::link::spec_definition::SpecDefinition;
 use crate::query_graph::QueryGraphNodeType;
 use crate::schema::referencer::{
@@ -308,6 +309,15 @@ impl CompositeTypeDefinitionPosition {
         schema: &'schema Schema,
     ) -> Option<&'schema ExtendedType> {
         self.get(schema).ok()
+    }
+
+    pub(crate) fn is_interface_object_type(&self, schema: &Schema) -> bool {
+        let Ok(ExtendedType::Object(obj_type_def)) = self.get(schema) else {
+            return false;
+        };
+        obj_type_def
+            .directives
+            .has(FEDERATION_INTERFACEOBJECT_DIRECTIVE_NAME_IN_SPEC.as_str())
     }
 }
 


### PR DESCRIPTION
Implemented the following:
- `FetchInputs::add/add_all` methods
- `wrap_input_selections` and `create_fetch_initial_path` functions
-  `compute_input_rewrites_on_key_fetch` function
- And some various helper methods.

https://apollographql.atlassian.net/browse/FED-37
