### PR TITLE
Track response path and source-entering edge in source-specific state

### DIFF
--- a/src/sources/connect/mod.rs
+++ b/src/sources/connect/mod.rs
@@ -180,6 +180,7 @@ impl SourceFetchDependencyGraphApi for ConnectFetchDependencyGraph {
 
     fn add_path(
         &self,
+        _query_graph: Arc<FederatedQueryGraph>,
         _source_path: SourcePath,
         _source_data: &mut SourceFetchDependencyGraphNode,
     ) -> Result<(), FederationError> {
@@ -208,6 +209,8 @@ impl SourceFetchDependencyGraphApi for ConnectFetchDependencyGraph {
 
 #[derive(Debug)]
 pub(crate) struct ConnectFetchDependencyGraphNode {
+    merge_at: Vec<FetchDataPathElement>,
+    source_entering_edge: EdgeIndex,
     field_response_name: Name,
     field_arguments: IndexMap<Name, Value>,
     selection: Selection,
@@ -215,7 +218,6 @@ pub(crate) struct ConnectFetchDependencyGraphNode {
 
 #[derive(Debug)]
 pub(crate) struct ConnectPath {
-    query_graph: Arc<FederatedQueryGraph>,
     merge_at: Vec<FetchDataPathElement>,
     source_entering_edge: EdgeIndex,
     source_id: SourceId,

--- a/src/sources/graphql/mod.rs
+++ b/src/sources/graphql/mod.rs
@@ -146,6 +146,7 @@ impl SourceFetchDependencyGraphApi for GraphqlFetchDependencyGraph {
 
     fn add_path(
         &self,
+        _query_graph: Arc<FederatedQueryGraph>,
         _source_path: SourcePath,
         _source_data: &mut SourceFetchDependencyGraphNode,
     ) -> Result<(), FederationError> {
@@ -175,9 +176,13 @@ impl SourceFetchDependencyGraphApi for GraphqlFetchDependencyGraph {
 #[derive(Debug)]
 pub(crate) enum GraphqlFetchDependencyGraphNode {
     OperationRoot {
+        merge_at: Vec<FetchDataPathElement>,
+        source_entering_edge: EdgeIndex,
         selection_set: NormalizedSelectionSet,
     },
     EntitiesField {
+        merge_at: Vec<FetchDataPathElement>,
+        source_entering_edge: EdgeIndex,
         key_condition_resolution: Option<ConditionResolutionId>,
         selection_set: NormalizedSelectionSet,
     },
@@ -185,7 +190,6 @@ pub(crate) enum GraphqlFetchDependencyGraphNode {
 
 #[derive(Debug)]
 pub(crate) struct GraphqlPath {
-    query_graph: Arc<FederatedQueryGraph>,
     merge_at: Vec<FetchDataPathElement>,
     source_entering_edge: EdgeIndex,
     source_id: SourceId,

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -186,6 +186,7 @@ pub(crate) trait SourceFetchDependencyGraphApi {
 
     fn add_path(
         &self,
+        query_graph: Arc<FederatedQueryGraph>,
         source_path: SourcePath,
         source_data: &mut SourceFetchDependencyGraphNode,
     ) -> Result<(), FederationError>;


### PR DESCRIPTION
<!-- FED-197 -->
This PR tracks the `merge_at`/response path and source-entering edge in source-specific state, and shifts the source path to not store the `Arc<FederatedQueryGraph>`. This is tracked in both source-specific and source-agnostic state for reasons that will become clearer during the second milestone.