### PR TITLE
Port has_an_implementation_with_provides()

### DIFF
--- a/src/query_graph/mod.rs
+++ b/src/query_graph/mod.rs
@@ -13,7 +13,6 @@ use indexmap::{IndexMap, IndexSet};
 use petgraph::graph::{DiGraph, EdgeIndex, EdgeReference, NodeIndex};
 use petgraph::visit::EdgeRef;
 use petgraph::Direction;
-use std::any::type_name;
 use std::fmt::{Display, Formatter};
 use std::hash::Hash;
 use std::sync::Arc;


### PR DESCRIPTION
This is used in `OpGraphPath::advance_with_operation_element()`.

Original in JS: https://github.com/apollographql/federation/blob/bbf83946800d0e6f83307e1941cd7052f8a3c38d/query-graphs-js/src/graphPath.ts#L2213-L2224