### PR TITLE
Adjust naming, and add data for GraphqlPath/ConnectPath

### DIFF
--- a/src/source_aware/federated_query_graph/builder.rs
+++ b/src/source_aware/federated_query_graph/builder.rs
@@ -1,11 +1,12 @@
 use crate::error::FederationError;
+use crate::schema::position::ObjectTypeDefinitionPosition;
 use crate::schema::ValidFederationSchema;
 use crate::source_aware::federated_query_graph::{FederatedQueryGraph, SelfConditionIndex};
 use crate::sources::{
     SourceFederatedAbstractFieldQueryGraphEdge, SourceFederatedConcreteFieldQueryGraphEdge,
     SourceFederatedConcreteQueryGraphNode, SourceFederatedEnumQueryGraphNode,
     SourceFederatedQueryGraph, SourceFederatedQueryGraphBuilders,
-    SourceFederatedScalarQueryGraphNode, SourceFederatedSourceEnterQueryGraphEdge,
+    SourceFederatedScalarQueryGraphNode, SourceFederatedSourceEnteringQueryGraphEdge,
     SourceFederatedTypeConditionQueryGraphEdge, SourceId, SourceKind,
 };
 use crate::ValidFederationSubgraph;
@@ -41,7 +42,8 @@ struct IntraSourceQueryGraphBuilder {
     supergraph_schema: ValidFederationSchema,
     api_schema: ValidFederationSchema,
     is_for_query_planning: bool,
-    non_entity_supergraph_types_to_nodes: IndexMap<NamedType, IndexSet<NodeIndex>>,
+    non_entity_supergraph_types_to_nodes:
+        IndexMap<ObjectTypeDefinitionPosition, IndexSet<NodeIndex>>,
     current_source_kind: Option<SourceKind>,
     current_source_id: Option<SourceId>,
 }
@@ -110,10 +112,10 @@ pub(crate) trait IntraSourceQueryGraphBuilderApi {
         source_data: SourceFederatedTypeConditionQueryGraphEdge,
     ) -> Result<EdgeIndex, FederationError>;
 
-    fn add_source_enter_edge(
+    fn add_source_entering_edge(
         &mut self,
         tail: NodeIndex,
         self_conditions: Option<SelfConditionIndex>,
-        source_data: SourceFederatedSourceEnterQueryGraphEdge,
+        source_data: SourceFederatedSourceEnteringQueryGraphEdge,
     ) -> Result<EdgeIndex, FederationError>;
 }

--- a/src/source_aware/federated_query_graph/graph_path.rs
+++ b/src/source_aware/federated_query_graph/graph_path.rs
@@ -1,6 +1,5 @@
 use crate::query_plan::operation::normalized_field_selection::NormalizedField;
 use crate::query_plan::operation::normalized_inline_fragment_selection::NormalizedInlineFragment;
-use crate::schema::position::ObjectTypeDefinitionPosition;
 use crate::source_aware::federated_query_graph::path_tree::FederatedPathTree;
 use crate::source_aware::federated_query_graph::{FederatedQueryGraph, SelfConditionIndex};
 use crate::source_aware::query_plan::QueryPlanCost;
@@ -14,10 +13,9 @@ pub(crate) struct FederatedGraphPath {
     head: NodeIndex,
     tail: NodeIndex,
     edges: Vec<Arc<FederatedGraphPathEdge>>,
-    last_source_enter_edge_info: Option<SourceEnterEdgeInfo>,
-    runtime_types_at_tail: Arc<IndexSet<ObjectTypeDefinitionPosition>>,
-    runtime_types_before_last_edge_if_type_condition:
-        Option<Arc<IndexSet<ObjectTypeDefinitionPosition>>>,
+    last_source_entering_edge_info: Option<SourceEnteringEdgeInfo>,
+    possible_concrete_nodes_at_tail: Arc<IndexSet<NodeIndex>>,
+    possible_concrete_nodes_before_last_edge_if_type_condition: Option<Arc<IndexSet<NodeIndex>>>,
 }
 
 #[derive(Debug)]
@@ -25,7 +23,7 @@ pub(crate) struct FederatedGraphPathEdge {
     operation_element: Option<Arc<OperationPathElement>>,
     edge: Option<EdgeIndex>,
     self_condition_resolutions_for_edge: IndexMap<SelfConditionIndex, ConditionResolutionId>,
-    source_enter_condition_resolutions_at_edge:
+    source_entering_condition_resolutions_at_edge:
         IndexMap<SelfConditionIndex, ConditionResolutionInfo>,
     condition_resolutions_at_edge: IndexMap<SelfConditionIndex, ConditionResolutionInfo>,
 }
@@ -47,7 +45,7 @@ pub(crate) struct ConditionResolutionInfo {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct SourceEnterEdgeInfo {
+pub(crate) struct SourceEnteringEdgeInfo {
     index: usize,
     conditions_cost: QueryPlanCost,
 }

--- a/src/source_aware/federated_query_graph/path_tree.rs
+++ b/src/source_aware/federated_query_graph/path_tree.rs
@@ -17,7 +17,7 @@ pub(crate) struct FederatedPathTree {
 pub(crate) struct FederatedPathTreeChild {
     key: FederatedPathTreeChildKey,
     self_condition_resolutions_for_edge: IndexMap<SelfConditionIndex, ConditionResolutionId>,
-    source_enter_condition_resolutions_at_edge:
+    source_entering_condition_resolutions_at_edge:
         IndexMap<SelfConditionIndex, ConditionResolutionInfo>,
     condition_resolutions_at_edge: IndexMap<SelfConditionIndex, ConditionResolutionInfo>,
     tree: Arc<FederatedPathTree>,

--- a/src/source_aware/fetch_dependency_graph/mod.rs
+++ b/src/source_aware/fetch_dependency_graph/mod.rs
@@ -28,7 +28,7 @@ type FetchDependencyGraphPetgraph =
 #[derive(Debug)]
 pub(crate) struct FetchDependencyGraphNode {
     merge_at: Vec<FetchDataPathElement>,
-    source_enter_edge: EdgeIndex,
+    source_entering_edge: EdgeIndex,
     operation_variables: IndexSet<Name>,
     depends_on_condition_resolutions: IndexSet<ConditionResolutionId>,
     contains_condition_resolutions: IndexSet<ConditionResolutionId>,

--- a/src/source_aware/query_plan/mod.rs
+++ b/src/source_aware/query_plan/mod.rs
@@ -49,7 +49,7 @@ pub enum PlanNode {
 #[derive(Debug)]
 pub struct FetchNode {
     pub operation_variables: IndexSet<Name>,
-    pub key_conditions: SelectionSet,
+    pub input_conditions: SelectionSet,
     pub source_data: SourceFetchNode,
 }
 

--- a/src/sources/connect/mod.rs
+++ b/src/sources/connect/mod.rs
@@ -118,7 +118,7 @@ pub(crate) enum ConnectFederatedConcreteFieldQueryGraphEdge {
 pub(crate) struct ConnectFederatedTypeConditionQueryGraphEdge;
 
 #[derive(Debug)]
-pub(crate) enum ConnectFederatedSourceEnterQueryGraphEdge {
+pub(crate) enum ConnectFederatedSourceEnteringQueryGraphEdge {
     ConnectParent {
         subgraph_type: ObjectTypeDefinitionPosition,
     },
@@ -144,7 +144,7 @@ impl SourceFetchDependencyGraphApi for ConnectFetchDependencyGraph {
         &self,
         _query_graph: Arc<FederatedQueryGraph>,
         _merge_at: &[FetchDataPathElement],
-        _source_enter_edge: EdgeIndex,
+        _source_entering_edge: EdgeIndex,
         _source_data: &SourceFetchDependencyGraphNode,
         _path_tree_edges: Vec<FederatedPathTreeChildKey>,
     ) -> Result<Vec<FederatedPathTreeChildKey>, FederationError> {
@@ -155,7 +155,7 @@ impl SourceFetchDependencyGraphApi for ConnectFetchDependencyGraph {
         &self,
         _query_graph: Arc<FederatedQueryGraph>,
         _merge_at: &[FetchDataPathElement],
-        _source_enter_edge: EdgeIndex,
+        _source_entering_edge: EdgeIndex,
         _self_condition_resolution: Option<ConditionResolutionId>,
     ) -> Result<SourceFetchDependencyGraphNode, FederationError> {
         todo!()
@@ -165,7 +165,7 @@ impl SourceFetchDependencyGraphApi for ConnectFetchDependencyGraph {
         &self,
         _query_graph: Arc<FederatedQueryGraph>,
         _merge_at: &[FetchDataPathElement],
-        _source_enter_edge: EdgeIndex,
+        _source_entering_edge: EdgeIndex,
         _self_condition_resolution: Option<ConditionResolutionId>,
     ) -> Result<SourcePath, FederationError> {
         todo!()
@@ -206,7 +206,46 @@ pub(crate) struct ConnectFetchDependencyGraphNode {
 }
 
 #[derive(Debug)]
-pub(crate) struct ConnectPath;
+pub(crate) struct ConnectPath {
+    query_graph: Arc<FederatedQueryGraph>,
+    merge_at: Vec<FetchDataPathElement>,
+    source_entering_edge: EdgeIndex,
+    source_id: SourceId,
+    field: Option<ConnectPathField>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ConnectPathField {
+    response_name: Name,
+    arguments: IndexMap<Name, Value>,
+    selections: ConnectPathSelections,
+}
+
+#[derive(Debug)]
+pub(crate) enum ConnectPathSelections {
+    Selections {
+        head_property_path: Vec<Property>,
+        named_selections: Vec<(Name, Vec<Property>)>,
+        tail_selection: Option<(Name, ConnectPathTailSelection)>,
+    },
+    CustomScalarRoot {
+        selection: Selection,
+    },
+}
+
+#[derive(Debug)]
+pub(crate) enum ConnectPathTailSelection {
+    Selection {
+        property_path: Vec<Property>,
+    },
+    CustomScalarPathSelection {
+        path_selection: PathSelection,
+    },
+    CustomScalarStarSelection {
+        star_subselection: Option<SubSelection>,
+        excluded_properties: IndexSet<Property>,
+    },
+}
 
 impl SourcePathApi for ConnectPath {
     fn source_id(&self) -> &SourceId {
@@ -227,6 +266,7 @@ impl SourcePathApi for ConnectPath {
 #[derive(Debug)]
 pub struct ConnectFetchNode {
     source_id: ConnectId,
-    arguments: IndexMap<Name, Value>,
+    field_response_name: Name,
+    field_arguments: IndexMap<Name, Value>,
     selection: Selection,
 }

--- a/src/sources/graphql/mod.rs
+++ b/src/sources/graphql/mod.rs
@@ -75,7 +75,7 @@ pub(crate) struct GraphqlFederatedTypeConditionQueryGraphEdge {
 }
 
 #[derive(Debug)]
-pub(crate) enum GraphqlFederatedSourceEnterQueryGraphEdge {
+pub(crate) enum GraphqlFederatedSourceEnteringQueryGraphEdge {
     OperationRoot {
         subgraph_type: ObjectTypeDefinitionPosition,
         root_kind: SchemaRootDefinitionKind,
@@ -110,7 +110,7 @@ impl SourceFetchDependencyGraphApi for GraphqlFetchDependencyGraph {
         &self,
         _query_graph: Arc<FederatedQueryGraph>,
         _merge_at: &[FetchDataPathElement],
-        _source_enter_edge: EdgeIndex,
+        _source_entering_edge: EdgeIndex,
         _source_data: &SourceFetchDependencyGraphNode,
         _path_tree_edges: Vec<FederatedPathTreeChildKey>,
     ) -> Result<Vec<FederatedPathTreeChildKey>, FederationError> {
@@ -121,7 +121,7 @@ impl SourceFetchDependencyGraphApi for GraphqlFetchDependencyGraph {
         &self,
         _query_graph: Arc<FederatedQueryGraph>,
         _merge_at: &[FetchDataPathElement],
-        _source_enter_edge: EdgeIndex,
+        _source_entering_edge: EdgeIndex,
         _self_condition_resolution: Option<ConditionResolutionId>,
     ) -> Result<SourceFetchDependencyGraphNode, FederationError> {
         todo!()
@@ -131,7 +131,7 @@ impl SourceFetchDependencyGraphApi for GraphqlFetchDependencyGraph {
         &self,
         _query_graph: Arc<FederatedQueryGraph>,
         _merge_at: &[FetchDataPathElement],
-        _source_enter_edge: EdgeIndex,
+        _source_entering_edge: EdgeIndex,
         _self_condition_resolution: Option<ConditionResolutionId>,
     ) -> Result<SourcePath, FederationError> {
         todo!()
@@ -177,7 +177,13 @@ pub(crate) enum GraphqlFetchDependencyGraphNode {
 }
 
 #[derive(Debug)]
-pub(crate) struct GraphqlPath;
+pub(crate) struct GraphqlPath {
+    query_graph: Arc<FederatedQueryGraph>,
+    merge_at: Vec<FetchDataPathElement>,
+    source_entering_edge: EdgeIndex,
+    source_id: SourceId,
+    operation_path: Vec<OperationPathElement>,
+}
 
 impl SourcePathApi for GraphqlPath {
     fn source_id(&self) -> &SourceId {

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -11,7 +11,7 @@ use crate::sources::connect::{
     ConnectFederatedConcreteFieldQueryGraphEdge, ConnectFederatedConcreteQueryGraphNode,
     ConnectFederatedEnumQueryGraphNode, ConnectFederatedQueryGraph,
     ConnectFederatedQueryGraphBuilder, ConnectFederatedScalarQueryGraphNode,
-    ConnectFederatedSourceEnterQueryGraphEdge, ConnectFederatedTypeConditionQueryGraphEdge,
+    ConnectFederatedSourceEnteringQueryGraphEdge, ConnectFederatedTypeConditionQueryGraphEdge,
     ConnectFetchDependencyGraph, ConnectFetchDependencyGraphNode, ConnectFetchNode, ConnectId,
     ConnectPath,
 };
@@ -20,7 +20,7 @@ use crate::sources::graphql::{
     GraphqlFederatedConcreteFieldQueryGraphEdge, GraphqlFederatedConcreteQueryGraphNode,
     GraphqlFederatedEnumQueryGraphNode, GraphqlFederatedQueryGraph,
     GraphqlFederatedQueryGraphBuilder, GraphqlFederatedScalarQueryGraphNode,
-    GraphqlFederatedSourceEnterQueryGraphEdge, GraphqlFederatedTypeConditionQueryGraphEdge,
+    GraphqlFederatedSourceEnteringQueryGraphEdge, GraphqlFederatedTypeConditionQueryGraphEdge,
     GraphqlFetchDependencyGraph, GraphqlFetchDependencyGraphNode, GraphqlFetchNode, GraphqlId,
     GraphqlPath,
 };
@@ -105,9 +105,9 @@ pub(crate) enum SourceFederatedTypeConditionQueryGraphEdge {
 }
 
 #[derive(Debug)]
-pub(crate) enum SourceFederatedSourceEnterQueryGraphEdge {
-    Graphql(GraphqlFederatedSourceEnterQueryGraphEdge),
-    Connect(ConnectFederatedSourceEnterQueryGraphEdge),
+pub(crate) enum SourceFederatedSourceEnteringQueryGraphEdge {
+    Graphql(GraphqlFederatedSourceEnteringQueryGraphEdge),
+    Connect(ConnectFederatedSourceEnteringQueryGraphEdge),
 }
 
 #[enum_dispatch(SourceFederatedQueryGraphBuilderApi)]
@@ -156,7 +156,7 @@ pub(crate) trait SourceFetchDependencyGraphApi {
         &self,
         query_graph: Arc<FederatedQueryGraph>,
         merge_at: &[FetchDataPathElement],
-        source_enter_edge: EdgeIndex,
+        source_entering_edge: EdgeIndex,
         source_data: &SourceFetchDependencyGraphNode,
         path_tree_edges: Vec<FederatedPathTreeChildKey>,
     ) -> Result<Vec<FederatedPathTreeChildKey>, FederationError>;
@@ -165,7 +165,7 @@ pub(crate) trait SourceFetchDependencyGraphApi {
         &self,
         query_graph: Arc<FederatedQueryGraph>,
         merge_at: &[FetchDataPathElement],
-        source_enter_edge: EdgeIndex,
+        source_entering_edge: EdgeIndex,
         self_condition_resolution: Option<ConditionResolutionId>,
     ) -> Result<SourceFetchDependencyGraphNode, FederationError>;
 
@@ -173,7 +173,7 @@ pub(crate) trait SourceFetchDependencyGraphApi {
         &self,
         query_graph: Arc<FederatedQueryGraph>,
         merge_at: &[FetchDataPathElement],
-        source_enter_edge: EdgeIndex,
+        source_entering_edge: EdgeIndex,
         self_condition_resolution: Option<ConditionResolutionId>,
     ) -> Result<SourcePath, FederationError>;
 


### PR DESCRIPTION
<!-- FED-197 -->
This PR:
- Adjusts some type/method naming.
- Adds explicit data for `GraphqlPath`/`ConnectPath`, to clarify what they could look like. (Which should help when referencing them in task descriptions.)