### PR TITLE
Adjust `source_query_graph()` in intra-source builder API

### DIFF
--- a/src/source_aware/federated_query_graph/builder.rs
+++ b/src/source_aware/federated_query_graph/builder.rs
@@ -4,9 +4,9 @@ use crate::source_aware::federated_query_graph::{FederatedQueryGraph, SelfCondit
 use crate::sources::{
     SourceFederatedAbstractFieldQueryGraphEdge, SourceFederatedConcreteFieldQueryGraphEdge,
     SourceFederatedConcreteQueryGraphNode, SourceFederatedEnumQueryGraphNode,
-    SourceFederatedQueryGraphBuilders, SourceFederatedQueryGraphs,
+    SourceFederatedQueryGraph, SourceFederatedQueryGraphBuilders,
     SourceFederatedScalarQueryGraphNode, SourceFederatedSourceEnterQueryGraphEdge,
-    SourceFederatedTypeConditionQueryGraphEdge, SourceId,
+    SourceFederatedTypeConditionQueryGraphEdge, SourceId, SourceKind,
 };
 use crate::ValidFederationSubgraph;
 use apollo_compiler::schema::{Name, NamedType};
@@ -18,7 +18,7 @@ struct FederatedQueryGraphBuilder {
     supergraph_schema: ValidFederationSchema,
     api_schema: ValidFederationSchema,
     subgraphs_by_name: IndexMap<NodeStr, ValidFederationSubgraph>,
-    for_query_planning: bool,
+    is_for_query_planning: bool,
     source_data: SourceFederatedQueryGraphBuilders,
 }
 
@@ -26,7 +26,7 @@ impl FederatedQueryGraphBuilder {
     pub(crate) fn new(
         _supergraph_schema: ValidFederationSchema,
         _api_schema: ValidFederationSchema,
-        _for_query_planning: bool,
+        _is_for_query_planning: bool,
     ) -> Result<Self, FederationError> {
         todo!()
     }
@@ -40,11 +40,13 @@ struct IntraSourceQueryGraphBuilder {
     graph: FederatedQueryGraph,
     supergraph_schema: ValidFederationSchema,
     api_schema: ValidFederationSchema,
-    for_query_planning: bool,
+    is_for_query_planning: bool,
+    current_source_kind: Option<SourceKind>,
+    current_source_id: Option<SourceId>,
 }
 
 pub(crate) trait IntraSourceQueryGraphBuilderApi {
-    fn source_query_graph(&mut self) -> &mut SourceFederatedQueryGraphs;
+    fn source_query_graph(&mut self) -> Result<&mut SourceFederatedQueryGraph, FederationError>;
 
     fn is_for_query_planning(&self) -> bool;
 

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -36,7 +36,6 @@ pub mod graphql;
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub(crate) enum SourceKind {
-    Root,
     Graphql,
     Connect,
 }
@@ -53,10 +52,14 @@ impl SourceId {
     }
 }
 
+pub(crate) enum SourceFederatedQueryGraph {
+    Graphql(GraphqlFederatedQueryGraph),
+    Connect(ConnectFederatedQueryGraph),
+}
+
 #[derive(Debug)]
 pub(crate) struct SourceFederatedQueryGraphs {
-    graphql: GraphqlFederatedQueryGraph,
-    connect: ConnectFederatedQueryGraph,
+    graphs: IndexMap<SourceKind, SourceFetchDependencyGraph>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
<!-- FED-197 -->
Previously `source_query_graph()` was returning `&mut SourceFederatedQueryGraphs`, though we'd prefer to give back `&mut SourceFederatedQueryGraph` instead (i.e. hiding other source-kind query graph data, since it turns out we can't really use `super` to hide them in `SourceFederatedQueryGraphs` without eliciting warnings).