### PR TITLE
FED-189: port extractDeferFromOperation

### DIFF
--- a/src/link/graphql_definition.rs
+++ b/src/link/graphql_definition.rs
@@ -10,8 +10,8 @@ use apollo_compiler::{name, Node, NodeStr};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct DeferDirectiveArguments {
-    label: Option<NodeStr>,
-    if_: Option<BooleanOrVariable>,
+    pub(crate) label: Option<NodeStr>,
+    pub(crate) if_: Option<BooleanOrVariable>,
 }
 
 impl DeferDirectiveArguments {

--- a/src/link/graphql_definition.rs
+++ b/src/link/graphql_definition.rs
@@ -10,8 +10,8 @@ use apollo_compiler::{name, Node, NodeStr};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct DeferDirectiveArguments {
-    pub(crate) label: Option<NodeStr>,
-    pub(crate) if_: Option<BooleanOrVariable>,
+    label: Option<NodeStr>,
+    if_: Option<BooleanOrVariable>,
 }
 
 impl DeferDirectiveArguments {

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -10,7 +10,7 @@ use std::str;
 use std::{collections::HashMap, sync::Arc};
 use thiserror::Error;
 
-mod argument;
+pub(crate) mod argument;
 pub mod database;
 pub(crate) mod federation_spec_definition;
 pub(crate) mod graphql_definition;

--- a/src/query_plan/fetch_dependency_graph.rs
+++ b/src/query_plan/fetch_dependency_graph.rs
@@ -202,8 +202,8 @@ pub(crate) struct DeferredInfo {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FetchDependencyGraphNodePath {
     pub(crate) full_path: Arc<OpPath>,
-    pub(crate) path_in_node: Arc<OpPath>,
-    pub(crate) response_path: Vec<FetchDataPathElement>,
+    path_in_node: Arc<OpPath>,
+    response_path: Vec<FetchDataPathElement>,
 }
 
 #[derive(Debug, Clone)]
@@ -2445,12 +2445,11 @@ fn extract_defer_from_operation(
         return Ok((Some(operation.clone()), updated_context));
     };
 
-    let Some(ref updated_defer_ref) = defer_args.label else {
+    let updated_defer_ref = defer_args.label().ok_or_else(||
         // PORT_NOTE: The original TypeScript code has an assertion here.
-        return Err(FederationError::internal(
-            "All defers should have a label at this point",
-        ));
-    };
+        FederationError::internal(
+                    "All defers should have a label at this point",
+                ))?;
     let updated_operation = operation.without_defer();
     let updated_path_to_defer_parent = match updated_operation {
         None => Default::default(), // empty OpPath

--- a/src/query_plan/fetch_dependency_graph_processor.rs
+++ b/src/query_plan/fetch_dependency_graph_processor.rs
@@ -346,7 +346,7 @@ impl FetchDependencyGraphProcessor<Option<PlanNode>, DeferredDeferBlock>
             } else {
                 Some(defer_info.label.clone())
             },
-            query_path: (&defer_info.path.full_path).try_into()?,
+            query_path: defer_info.path.full_path.as_ref().try_into()?,
             // Note that if the deferred block has nested @defer,
             // then the `value` is going to be a `DeferNode`
             // and we'll use it's own `subselection`, so we don't need it here.


### PR DESCRIPTION
Implemented `extract_defer_from_operation` function.

Even though most of its functionality won't be used until `@defer` is actually implemented, it's called from `compute_nodes_for_op_path_element` and we would've needed some implementation anyways. So, I ported all of it.