### PR TITLE
Add terse display impls for OpPath, FetchDependencyGraph

### DIFF
--- a/src/query_graph/graph_path.rs
+++ b/src/query_graph/graph_path.rs
@@ -242,6 +242,21 @@ impl Display for OpGraphPathTrigger {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub(crate) struct OpPath(pub(crate) Vec<Arc<OpPathElement>>);
 
+impl std::fmt::Display for OpPath {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        for (i, element) in self.0.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            match element.deref() {
+                OpPathElement::Field(field) => write!(f, "{field}")?,
+                OpPathElement::InlineFragment(fragment) => write!(f, "{fragment}")?,
+            }
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, derive_more::From)]
 pub(crate) enum OpPathElement {
     Field(NormalizedField),

--- a/src/query_plan/fetch_dependency_graph.rs
+++ b/src/query_plan/fetch_dependency_graph.rs
@@ -34,6 +34,7 @@ use indexmap::{IndexMap, IndexSet};
 use petgraph::stable_graph::{EdgeIndex, NodeIndex, StableDiGraph};
 use petgraph::visit::EdgeRef;
 use std::collections::HashSet;
+use std::fmt::Write as _;
 use std::sync::{atomic::AtomicU64, Arc, OnceLock};
 
 /// Represents the value of a `@defer(label:)` argument.
@@ -1157,7 +1158,7 @@ impl std::fmt::Display for FetchDependencyGraph {
 
             for child_id in g.children_of(node_id) {
                 if g.children_of(child_id).next().is_some() {
-                    write!(f, "\n")?;
+                    f.write_char('\n')?;
                     fmt_node(g, child_id, f, indent + 1)?;
                 }
             }
@@ -1166,7 +1167,7 @@ impl std::fmt::Display for FetchDependencyGraph {
 
         for (i, &node_id) in self.root_nodes_by_subgraph.values().enumerate() {
             if i > 0 {
-                write!(f, "\n")?;
+                f.write_char('\n')?;
             }
             fmt_node(self, node_id, f, 0)?;
         }


### PR DESCRIPTION
Ports `FetchDependencyGraph::toString()` from JS. One difference: JS only displays the subgraph name, here I used the terse display for fetch dependency nodes, as subgraph name alone was not enough for the println debugging I was doing.

For `OpPath`, I don't think the JS side had an exact equivalent, it would just stringify the array directly which is equivalent to calling `.toString()` on all its elements and separating by commas.

For this test query:
```
---- query_plan::query_planner::tests::it_does_not_crash stdout ----
{
  userById(id: 1) {
    name
    email
  }
}
```
The two op paths in this operation are displayed as:
```
userById(id: 1), name
userById(id: 1), email
```
The fetch dependency graph is displayed as:
```
[0] accounts[{}] <-
```
(The `{}` is a bug because we are missing the implementation for `addAtPath`: once implemented, the output would be `[0] accounts[{ userById(id: 1) { name email } }]`.)