### PR TITLE
Provide path tree edges when adding fetch dependency graph node

### DIFF
--- a/src/sources/connect/mod.rs
+++ b/src/sources/connect/mod.rs
@@ -140,24 +140,31 @@ impl SourceFederatedQueryGraphBuilderApi for ConnectFederatedQueryGraphBuilder {
 pub(crate) struct ConnectFetchDependencyGraph;
 
 impl SourceFetchDependencyGraphApi for ConnectFetchDependencyGraph {
-    fn can_reuse_node(
+    fn can_reuse_node<'path_tree>(
         &self,
         _query_graph: Arc<FederatedQueryGraph>,
         _merge_at: &[FetchDataPathElement],
         _source_entering_edge: EdgeIndex,
+        _path_tree_edges: Vec<&'path_tree FederatedPathTreeChildKey>,
         _source_data: &SourceFetchDependencyGraphNode,
-        _path_tree_edges: Vec<FederatedPathTreeChildKey>,
-    ) -> Result<Vec<FederatedPathTreeChildKey>, FederationError> {
+    ) -> Result<Vec<&'path_tree FederatedPathTreeChildKey>, FederationError> {
         todo!()
     }
 
-    fn add_node(
+    fn add_node<'path_tree>(
         &self,
         _query_graph: Arc<FederatedQueryGraph>,
         _merge_at: &[FetchDataPathElement],
         _source_entering_edge: EdgeIndex,
         _self_condition_resolution: Option<ConditionResolutionId>,
-    ) -> Result<SourceFetchDependencyGraphNode, FederationError> {
+        _path_tree_edges: Vec<&'path_tree FederatedPathTreeChildKey>,
+    ) -> Result<
+        (
+            SourceFetchDependencyGraphNode,
+            Vec<&'path_tree FederatedPathTreeChildKey>,
+        ),
+        FederationError,
+    > {
         todo!()
     }
 

--- a/src/sources/graphql/mod.rs
+++ b/src/sources/graphql/mod.rs
@@ -106,24 +106,31 @@ pub(crate) struct GraphqlFetchDependencyGraph {
 }
 
 impl SourceFetchDependencyGraphApi for GraphqlFetchDependencyGraph {
-    fn can_reuse_node(
+    fn can_reuse_node<'path_tree>(
         &self,
         _query_graph: Arc<FederatedQueryGraph>,
         _merge_at: &[FetchDataPathElement],
         _source_entering_edge: EdgeIndex,
+        _path_tree_edges: Vec<&'path_tree FederatedPathTreeChildKey>,
         _source_data: &SourceFetchDependencyGraphNode,
-        _path_tree_edges: Vec<FederatedPathTreeChildKey>,
-    ) -> Result<Vec<FederatedPathTreeChildKey>, FederationError> {
+    ) -> Result<Vec<&'path_tree FederatedPathTreeChildKey>, FederationError> {
         todo!()
     }
 
-    fn add_node(
+    fn add_node<'path_tree>(
         &self,
         _query_graph: Arc<FederatedQueryGraph>,
         _merge_at: &[FetchDataPathElement],
         _source_entering_edge: EdgeIndex,
         _self_condition_resolution: Option<ConditionResolutionId>,
-    ) -> Result<SourceFetchDependencyGraphNode, FederationError> {
+        _path_tree_edges: Vec<&'path_tree FederatedPathTreeChildKey>,
+    ) -> Result<
+        (
+            SourceFetchDependencyGraphNode,
+            Vec<&'path_tree FederatedPathTreeChildKey>,
+        ),
+        FederationError,
+    > {
         todo!()
     }
 

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -152,22 +152,29 @@ pub(crate) enum SourceFetchDependencyGraph {
 
 #[enum_dispatch]
 pub(crate) trait SourceFetchDependencyGraphApi {
-    fn can_reuse_node(
+    fn can_reuse_node<'path_tree>(
         &self,
         query_graph: Arc<FederatedQueryGraph>,
         merge_at: &[FetchDataPathElement],
         source_entering_edge: EdgeIndex,
+        path_tree_edges: Vec<&'path_tree FederatedPathTreeChildKey>,
         source_data: &SourceFetchDependencyGraphNode,
-        path_tree_edges: Vec<FederatedPathTreeChildKey>,
-    ) -> Result<Vec<FederatedPathTreeChildKey>, FederationError>;
+    ) -> Result<Vec<&'path_tree FederatedPathTreeChildKey>, FederationError>;
 
-    fn add_node(
+    fn add_node<'path_tree>(
         &self,
         query_graph: Arc<FederatedQueryGraph>,
         merge_at: &[FetchDataPathElement],
         source_entering_edge: EdgeIndex,
         self_condition_resolution: Option<ConditionResolutionId>,
-    ) -> Result<SourceFetchDependencyGraphNode, FederationError>;
+        path_tree_edges: Vec<&'path_tree FederatedPathTreeChildKey>,
+    ) -> Result<
+        (
+            SourceFetchDependencyGraphNode,
+            Vec<&'path_tree FederatedPathTreeChildKey>,
+        ),
+        FederationError,
+    >;
 
     fn new_path(
         &self,


### PR DESCRIPTION
<!-- FED-197 -->
Node addition may only be able to add certain groups of edges at a time, so this PR updates the API accordingly.