### PR TITLE
Adjust root node mapping in federated query graphs

### DIFF
--- a/src/source_aware/federated_query_graph/builder.rs
+++ b/src/source_aware/federated_query_graph/builder.rs
@@ -41,6 +41,7 @@ struct IntraSourceQueryGraphBuilder {
     supergraph_schema: ValidFederationSchema,
     api_schema: ValidFederationSchema,
     is_for_query_planning: bool,
+    non_entity_supergraph_types_to_nodes: IndexMap<NamedType, IndexSet<NodeIndex>>,
     current_source_kind: Option<SourceKind>,
     current_source_id: Option<SourceId>,
 }

--- a/src/source_aware/federated_query_graph/mod.rs
+++ b/src/source_aware/federated_query_graph/mod.rs
@@ -23,7 +23,7 @@ pub(crate) mod path_tree;
 #[derive(Debug)]
 pub struct FederatedQueryGraph {
     graph: DiGraph<FederatedQueryGraphNode, FederatedQueryGraphEdge>,
-    supergraph_types_to_root_nodes: IndexMap<NamedType, IndexSet<NodeIndex>>,
+    supergraph_types_to_root_nodes: IndexMap<NamedType, NodeIndex>,
     supergraph_root_kinds_to_types: IndexMap<SchemaRootDefinitionKind, NamedType>,
     self_conditions: Vec<NormalizedSelectionSet>,
     non_trivial_followup_edges: IndexMap<EdgeIndex, IndexSet<EdgeIndex>>,


### PR DESCRIPTION
<!-- FED-197 -->
This PR:
- Adjusts the root node mapping to indicate there's only one per supergraph type.
- Tracks non-entity nodes in the intra-source builder, so we can add `SourceExit` edges from them if a root appears later.