### PR TITLE
Adjust `ConnectFetchDependencyGraphNode` to contain response name

### DIFF
--- a/src/sources/connect/mod.rs
+++ b/src/sources/connect/mod.rs
@@ -201,7 +201,8 @@ impl SourceFetchDependencyGraphApi for ConnectFetchDependencyGraph {
 
 #[derive(Debug)]
 pub(crate) struct ConnectFetchDependencyGraphNode {
-    arguments: IndexMap<Name, Value>,
+    field_response_name: Name,
+    field_arguments: IndexMap<Name, Value>,
     selection: Selection,
 }
 


### PR DESCRIPTION
<!-- FED-197 -->
I've added the field's response name to the Connect source's plan node, but I forgot the fetch dependency graph node. This PR fixes that (and matches the name changes).