### PR TITLE
Add source-aware data structures for graph path, path tree, and fetch dependency graph

### DIFF
--- a/src/source_aware/federated_query_graph/builder.rs
+++ b/src/source_aware/federated_query_graph/builder.rs
@@ -5,7 +5,8 @@ use crate::sources::{
     SourceFederatedAbstractFieldQueryGraphEdge, SourceFederatedConcreteFieldQueryGraphEdge,
     SourceFederatedConcreteQueryGraphNode, SourceFederatedEnumQueryGraphNode,
     SourceFederatedQueryGraphBuilders, SourceFederatedQueryGraphs,
-    SourceFederatedScalarQueryGraphNode, SourceFederatedTypeConditionQueryGraphEdge, SourceId,
+    SourceFederatedScalarQueryGraphNode, SourceFederatedSourceEnterQueryGraphEdge,
+    SourceFederatedTypeConditionQueryGraphEdge, SourceId,
 };
 use crate::ValidFederationSubgraph;
 use apollo_compiler::schema::{Name, NamedType};
@@ -104,5 +105,12 @@ pub(crate) trait IntraSourceQueryGraphBuilderApi {
         head: NodeIndex,
         tail: NodeIndex,
         source_data: SourceFederatedTypeConditionQueryGraphEdge,
+    ) -> Result<EdgeIndex, FederationError>;
+
+    fn add_source_enter_edge(
+        &mut self,
+        tail: NodeIndex,
+        self_conditions: Option<SelfConditionIndex>,
+        source_data: SourceFederatedSourceEnterQueryGraphEdge,
     ) -> Result<EdgeIndex, FederationError>;
 }

--- a/src/source_aware/federated_query_graph/graph_path.rs
+++ b/src/source_aware/federated_query_graph/graph_path.rs
@@ -1,0 +1,53 @@
+use crate::query_plan::operation::normalized_field_selection::NormalizedField;
+use crate::query_plan::operation::normalized_inline_fragment_selection::NormalizedInlineFragment;
+use crate::schema::position::ObjectTypeDefinitionPosition;
+use crate::source_aware::federated_query_graph::path_tree::FederatedPathTree;
+use crate::source_aware::federated_query_graph::{FederatedQueryGraph, SelfConditionIndex};
+use crate::source_aware::query_plan::QueryPlanCost;
+use indexmap::{IndexMap, IndexSet};
+use petgraph::graph::{EdgeIndex, NodeIndex};
+use std::sync::Arc;
+
+#[derive(Debug, Clone)]
+pub(crate) struct FederatedGraphPath {
+    graph: Arc<FederatedQueryGraph>,
+    head: NodeIndex,
+    tail: NodeIndex,
+    edges: Vec<Arc<FederatedGraphPathEdge>>,
+    last_source_enter_edge_info: Option<SourceEnterEdgeInfo>,
+    runtime_types_at_tail: Arc<IndexSet<ObjectTypeDefinitionPosition>>,
+    runtime_types_before_last_edge_if_type_condition:
+        Option<Arc<IndexSet<ObjectTypeDefinitionPosition>>>,
+}
+
+#[derive(Debug)]
+pub(crate) struct FederatedGraphPathEdge {
+    operation_element: Option<Arc<OperationPathElement>>,
+    edge: Option<EdgeIndex>,
+    self_condition_resolutions_for_edge: IndexMap<SelfConditionIndex, ConditionResolutionId>,
+    source_enter_condition_resolutions_at_edge:
+        IndexMap<SelfConditionIndex, ConditionResolutionInfo>,
+    condition_resolutions_at_edge: IndexMap<SelfConditionIndex, ConditionResolutionInfo>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, derive_more::From)]
+pub(crate) enum OperationPathElement {
+    Field(NormalizedField),
+    InlineFragment(NormalizedInlineFragment),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub(crate) struct ConditionResolutionId(usize);
+
+#[derive(Debug)]
+pub(crate) struct ConditionResolutionInfo {
+    id: ConditionResolutionId,
+    resolution: Arc<FederatedPathTree>,
+    cost: QueryPlanCost,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SourceEnterEdgeInfo {
+    index: usize,
+    conditions_cost: QueryPlanCost,
+}

--- a/src/source_aware/federated_query_graph/mod.rs
+++ b/src/source_aware/federated_query_graph/mod.rs
@@ -8,8 +8,8 @@ use crate::schema::position::{
 use crate::sources::{
     SourceFederatedAbstractFieldQueryGraphEdge, SourceFederatedAbstractQueryGraphNode,
     SourceFederatedConcreteFieldQueryGraphEdge, SourceFederatedConcreteQueryGraphNode,
-    SourceFederatedEnumQueryGraphNode, SourceFederatedLookupQueryGraphEdge,
-    SourceFederatedQueryGraphs, SourceFederatedScalarQueryGraphNode,
+    SourceFederatedEnumQueryGraphNode, SourceFederatedQueryGraphs,
+    SourceFederatedScalarQueryGraphNode, SourceFederatedSourceEnterQueryGraphEdge,
     SourceFederatedTypeConditionQueryGraphEdge, SourceId,
 };
 use apollo_compiler::schema::NamedType;
@@ -17,12 +17,14 @@ use indexmap::{IndexMap, IndexSet};
 use petgraph::graph::{DiGraph, EdgeIndex, NodeIndex};
 
 pub(crate) mod builder;
+pub(crate) mod graph_path;
+pub(crate) mod path_tree;
 
 #[derive(Debug)]
 pub struct FederatedQueryGraph {
     graph: DiGraph<FederatedQueryGraphNode, FederatedQueryGraphEdge>,
-    supergraph_types_to_nodes: IndexMap<NamedType, IndexSet<NodeIndex>>,
-    supergraph_root_kinds_to_nodes: IndexMap<SchemaRootDefinitionKind, NodeIndex>,
+    supergraph_types_to_root_nodes: IndexMap<NamedType, IndexSet<NodeIndex>>,
+    supergraph_root_kinds_to_types: IndexMap<SchemaRootDefinitionKind, NamedType>,
     self_conditions: Vec<NormalizedSelectionSet>,
     non_trivial_followup_edges: IndexMap<EdgeIndex, IndexSet<EdgeIndex>>,
     source_data: SourceFederatedQueryGraphs,
@@ -30,18 +32,22 @@ pub struct FederatedQueryGraph {
 
 #[derive(Debug)]
 pub(crate) enum FederatedQueryGraphNode {
+    Root {
+        supergraph_type: ObjectTypeDefinitionPosition,
+        source_enters: IndexMap<NodeIndex, IndexSet<EdgeIndex>>,
+    },
     Abstract {
         supergraph_type: AbstractTypeDefinitionPosition,
-        fields: IndexMap<AbstractFieldDefinitionPosition, IndexSet<EdgeIndex>>,
-        type_conditions: IndexMap<CompositeTypeDefinitionPosition, IndexSet<EdgeIndex>>,
-        lookups: IndexMap<NodeIndex, IndexSet<EdgeIndex>>,
+        fields: IndexMap<AbstractFieldDefinitionPosition, EdgeIndex>,
+        type_conditions:
+            IndexMap<CompositeTypeDefinitionPosition, (Option<EdgeIndex>, IndexSet<EdgeIndex>)>,
         source_id: SourceId,
         source_data: SourceFederatedAbstractQueryGraphNode,
     },
     Concrete {
         supergraph_type: ObjectTypeDefinitionPosition,
-        fields: IndexMap<ObjectFieldDefinitionPosition, IndexSet<EdgeIndex>>,
-        lookups: IndexMap<NodeIndex, IndexSet<EdgeIndex>>,
+        fields: IndexMap<ObjectFieldDefinitionPosition, EdgeIndex>,
+        source_exit: Option<EdgeIndex>,
         source_id: SourceId,
         source_data: SourceFederatedConcreteQueryGraphNode,
     },
@@ -60,6 +66,9 @@ pub(crate) enum FederatedQueryGraphNode {
 impl FederatedQueryGraphNode {
     pub(crate) fn supergraph_type(&self) -> OutputTypeDefinitionPosition {
         match self {
+            FederatedQueryGraphNode::Root {
+                supergraph_type, ..
+            } => supergraph_type.clone().into(),
             FederatedQueryGraphNode::Abstract {
                 supergraph_type, ..
             } => supergraph_type.clone().into(),
@@ -75,12 +84,13 @@ impl FederatedQueryGraphNode {
         }
     }
 
-    pub(crate) fn source_id(&self) -> &SourceId {
+    pub(crate) fn source_id(&self) -> Option<&SourceId> {
         match self {
-            FederatedQueryGraphNode::Abstract { source_id, .. } => source_id,
-            FederatedQueryGraphNode::Concrete { source_id, .. } => source_id,
-            FederatedQueryGraphNode::Enum { source_id, .. } => source_id,
-            FederatedQueryGraphNode::Scalar { source_id, .. } => source_id,
+            FederatedQueryGraphNode::Root { .. } => None,
+            FederatedQueryGraphNode::Abstract { source_id, .. } => Some(source_id),
+            FederatedQueryGraphNode::Concrete { source_id, .. } => Some(source_id),
+            FederatedQueryGraphNode::Enum { source_id, .. } => Some(source_id),
+            FederatedQueryGraphNode::Scalar { source_id, .. } => Some(source_id),
         }
     }
 }
@@ -89,14 +99,13 @@ impl FederatedQueryGraphNode {
 pub(crate) enum FederatedQueryGraphEdge {
     AbstractField {
         supergraph_field: AbstractFieldDefinitionPosition,
-        self_conditions: Option<ConditionNormalizedSelectionSet>,
         matches_concrete_options: bool,
         source_id: SourceId,
         source_data: Option<SourceFederatedAbstractFieldQueryGraphEdge>,
     },
     ConcreteField {
         supergraph_field: ObjectFieldDefinitionPosition,
-        self_conditions: Option<ConditionNormalizedSelectionSet>,
+        self_conditions: Option<SelfConditionIndex>,
         source_id: SourceId,
         source_data: Option<SourceFederatedConcreteFieldQueryGraphEdge>,
     },
@@ -105,11 +114,15 @@ pub(crate) enum FederatedQueryGraphEdge {
         source_id: SourceId,
         source_data: Option<SourceFederatedTypeConditionQueryGraphEdge>,
     },
-    Lookup {
+    SourceEnter {
         supergraph_type: ObjectTypeDefinitionPosition,
-        self_conditions: Option<ConditionNormalizedSelectionSet>,
-        source_id: SourceId,
-        source_data: Option<SourceFederatedLookupQueryGraphEdge>,
+        self_conditions: Option<SelfConditionIndex>,
+        tail_source_id: SourceId,
+        source_data: Option<SourceFederatedSourceEnterQueryGraphEdge>,
+    },
+    SourceExit {
+        supergraph_type: ObjectTypeDefinitionPosition,
+        head_source_id: SourceId,
     },
 }
 

--- a/src/source_aware/federated_query_graph/path_tree.rs
+++ b/src/source_aware/federated_query_graph/path_tree.rs
@@ -1,0 +1,30 @@
+use crate::source_aware::federated_query_graph::graph_path::{
+    ConditionResolutionId, ConditionResolutionInfo, OperationPathElement,
+};
+use crate::source_aware::federated_query_graph::{FederatedQueryGraph, SelfConditionIndex};
+use indexmap::IndexMap;
+use petgraph::graph::{EdgeIndex, NodeIndex};
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub(crate) struct FederatedPathTree {
+    graph: Arc<FederatedQueryGraph>,
+    node: NodeIndex,
+    childs: Vec<Arc<FederatedPathTreeChild>>,
+}
+
+#[derive(Debug)]
+pub(crate) struct FederatedPathTreeChild {
+    key: FederatedPathTreeChildKey,
+    self_condition_resolutions_for_edge: IndexMap<SelfConditionIndex, ConditionResolutionId>,
+    source_enter_condition_resolutions_at_edge:
+        IndexMap<SelfConditionIndex, ConditionResolutionInfo>,
+    condition_resolutions_at_edge: IndexMap<SelfConditionIndex, ConditionResolutionInfo>,
+    tree: Arc<FederatedPathTree>,
+}
+
+#[derive(Debug)]
+pub(crate) struct FederatedPathTreeChildKey {
+    operation_element: Option<Arc<OperationPathElement>>,
+    edge: Option<EdgeIndex>,
+}

--- a/src/source_aware/fetch_dependency_graph/mod.rs
+++ b/src/source_aware/fetch_dependency_graph/mod.rs
@@ -1,0 +1,40 @@
+use crate::query_plan::operation::NormalizedSelectionSet;
+use crate::source_aware::federated_query_graph::graph_path::ConditionResolutionId;
+use crate::source_aware::federated_query_graph::FederatedQueryGraph;
+use crate::source_aware::query_plan::FetchDataPathElement;
+use crate::sources::{SourceFetchDependencyGraphNode, SourceFetchDependencyGraphs, SourceId};
+use apollo_compiler::executable::Name;
+use indexmap::{IndexMap, IndexSet};
+use petgraph::graph::{EdgeIndex, NodeIndex};
+use petgraph::stable_graph::StableDiGraph;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub(crate) struct FetchDependencyGraph {
+    query_graph: Arc<FederatedQueryGraph>,
+    graph: FetchDependencyGraphPetgraph,
+    root_nodes_by_source: IndexMap<SourceId, IndexSet<NodeIndex>>,
+    is_reduced: bool,
+    condition_resolutions_to_selection_sets:
+        IndexMap<ConditionResolutionId, NormalizedSelectionSet>,
+    condition_resolutions_to_dependent_nodes: IndexMap<ConditionResolutionId, IndexSet<NodeIndex>>,
+    condition_resolutions_to_containing_nodes: IndexMap<ConditionResolutionId, IndexSet<NodeIndex>>,
+    source_data: SourceFetchDependencyGraphs,
+}
+
+type FetchDependencyGraphPetgraph =
+    StableDiGraph<Arc<FetchDependencyGraphNode>, Arc<FetchDependencyGraphEdge>>;
+
+#[derive(Debug)]
+pub(crate) struct FetchDependencyGraphNode {
+    merge_at: Vec<FetchDataPathElement>,
+    source_enter_edge: EdgeIndex,
+    operation_variables: IndexSet<Name>,
+    depends_on_condition_resolutions: IndexSet<ConditionResolutionId>,
+    contains_condition_resolutions: IndexSet<ConditionResolutionId>,
+    source_id: SourceId,
+    source_data: SourceFetchDependencyGraphNode,
+}
+
+#[derive(Debug)]
+pub(crate) struct FetchDependencyGraphEdge;

--- a/src/source_aware/mod.rs
+++ b/src/source_aware/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod federated_query_graph;
+pub(crate) mod fetch_dependency_graph;
 pub(crate) mod query_plan;

--- a/src/source_aware/query_plan/mod.rs
+++ b/src/source_aware/query_plan/mod.rs
@@ -49,7 +49,7 @@ pub enum PlanNode {
 #[derive(Debug)]
 pub struct FetchNode {
     pub operation_variables: IndexSet<Name>,
-    pub key_and_requires_conditions: SelectionSet,
+    pub key_conditions: SelectionSet,
     pub source_data: SourceFetchNode,
 }
 

--- a/src/sources/connect/mod.rs
+++ b/src/sources/connect/mod.rs
@@ -5,19 +5,30 @@ mod url_path_template;
 use crate::error::FederationError;
 use crate::schema::position::{
     EnumTypeDefinitionPosition, ObjectFieldDefinitionPosition,
-    ObjectOrInterfaceFieldDirectivePosition, ObjectOrInterfaceTypeDefinitionPosition,
-    ObjectTypeDefinitionPosition, ScalarTypeDefinitionPosition,
+    ObjectOrInterfaceFieldDirectivePosition, ObjectTypeDefinitionPosition,
+    ScalarTypeDefinitionPosition,
 };
 use crate::source_aware::federated_query_graph::builder::IntraSourceQueryGraphBuilderApi;
+use crate::source_aware::federated_query_graph::graph_path::{
+    ConditionResolutionId, OperationPathElement,
+};
+use crate::source_aware::federated_query_graph::path_tree::FederatedPathTreeChildKey;
+use crate::source_aware::federated_query_graph::{FederatedQueryGraph, SelfConditionIndex};
+use crate::source_aware::query_plan::{FetchDataPathElement, QueryPlanCost};
 use crate::sources::connect::selection_parser::{PathSelection, Property, SubSelection};
-use crate::sources::{FederatedLookupTailData, SourceFederatedQueryGraphBuilderApi};
+use crate::sources::{
+    SourceFederatedQueryGraphBuilderApi, SourceFetchDependencyGraphApi,
+    SourceFetchDependencyGraphNode, SourceFetchNode, SourceId, SourcePath, SourcePathApi,
+};
 use crate::ValidFederationSubgraph;
 use apollo_compiler::executable::{Name, Value};
 use apollo_compiler::NodeStr;
 use indexmap::{IndexMap, IndexSet};
+use petgraph::graph::EdgeIndex;
 pub use selection_parser::ApplyTo;
 pub use selection_parser::ApplyToError;
 pub use selection_parser::Selection;
+use std::sync::Arc;
 pub use url_path_template::URLPathTemplate;
 
 pub(crate) use spec::ConnectSpecDefinition;
@@ -106,9 +117,9 @@ pub(crate) enum ConnectFederatedConcreteFieldQueryGraphEdge {
 pub(crate) struct ConnectFederatedTypeConditionQueryGraphEdge;
 
 #[derive(Debug)]
-pub(crate) enum ConnectFederatedLookupQueryGraphEdge {
+pub(crate) enum ConnectFederatedSourceEnterQueryGraphEdge {
     ConnectParent {
-        subgraph_type: ObjectOrInterfaceTypeDefinitionPosition,
+        subgraph_type: ObjectTypeDefinitionPosition,
     },
 }
 
@@ -119,7 +130,95 @@ impl SourceFederatedQueryGraphBuilderApi for ConnectFederatedQueryGraphBuilder {
         &self,
         _subgraph: ValidFederationSubgraph,
         _builder: &mut impl IntraSourceQueryGraphBuilderApi,
-    ) -> Result<Vec<FederatedLookupTailData>, FederationError> {
+    ) -> Result<(), FederationError> {
+        todo!()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ConnectFetchDependencyGraph;
+
+impl SourceFetchDependencyGraphApi for ConnectFetchDependencyGraph {
+    fn can_reuse_node(
+        &self,
+        _query_graph: Arc<FederatedQueryGraph>,
+        _merge_at: &[FetchDataPathElement],
+        _source_enter_edge: EdgeIndex,
+        _source_data: &SourceFetchDependencyGraphNode,
+        _path_tree_edges: Vec<FederatedPathTreeChildKey>,
+    ) -> Result<Vec<FederatedPathTreeChildKey>, FederationError> {
+        todo!()
+    }
+
+    fn add_node(
+        &self,
+        _query_graph: Arc<FederatedQueryGraph>,
+        _merge_at: &[FetchDataPathElement],
+        _source_enter_edge: EdgeIndex,
+        _self_condition_resolution: Option<ConditionResolutionId>,
+    ) -> Result<SourceFetchDependencyGraphNode, FederationError> {
+        todo!()
+    }
+
+    fn new_path(
+        &self,
+        _query_graph: Arc<FederatedQueryGraph>,
+        _merge_at: &[FetchDataPathElement],
+        _source_enter_edge: EdgeIndex,
+        _self_condition_resolution: Option<ConditionResolutionId>,
+    ) -> Result<SourcePath, FederationError> {
+        todo!()
+    }
+
+    fn add_path(
+        &self,
+        _source_path: SourcePath,
+        _source_data: &mut SourceFetchDependencyGraphNode,
+    ) -> Result<(), FederationError> {
+        todo!()
+    }
+
+    fn to_cost(
+        &self,
+        _query_graph: Arc<FederatedQueryGraph>,
+        _source_id: SourceId,
+        _source_data: &SourceFetchDependencyGraphNode,
+    ) -> Result<QueryPlanCost, FederationError> {
+        todo!()
+    }
+
+    fn to_plan_node(
+        &self,
+        _query_graph: Arc<FederatedQueryGraph>,
+        _source_id: SourceId,
+        _source_data: &SourceFetchDependencyGraphNode,
+        _fetch_count: u32,
+    ) -> Result<SourceFetchNode, FederationError> {
+        todo!()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ConnectFetchDependencyGraphNode {
+    arguments: IndexMap<Name, Value>,
+    selection: Selection,
+}
+
+#[derive(Debug)]
+pub(crate) struct ConnectPath;
+
+impl SourcePathApi for ConnectPath {
+    fn source_id(&self) -> &SourceId {
+        todo!()
+    }
+
+    fn add_operation_element(
+        &self,
+        _query_graph: Arc<FederatedQueryGraph>,
+        _operation_element: Arc<OperationPathElement>,
+        _edge: Option<EdgeIndex>,
+        _self_condition_resolutions: IndexMap<SelfConditionIndex, ConditionResolutionId>,
+    ) -> Result<SourcePath, FederationError> {
         todo!()
     }
 }

--- a/src/sources/graphql/mod.rs
+++ b/src/sources/graphql/mod.rs
@@ -1,4 +1,6 @@
 use crate::error::FederationError;
+use crate::query_plan::operation::NormalizedSelectionSet;
+use crate::query_plan::query_planner::QueryPlannerConfig;
 use crate::schema::position::{
     AbstractFieldDefinitionPosition, AbstractTypeDefinitionPosition,
     CompositeTypeDefinitionPosition, EnumTypeDefinitionPosition, ObjectFieldDefinitionPosition,
@@ -6,13 +8,23 @@ use crate::schema::position::{
     ScalarTypeDefinitionPosition, SchemaRootDefinitionKind,
 };
 use crate::source_aware::federated_query_graph::builder::IntraSourceQueryGraphBuilderApi;
-use crate::source_aware::federated_query_graph::SelfConditionIndex;
-use crate::sources::{FederatedLookupTailData, SourceFederatedQueryGraphBuilderApi};
+use crate::source_aware::federated_query_graph::graph_path::{
+    ConditionResolutionId, OperationPathElement,
+};
+use crate::source_aware::federated_query_graph::path_tree::FederatedPathTreeChildKey;
+use crate::source_aware::federated_query_graph::{FederatedQueryGraph, SelfConditionIndex};
+use crate::source_aware::query_plan::{FetchDataPathElement, QueryPlanCost};
+use crate::sources::{
+    SourceFederatedQueryGraphBuilderApi, SourceFetchDependencyGraphApi,
+    SourceFetchDependencyGraphNode, SourceFetchNode, SourceId, SourcePath, SourcePathApi,
+};
 use crate::ValidFederationSubgraph;
-use apollo_compiler::executable::OperationType;
+use apollo_compiler::executable::{OperationType, VariableDefinition};
 use apollo_compiler::validation::Valid;
-use apollo_compiler::{ExecutableDocument, NodeStr};
+use apollo_compiler::{ExecutableDocument, Node, NodeStr};
 use indexmap::IndexMap;
+use petgraph::graph::EdgeIndex;
+use std::sync::Arc;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub(crate) struct GraphqlId {
@@ -63,7 +75,7 @@ pub(crate) struct GraphqlFederatedTypeConditionQueryGraphEdge {
 }
 
 #[derive(Debug)]
-pub(crate) enum GraphqlFederatedLookupQueryGraphEdge {
+pub(crate) enum GraphqlFederatedSourceEnterQueryGraphEdge {
     OperationRoot {
         subgraph_type: ObjectTypeDefinitionPosition,
         root_kind: SchemaRootDefinitionKind,
@@ -81,7 +93,104 @@ impl SourceFederatedQueryGraphBuilderApi for GraphqlFederatedQueryGraphBuilder {
         &self,
         _subgraph: ValidFederationSubgraph,
         _builder: &mut impl IntraSourceQueryGraphBuilderApi,
-    ) -> Result<Vec<FederatedLookupTailData>, FederationError> {
+    ) -> Result<(), FederationError> {
+        todo!()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct GraphqlFetchDependencyGraph {
+    parameters: Arc<QueryPlannerConfig>,
+    variable_definitions: Vec<Node<VariableDefinition>>,
+    operation_name: Option<NodeStr>,
+}
+
+impl SourceFetchDependencyGraphApi for GraphqlFetchDependencyGraph {
+    fn can_reuse_node(
+        &self,
+        _query_graph: Arc<FederatedQueryGraph>,
+        _merge_at: &[FetchDataPathElement],
+        _source_enter_edge: EdgeIndex,
+        _source_data: &SourceFetchDependencyGraphNode,
+        _path_tree_edges: Vec<FederatedPathTreeChildKey>,
+    ) -> Result<Vec<FederatedPathTreeChildKey>, FederationError> {
+        todo!()
+    }
+
+    fn add_node(
+        &self,
+        _query_graph: Arc<FederatedQueryGraph>,
+        _merge_at: &[FetchDataPathElement],
+        _source_enter_edge: EdgeIndex,
+        _self_condition_resolution: Option<ConditionResolutionId>,
+    ) -> Result<SourceFetchDependencyGraphNode, FederationError> {
+        todo!()
+    }
+
+    fn new_path(
+        &self,
+        _query_graph: Arc<FederatedQueryGraph>,
+        _merge_at: &[FetchDataPathElement],
+        _source_enter_edge: EdgeIndex,
+        _self_condition_resolution: Option<ConditionResolutionId>,
+    ) -> Result<SourcePath, FederationError> {
+        todo!()
+    }
+
+    fn add_path(
+        &self,
+        _source_path: SourcePath,
+        _source_data: &mut SourceFetchDependencyGraphNode,
+    ) -> Result<(), FederationError> {
+        todo!()
+    }
+
+    fn to_cost(
+        &self,
+        _query_graph: Arc<FederatedQueryGraph>,
+        _source_id: SourceId,
+        _source_data: &SourceFetchDependencyGraphNode,
+    ) -> Result<QueryPlanCost, FederationError> {
+        todo!()
+    }
+
+    fn to_plan_node(
+        &self,
+        _query_graph: Arc<FederatedQueryGraph>,
+        _source_id: SourceId,
+        _source_data: &SourceFetchDependencyGraphNode,
+        _fetch_count: u32,
+    ) -> Result<SourceFetchNode, FederationError> {
+        todo!()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum GraphqlFetchDependencyGraphNode {
+    OperationRoot {
+        selection_set: NormalizedSelectionSet,
+    },
+    EntitiesField {
+        key_condition_resolution: Option<ConditionResolutionId>,
+        selection_set: NormalizedSelectionSet,
+    },
+}
+
+#[derive(Debug)]
+pub(crate) struct GraphqlPath;
+
+impl SourcePathApi for GraphqlPath {
+    fn source_id(&self) -> &SourceId {
+        todo!()
+    }
+
+    fn add_operation_element(
+        &self,
+        _query_graph: Arc<FederatedQueryGraph>,
+        _operation_element: Arc<OperationPathElement>,
+        _edge: Option<EdgeIndex>,
+        _self_condition_resolutions: IndexMap<SelfConditionIndex, ConditionResolutionId>,
+    ) -> Result<SourcePath, FederationError> {
         todo!()
     }
 }


### PR DESCRIPTION
<!-- FED-197 -->
This PR adds source-aware data structures for graph paths, path trees, and fetch dependency graphs.

To summarize:
1. Graph paths have been updated to use condition indexes (which speeds up comparisons, and helps us avoid merging until the end) and condition resolution IDs (which help us better track data dependencies).
2. Path trees have been updated to accommodate the above changes.
3. Fetch dependency graphs have similarly been updated to accommodate the above changes, along with changes toward splitting out source-agnostic and source-specific code. This introduces a few traits at the boundary of such code (`SourceFetchDependencyGraphApi` and `SourcePathApi`).